### PR TITLE
don't bump timeline when adding notes

### DIFF
--- a/src/timeline.rs
+++ b/src/timeline.rs
@@ -153,6 +153,7 @@ pub fn timeline_view(ui: &mut egui::Ui, app: &mut Damus, timeline: usize) {
     ui.add_space(3.0);
 
     egui::ScrollArea::vertical()
+        .animated(false)
         .scroll_bar_visibility(ScrollBarVisibility::AlwaysVisible)
         .show(ui, |ui| {
             let len = app.timelines[timeline].notes.len();


### PR DESCRIPTION
This is quite different than Damus iOS. The timeline will continually add new items without bumping scroll position, thanks to egui-virtual-list's `items_inserted_at_start` function.

Fixes:
- https://github.com/damus-io/notedeck/issues/38
- https://github.com/damus-io/notedeck/issues/59