### PR TITLE
add functionality to add account buttons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,7 +1042,7 @@ dependencies = [
 [[package]]
 name = "egui_nav"
 version = "0.1.0"
-source = "git+https://github.com/damus-io/egui-nav?branch=egui-0.28#a8dd95d2ae2a9a5c5251d47407320ad0eb074953"
+source = "git+https://github.com/damus-io/egui-nav?rev=345535aacaa145049b109366d2124707d339b0f6#345535aacaa145049b109366d2124707d339b0f6"
 dependencies = [
  "egui",
  "egui_extras",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ eframe = { git = "https://github.com/emilk/egui", rev = "fcb7764e48ce00f8f8e58da
 egui_extras = { git = "https://github.com/emilk/egui", rev = "fcb7764e48ce00f8f8e58da10f937410d65b0bfb", package = "egui_extras", features = ["all_loaders"] }
 ehttp = "0.2.0"
 egui_tabs = { git = "https://github.com/damus-io/egui-tabs", branch = "egui-0.28" }
-egui_nav = { git = "https://github.com/damus-io/egui-nav", branch = "egui-0.28" }
+egui_nav = { git = "https://github.com/damus-io/egui-nav", rev = "345535aacaa145049b109366d2124707d339b0f6" }
 egui_virtual_list = { git = "https://github.com/jb55/hello_egui", branch = "egui-0.28", package = "egui_virtual_list" }
 reqwest = { version = "0.12.4", default-features = false, features = [ "rustls-tls-native-roots" ] }
 image = { version = "0.24", features = ["jpeg", "png", "webp"] }

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -58,6 +58,7 @@ impl AccountManager {
                 }
             }
         }
+        self.select_if_singleton();
     }
 
     pub fn has_account_pubkey(&self, pubkey: &[u8; 32]) -> bool {
@@ -77,6 +78,7 @@ impl AccountManager {
         }
         let _ = self.key_store.add_key(&account);
         self.accounts.push(account);
+        self.select_if_singleton();
         true
     }
 
@@ -108,5 +110,11 @@ impl AccountManager {
 
     pub fn clear_selected_account(&mut self) {
         self.currently_selected_account = None
+    }
+
+    fn select_if_singleton(&mut self) {
+        if self.accounts.len() == 1 {
+            self.select_account(0);
+        }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -785,7 +785,7 @@ impl Damus {
             account_manager.add_account(key);
         }
 
-        // TODO: pull currently selected account from settings
+        // TODO: remove when currently_selected_account is pulled from settings
         if account_manager.num_accounts() > 0 {
             account_manager.select_account(0);
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,6 +6,7 @@ use crate::error::Error;
 use crate::frame_history::FrameHistory;
 use crate::imgcache::ImageCache;
 use crate::key_storage::KeyStorageType;
+use crate::login_manager::LoginManager;
 use crate::notecache::{CachedNote, NoteCache};
 use crate::relay_pool_manager::RelayPoolManager;
 use crate::route::Route;
@@ -57,6 +58,7 @@ pub struct Damus {
     pub img_cache: ImageCache,
     pub ndb: Ndb,
     pub account_manager: AccountManager,
+    pub login_manager: LoginManager,
 
     frame_history: crate::frame_history::FrameHistory,
     pub show_account_switcher: bool,
@@ -788,6 +790,8 @@ impl Damus {
             account_manager.select_account(0);
         }
 
+        let login_manager = LoginManager::new();
+
         Self {
             is_mobile,
             drafts: Drafts::default(),
@@ -800,6 +804,7 @@ impl Damus {
             textmode: false,
             ndb: Ndb::new(data_path.as_ref().to_str().expect("db path ok"), &config).expect("ndb"),
             account_manager,
+            login_manager,
             //compose: "".to_string(),
             frame_history: FrameHistory::default(),
             show_account_switcher: false,
@@ -830,6 +835,7 @@ impl Damus {
             textmode: false,
             ndb: Ndb::new(data_path.as_ref().to_str().expect("db path ok"), &config).expect("ndb"),
             account_manager: AccountManager::new(None, determine_key_storage_type()),
+            login_manager: LoginManager::new(),
             frame_history: FrameHistory::default(),
             show_account_switcher: false,
             show_global_popup: true,
@@ -983,6 +989,8 @@ fn render_nav(routes: Vec<Route>, timeline_ind: usize, app: &mut Damus, ui: &mut
                 ui.label("account management view");
                 None
             }
+
+            Route::AddAccount => None,
 
             Route::Thread(_key) => {
                 ui.label("thread view");

--- a/src/login_manager.rs
+++ b/src/login_manager.rs
@@ -85,6 +85,10 @@ impl<'a> LoginManager {
         }
         None
     }
+
+    pub fn clear(&mut self) {
+        *self = Default::default();
+    }
 }
 
 #[cfg(test)]

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,14 +1,19 @@
-use egui::{Response, RichText};
+use egui::{Response, RichText, Vec2};
 use enostr::NoteId;
 use std::fmt::{self};
 
-use crate::{ui::AccountManagementView, Damus};
+use crate::{
+    app_style::NotedeckTextStyle,
+    ui::{account_login_view::AccountLoginView, AccountManagementView},
+    Damus,
+};
 
 /// App routing. These describe different places you can go inside Notedeck.
 #[derive(Clone, Debug)]
 pub enum Route {
     Timeline(String),
     ManageAccount,
+    AddAccount,
     Thread(NoteId),
     Reply(NoteId),
     Relays,
@@ -18,6 +23,7 @@ impl fmt::Display for Route {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Route::ManageAccount => write!(f, "Manage Account"),
+            Route::AddAccount => write!(f, "Add Account"),
             Route::Timeline(name) => write!(f, "{}", name),
             Route::Thread(_id) => write!(f, "Thread"),
             Route::Reply(_id) => write!(f, "Reply"),
@@ -30,13 +36,29 @@ impl Route {
     pub fn show_global_popup(&self, app: &mut Damus, ui: &mut egui::Ui) -> Option<Response> {
         match self {
             Route::ManageAccount => AccountManagementView::ui(app, ui),
+            Route::AddAccount => Some(AccountLoginView::ui(app, ui)),
             _ => None,
+        }
+    }
+
+    pub fn preferred_rect(&self, ui: &mut egui::Ui) -> egui::Rect {
+        let screen_rect = ui.ctx().screen_rect();
+        match self {
+            Route::ManageAccount => screen_rect.shrink(200.0),
+            Route::AddAccount => {
+                let size = Vec2::new(560.0, 480.0);
+                egui::Rect::from_center_size(screen_rect.center(), size)
+            }
+            _ => screen_rect,
         }
     }
 
     pub fn title(&self) -> RichText {
         match self {
             Route::ManageAccount => RichText::new("Manage Account").size(24.0),
+            Route::AddAccount => RichText::new("Login")
+                .text_style(NotedeckTextStyle::Heading2.text_style())
+                .strong(),
             Route::Thread(_) => RichText::new("Thread"),
             Route::Reply(_) => RichText::new("Reply"),
             Route::Relays => RichText::new("Relays"),

--- a/src/ui/account_login_view.rs
+++ b/src/ui/account_login_view.rs
@@ -4,6 +4,7 @@ use crate::login_manager::LoginManager;
 use crate::Damus;
 use egui::TextEdit;
 use egui::{Align, Align2, Button, Color32, Frame, Margin, RichText, Ui, Vec2, Window};
+use enostr::FullKeypair;
 
 pub struct AccountLoginView {}
 
@@ -145,7 +146,7 @@ impl AccountLoginView {
         ui.add_space(8.0);
     }
 
-    fn generate_group(_app: &mut Damus, ui: &mut egui::Ui) {
+    fn generate_group(app: &mut Damus, ui: &mut egui::Ui) {
         ui.horizontal(|ui| {
             ui.label(
                 RichText::new("New in nostr?").text_style(NotedeckTextStyle::Heading3.text_style()),
@@ -168,7 +169,9 @@ impl AccountLoginView {
 
         let generate_button = generate_keys_button().min_size(Vec2::new(MIN_WIDTH, 40.0));
         if ui.add(generate_button).clicked() {
-            // TODO: keygen
+            app.account_manager
+                .add_account(FullKeypair::generate().to_keypair());
+            app.global_nav.pop();
         }
     }
 }

--- a/src/ui/account_login_view.rs
+++ b/src/ui/account_login_view.rs
@@ -124,6 +124,7 @@ impl AccountLoginView {
                         .select_account(app.account_manager.num_accounts() - 1)
                 }
                 app.global_nav.pop();
+                app.login_manager.clear();
             }
         });
     }

--- a/src/ui/account_management.rs
+++ b/src/ui/account_management.rs
@@ -26,7 +26,7 @@ impl AccountManagementView {
         Frame::none()
             .outer_margin(24.0)
             .show(ui, |ui| {
-                Self::top_section_buttons_widget(ui);
+                Self::top_section_buttons_widget(app, ui);
                 ui.add_space(8.0);
                 scroll_area().show(ui, |ui| {
                     Self::show_accounts(app, ui);
@@ -70,20 +70,20 @@ impl AccountManagementView {
 
     fn show_mobile(app: &mut Damus, ui: &mut egui::Ui) {
         mobile_title(ui);
-        Self::top_section_buttons_widget(ui);
+        Self::top_section_buttons_widget(app, ui);
 
         ui.add_space(8.0);
         scroll_area().show(ui, |ui| Self::show_accounts_mobile(app, ui));
     }
 
-    fn top_section_buttons_widget(ui: &mut egui::Ui) -> egui::Response {
+    fn top_section_buttons_widget(app: &mut Damus, ui: &mut egui::Ui) -> egui::Response {
         ui.horizontal(|ui| {
             ui.allocate_ui_with_layout(
                 Vec2::new(ui.available_size_before_wrap().x, 32.0),
                 Layout::left_to_right(egui::Align::Center),
                 |ui| {
                     if ui.add(add_account_button()).clicked() {
-                        // TODO: route to AccountLoginView
+                        app.global_nav.push(crate::route::Route::AddAccount);
                     }
                 },
             );

--- a/src/ui/account_switcher.rs
+++ b/src/ui/account_switcher.rs
@@ -80,7 +80,11 @@ impl AccountSelectionWidget {
                     }
                 });
                 ui.add_space(8.0);
-                ui.add(add_account_button());
+                if ui.add(add_account_button()).clicked() {
+                    app.global_nav.push(Route::AddAccount);
+                    app.show_account_switcher = false;
+                    app.show_global_popup = true;
+                }
 
                 if let Some(_index) = selected_index {
                     if let Some(account) = app.account_manager.get_account(_index) {

--- a/src/ui/global_popup.rs
+++ b/src/ui/global_popup.rs
@@ -1,11 +1,8 @@
 use std::{cell::RefCell, rc::Rc};
 
-use egui::Sense;
 use egui_nav::{Nav, NavAction};
 
 use crate::{route::Route, ui, Damus};
-
-static MARGIN: f32 = 200.0;
 
 pub struct DesktopGlobalPopup {}
 
@@ -15,8 +12,10 @@ impl DesktopGlobalPopup {
             return;
         }
 
-        let rect = ui.ctx().screen_rect().shrink(MARGIN);
-
+        let rect = routes
+            .last()
+            .map(|r| r.preferred_rect(ui))
+            .unwrap_or_else(|| ui.ctx().screen_rect());
         let title = routes.last().map(|r| r.title());
 
         let app_ctx = Rc::new(RefCell::new(app));
@@ -27,13 +26,9 @@ impl DesktopGlobalPopup {
                     .title(false)
                     .navigating(false)
                     .show(ui, |ui, nav| {
-                        if let Some(resp) =
-                            nav.top().show_global_popup(&mut app_ctx.borrow_mut(), ui)
-                        {
-                            ui.allocate_rect(resp.rect, Sense::hover())
-                        } else {
-                            ui.label("") // TODO(kernelkind): not a great practice
-                        }
+                        nav.top()
+                            .show_global_popup(&mut app_ctx.borrow_mut(), ui)
+                            .unwrap_or_else(|| ui.label(""))
                     });
 
             if let Some(NavAction::Returned) = nav_response.action {


### PR DESCRIPTION
This PR adds functionality to the "add account" button in the account switcher and the "add account" button in the account management view. While implementing this functionality, some problems with `egui-nav` were uncovered.

Navigating in the global window crashes:
<img width="912" alt="image" src="https://github.com/damus-io/notedeck/assets/8139906/324b3867-a0eb-47ca-9cd0-63f60957c73e">
after pressing the `< Manage Account` button:
```
thread 'main' panicked at /Users/redacted/.cargo/git/checkouts/egui-5e4507fa4153be06/fcb7764/crates/egui/src/widget_rect.rs:142:17:
Widget changed layer_id during the frame
stack backtrace:
   0: rust_begin_unwind
             at /rustc/6292b2af620dbd771ebb687c3a93c69ba8f97268/library/std/src/panicking.rs:661:5
   1: core::panicking::panic_fmt
             at /rustc/6292b2af620dbd771ebb687c3a93c69ba8f97268/library/core/src/panicking.rs:74:14
   2: egui::widget_rect::WidgetRects::insert
             at /Users/redacted/.cargo/git/checkouts/egui-5e4507fa4153be06/fcb7764/crates/egui/src/widget_rect.rs:142:17
   3: egui::context::Context::create_widget::{{closure}}
             at /Users/redacted/.cargo/git/checkouts/egui-5e4507fa4153be06/fcb7764/crates/egui/src/context.rs:1033:13
   4: egui::context::Context::write
             at /Users/redacted/.cargo/git/checkouts/egui-5e4507fa4153be06/fcb7764/crates/egui/src/context.rs:724:9
   5: egui::context::Context::create_widget
             at /Users/redacted/.cargo/git/checkouts/egui-5e4507fa4153be06/fcb7764/crates/egui/src/context.rs:1027:9
   6: egui::ui::Ui::new
             at /Users/redacted/.cargo/git/checkouts/egui-5e4507fa4153be06/fcb7764/crates/egui/src/ui.rs:116:9
   7: egui_nav::Nav<T>::show
             at /Users/redacted/.cargo/git/checkouts/egui-nav-f3bee59503678f4e/a8dd95d/egui-nav/src/lib.rs:350:26
   8: notedeck::ui::global_popup::DesktopGlobalPopup::show::{{closure}}
             at ./src/ui/global_popup.rs:25:17
   9: notedeck::ui::fixed_window::FixedWindow::show::{{closure}}
             at ./src/ui/fixed_window.rs:53:28
             
...
```

I think this is happening because the underlying window in `FixedWindow` has `LayerId` `Order::Middle`, but in `egui-nav/src/lib.rs:353` we're setting the `LayerId` to `Order::Background` in the same frame

@jb55 I'm not very familiar with how `egui-nav` works, what are your thoughts on how to fix this?