### PR TITLE
Add note wide mode for reposts

### DIFF
--- a/src/ui/note/contents.rs
+++ b/src/ui/note/contents.rs
@@ -92,6 +92,7 @@ fn render_note_preview(
             ui::NoteView::new(app, &note)
                 .actionbar(false)
                 .small_pfp(true)
+                .wide(true)
                 .note_previews(false)
                 .show(ui);
         })

--- a/src/ui/note/options.rs
+++ b/src/ui/note/options.rs
@@ -1,3 +1,4 @@
+use crate::ui::ProfilePic;
 use bitflags::bitflags;
 
 bitflags! {
@@ -34,9 +35,28 @@ impl NoteOptions {
         (self & NoteOptions::medium_pfp) == NoteOptions::medium_pfp
     }
 
+    pub fn pfp_size(&self) -> f32 {
+        if self.has_small_pfp() {
+            ProfilePic::small_size()
+        } else if self.has_medium_pfp() {
+            ProfilePic::medium_size()
+        } else {
+            ProfilePic::default_size()
+        }
+    }
+
     #[inline]
     pub fn has_wide(self) -> bool {
         (self & NoteOptions::wide) == NoteOptions::wide
+    }
+
+    #[inline]
+    pub fn set_wide(&mut self, enable: bool) {
+        if enable {
+            *self |= NoteOptions::wide;
+        } else {
+            *self &= !NoteOptions::wide;
+        }
     }
 
     #[inline]


### PR DESCRIPTION
This adds a 'wide' note design for `NoteView`s. This is a mode where the note contents does not have padding at the start. This makes notes previews a bit nicer.

Screenshot:

<img src="https://cdn.jb55.com/s/84271f386d564c34.png" width="50%" />
