### PR TITLE
debug: add crate features which enable egui DebugOptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,6 +1069,7 @@ version = "0.27.2"
 source = "git+https://github.com/emilk/egui?rev=fcb7764e48ce00f8f8e58da10f937410d65b0bfb#fcb7764e48ce00f8f8e58da10f937410d65b0bfb"
 dependencies = [
  "ahash",
+ "backtrace",
  "emath",
  "epaint",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ security-framework = "2.11.0"
 [features]
 default = []
 profiling = ["puffin", "puffin_egui", "eframe/puffin"]
+debug-widget-callstack = ["egui/callstack"]
+debug-interactive-widgets = []
 
 [profile.small]
 inherits = 'release'

--- a/src/app_style.rs
+++ b/src/app_style.rs
@@ -68,6 +68,19 @@ pub fn create_custom_style(ctx: &Context, font_size: fn(&NotedeckTextStyle) -> f
         ..Interaction::default()
     };
 
+    // debug: show callstack for the current widget on hover if all
+    // modifier keys are pressed down.
+    #[cfg(feature = "debug-widget-callstack")]
+    {
+        style.debug.debug_on_hover_with_all_modifiers = true;
+    }
+
+    // debug: show an overlay on all interactive widgets
+    #[cfg(feature = "debug-interactive-widgets")]
+    {
+        style.debug.show_interactive_widgets = true;
+    }
+
     style
 }
 


### PR DESCRIPTION
--features debug-widget-callstack
  Show callstack for the current widget on hover if all modifier keys
  are pressed down

--features debug-interactive-widgets
  Show an overlay on all interactive widgets

Notes:
- debug-widget-callstack asserts `egui:callstack` feature when enabled
- Only works in debug builds, compile error w/ release builds