### PR TITLE
Note more options

### DIFF
--- a/enostr/src/pubkey.rs
+++ b/enostr/src/pubkey.rs
@@ -68,6 +68,10 @@ impl Pubkey {
             Ok(Pubkey(data.1.try_into().unwrap()))
         }
     }
+
+    pub fn to_bech(&self) -> Option<String> {
+        nostr::bech32::encode::<nostr::bech32::Bech32>(HRP_NPUB, &self.0).ok()
+    }
 }
 
 impl fmt::Display for Pubkey {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod login_manager;
 mod macos_key_storage;
 mod nav;
 mod note;
+mod note_options;
 mod notecache;
 mod post;
 mod post_action_executor;

--- a/src/note_options.rs
+++ b/src/note_options.rs
@@ -1,0 +1,40 @@
+use enostr::{NoteId, Pubkey};
+use nostrdb::Note;
+
+#[derive(Clone)]
+#[allow(clippy::enum_variant_names)]
+pub enum NoteOptionSelection {
+    CopyText,
+    CopyPubkey,
+    CopyNoteId,
+}
+
+pub fn process_note_selection(
+    ui: &mut egui::Ui,
+    selection: Option<NoteOptionSelection>,
+    note: &Note<'_>,
+) {
+    if let Some(option) = selection {
+        match option {
+            NoteOptionSelection::CopyText => {
+                ui.output_mut(|w| {
+                    w.copied_text = note.content().to_string();
+                });
+            }
+            NoteOptionSelection::CopyPubkey => {
+                ui.output_mut(|w| {
+                    if let Some(bech) = Pubkey::new(*note.pubkey()).to_bech() {
+                        w.copied_text = bech;
+                    }
+                });
+            }
+            NoteOptionSelection::CopyNoteId => {
+                ui.output_mut(|w| {
+                    if let Some(bech) = NoteId::new(*note.id()).to_bech() {
+                        w.copied_text = bech;
+                    }
+                });
+            }
+        }
+    }
+}

--- a/src/notecache.rs
+++ b/src/notecache.rs
@@ -35,7 +35,6 @@ impl NoteCache {
 pub struct CachedNote {
     reltime: TimeCached<String>,
     pub reply: NoteReplyBuf,
-    pub bar_open: bool,
 }
 
 impl CachedNote {
@@ -46,12 +45,7 @@ impl CachedNote {
             Box::new(move || time_ago_since(created_at)),
         );
         let reply = NoteReply::new(note.tags()).to_owned();
-        let bar_open = false;
-        CachedNote {
-            reltime,
-            reply,
-            bar_open,
-        }
+        CachedNote { reltime, reply }
     }
 
     pub fn reltime_str_mut(&mut self) -> &str {

--- a/src/ui/note/contents.rs
+++ b/src/ui/note/contents.rs
@@ -108,6 +108,7 @@ pub fn render_note_preview(
                 .small_pfp(true)
                 .wide(true)
                 .note_previews(false)
+                .use_more_options_button(true)
                 .show(ui);
         })
         .response

--- a/src/ui/note/contents.rs
+++ b/src/ui/note/contents.rs
@@ -1,5 +1,6 @@
 use crate::images::ImageType;
 use crate::imgcache::ImageCache;
+use crate::note_options::process_note_selection;
 use crate::notecache::NoteCache;
 use crate::ui::note::NoteOptions;
 use crate::ui::ProfilePic;
@@ -103,13 +104,15 @@ pub fn render_note_preview(
             ui.visuals().noninteractive().bg_stroke.color,
         ))
         .show(ui, |ui| {
-            ui::NoteView::new(ndb, note_cache, img_cache, &note)
+            let resp = ui::NoteView::new(ndb, note_cache, img_cache, &note)
                 .actionbar(false)
                 .small_pfp(true)
                 .wide(true)
                 .note_previews(false)
                 .use_more_options_button(true)
                 .show(ui);
+
+            process_note_selection(ui, resp.option_selection, &note);
         })
         .response
 }

--- a/src/ui/note/reply.rs
+++ b/src/ui/note/reply.rs
@@ -67,6 +67,7 @@ impl<'a> PostReplyView<'a> {
                     ui::NoteView::new(self.ndb, self.note_cache, self.img_cache, self.note)
                         .actionbar(false)
                         .medium_pfp(true)
+                        .use_more_options_button(true)
                         .show(ui);
                 });
 

--- a/src/ui/thread.rs
+++ b/src/ui/thread.rs
@@ -1,5 +1,6 @@
 use crate::{
-    actionbar::BarAction, imgcache::ImageCache, notecache::NoteCache, thread::Threads, ui,
+    actionbar::BarAction, imgcache::ImageCache, note_options::process_note_selection,
+    notecache::NoteCache, thread::Threads, ui,
 };
 use nostrdb::{Ndb, NoteKey, Transaction};
 use tracing::{error, warn};
@@ -115,15 +116,17 @@ impl<'a> ThreadView<'a> {
                         };
 
                         ui::padding(8.0, ui, |ui| {
-                            if let Some(bar_action) =
+                            let note_response =
                                 ui::NoteView::new(self.ndb, self.note_cache, self.img_cache, &note)
                                     .note_previews(!self.textmode)
                                     .textmode(self.textmode)
-                                    .show(ui)
-                                    .action
-                            {
+                                    .use_more_options_button(!self.textmode)
+                                    .show(ui);
+                            if let Some(bar_action) = note_response.action {
                                 action = Some(bar_action);
                             }
+
+                            process_note_selection(ui, note_response.option_selection, &note);
                         });
 
                         ui::hline(ui);

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -1,4 +1,5 @@
 use crate::draft::Draft;
+use crate::note_options::process_note_selection;
 use crate::{
     actionbar::BarAction, column::Columns, imgcache::ImageCache, notecache::NoteCache,
     timeline::TimelineId, ui,
@@ -149,6 +150,7 @@ fn timeline_ui(
                         let resp = ui::NoteView::new(ndb, note_cache, img_cache, &note)
                             .note_previews(!textmode)
                             .selectable_text(false)
+                            .use_more_options_button(true)
                             .show(ui);
 
                         if let Some(ba) = resp.action {
@@ -156,6 +158,8 @@ fn timeline_ui(
                         } else if resp.response.clicked() {
                             debug!("clicked note");
                         }
+
+                        process_note_selection(ui, resp.option_selection, &note);
                     });
 
                     ui::hline(ui);


### PR DESCRIPTION
Adds three dots 'more options' button to each note. When clicked, it shows a more options context menu. Right now there are three options, each of which copy things to the system's clipboard

<img width="912" alt="image" src="https://github.com/user-attachments/assets/57039b49-d802-4e8c-91c3-067138bd00ae">