### PR TITLE
Update account_login_view.rs

### DIFF
--- a/src/ui/account_login_view.rs
+++ b/src/ui/account_login_view.rs
@@ -130,7 +130,7 @@ fn login_textedit(manager: &mut LoginState) -> TextEdit {
     manager.get_login_textedit(|text| {
         egui::TextEdit::singleline(text)
             .hint_text(
-                RichText::new("Your key here...").text_style(NotedeckTextStyle::Body.text_style()),
+                RichText::new("Enter your public key (npub, nip05), or private key (nsec) here...").text_style(NotedeckTextStyle::Body.text_style()),
             )
             .vertical_align(Align::Center)
             .min_size(Vec2::new(0.0, 40.0))


### PR DESCRIPTION
In src/ui/account_login_view.rs 

changed "enter your key here" to include specific reference to npub, nsec, and nip05 as to show login options to the notedeck customer.

New text: "Enter your public key (npub, nip05), or private key (nsec) here..."