### PR TITLE
Persist columns

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -2,6 +2,7 @@ use std::cmp::Ordering;
 
 use enostr::{FilledKeypair, FullKeypair, Keypair};
 use nostrdb::Ndb;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     column::Columns,
@@ -32,7 +33,7 @@ pub enum AccountsRouteResponse {
     AddAccount(AccountLoginResponse),
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum AccountsRoute {
     Accounts,
     AddAccount,

--- a/src/args.rs
+++ b/src/args.rs
@@ -219,18 +219,13 @@ impl Args {
             i += 1;
         }
 
-        if res.columns.is_empty() {
-            let ck = TimelineKind::contact_list(PubkeySource::DeckAuthor);
-            info!("No columns set, setting up defaults: {:?}", ck);
-            res.columns.push(ArgColumn::Timeline(ck));
-        }
-
         res
     }
 }
 
 /// A way to define columns from the commandline. Can be column kinds or
 /// generic queries
+#[derive(Debug)]
 pub enum ArgColumn {
     Timeline(TimelineKind),
     Generic(Vec<Filter>),

--- a/src/column.rs
+++ b/src/column.rs
@@ -1,10 +1,13 @@
 use crate::route::{Route, Router};
-use crate::timeline::{Timeline, TimelineId};
+use crate::timeline::{SerializableTimeline, Timeline, TimelineId, TimelineRoute};
 use indexmap::IndexMap;
+use nostrdb::Ndb;
+use serde::{Deserialize, Deserializer, Serialize};
 use std::iter::Iterator;
 use std::sync::atomic::{AtomicU32, Ordering};
-use tracing::warn;
+use tracing::{error, warn};
 
+#[derive(Clone)]
 pub struct Column {
     router: Router<Route>,
 }
@@ -21,6 +24,28 @@ impl Column {
 
     pub fn router_mut(&mut self) -> &mut Router<Route> {
         &mut self.router
+    }
+}
+
+impl serde::Serialize for Column {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.router.routes().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Column {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let routes = Vec::<Route>::deserialize(deserializer)?;
+
+        Ok(Column {
+            router: Router::new(routes),
+        })
     }
 }
 
@@ -66,6 +91,10 @@ impl Columns {
 
     fn get_new_id() -> u32 {
         UIDS.fetch_add(1, Ordering::Relaxed)
+    }
+
+    pub fn add_column_at(&mut self, column: Column, index: u32) {
+        self.columns.insert(index, column);
     }
 
     pub fn add_column(&mut self, column: Column) {
@@ -193,5 +222,60 @@ impl Columns {
                 self.new_column_picker();
             }
         }
+    }
+
+    pub fn as_serializable_columns(&self) -> SerializableColumns {
+        SerializableColumns {
+            columns: self.columns.values().cloned().collect(),
+            timelines: self
+                .timelines
+                .values()
+                .map(|t| t.as_serializable_timeline())
+                .collect(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SerializableColumns {
+    pub columns: Vec<Column>,
+    pub timelines: Vec<SerializableTimeline>,
+}
+
+impl SerializableColumns {
+    pub fn into_columns(self, ndb: &Ndb, deck_pubkey: Option<&[u8; 32]>) -> Columns {
+        let mut columns = Columns::default();
+
+        for column in self.columns {
+            let id = Columns::get_new_id();
+            let mut routes = Vec::new();
+            for route in column.router.routes() {
+                match route {
+                    Route::Timeline(TimelineRoute::Timeline(timeline_id)) => {
+                        if let Some(serializable_tl) =
+                            self.timelines.iter().find(|tl| tl.id == *timeline_id)
+                        {
+                            let tl = serializable_tl.clone().into_timeline(ndb, deck_pubkey);
+                            if let Some(tl) = tl {
+                                routes.push(Route::Timeline(TimelineRoute::Timeline(tl.id)));
+                                columns.timelines.insert(id, tl);
+                            } else {
+                                error!("Problem deserializing timeline {:?}", serializable_tl);
+                            }
+                        }
+                    }
+                    Route::Timeline(TimelineRoute::Thread(_thread)) => {
+                        // TODO: open thread before pushing route
+                    }
+                    Route::Profile(_profile) => {
+                        // TODO: open profile before pushing route
+                    }
+                    _ => routes.push(*route),
+                }
+            }
+            columns.add_column_at(Column::new(routes), id);
+        }
+
+        columns
     }
 }

--- a/src/nav.rs
+++ b/src/nav.rs
@@ -27,7 +27,8 @@ use egui_nav::{Nav, NavAction, TitleBarResponse};
 use nostrdb::{Ndb, Transaction};
 use tracing::{error, info};
 
-pub fn render_nav(col: usize, app: &mut Damus, ui: &mut egui::Ui) {
+pub fn render_nav(col: usize, app: &mut Damus, ui: &mut egui::Ui) -> bool {
+    let mut col_changed = false;
     let col_id = app.columns.get_column_id_at_index(col);
     // TODO(jb55): clean up this router_mut mess by using Router<R> in egui-nav directly
     let routes = app
@@ -201,12 +202,14 @@ pub fn render_nav(col: usize, app: &mut Damus, ui: &mut egui::Ui) {
                 pubkey.bytes(),
             );
         }
+        col_changed = true;
     } else if let Some(NavAction::Navigated) = nav_response.action {
         let cur_router = app.columns_mut().column_mut(col).router_mut();
         cur_router.navigating = false;
         if cur_router.is_replacing() {
             cur_router.remove_previous_route();
         }
+        col_changed = true;
     }
 
     if let Some(title_response) = nav_response.title_response {
@@ -220,6 +223,8 @@ pub fn render_nav(col: usize, app: &mut Damus, ui: &mut egui::Ui) {
             }
         }
     }
+
+    col_changed
 }
 
 fn unsubscribe_timeline(ndb: &Ndb, timeline: &Timeline) {

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,5 +1,6 @@
 use enostr::{NoteId, Pubkey};
 use nostrdb::Ndb;
+use serde::{Deserialize, Serialize};
 use std::fmt::{self};
 
 use crate::{
@@ -10,7 +11,7 @@ use crate::{
 };
 
 /// App routing. These describe different places you can go inside Notedeck.
-#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub enum Route {
     Timeline(TimelineRoute),
     Accounts(AccountsRoute),

--- a/src/storage/columns.rs
+++ b/src/storage/columns.rs
@@ -1,0 +1,60 @@
+use tracing::{error, info};
+
+use crate::column::SerializableColumns;
+
+use super::{write_file, DataPaths, Directory};
+
+static COLUMNS_FILE: &str = "columns.json";
+
+pub fn save_columns(columns: SerializableColumns) {
+    let serialized_columns = match serde_json::to_string(&columns) {
+        Ok(s) => s,
+        Err(e) => {
+            error!("Could not serialize columns: {}", e);
+            return;
+        }
+    };
+
+    let data_path = match DataPaths::Setting.get_path() {
+        Ok(s) => s,
+        Err(e) => {
+            error!("Could not get data path: {}", e);
+            return;
+        }
+    };
+
+    if let Err(e) = write_file(&data_path, COLUMNS_FILE.to_string(), &serialized_columns) {
+        error!("Could not write columns to file {}: {}", COLUMNS_FILE, e);
+    } else {
+        info!("Successfully wrote columns to {}", COLUMNS_FILE);
+    }
+}
+
+pub fn load_columns() -> Option<SerializableColumns> {
+    let data_path = match DataPaths::Setting.get_path() {
+        Ok(s) => s,
+        Err(e) => {
+            error!("Could not get data path: {}", e);
+            return None;
+        }
+    };
+
+    let columns_string = match Directory::new(data_path).get_file(COLUMNS_FILE.to_owned()) {
+        Ok(s) => s,
+        Err(e) => {
+            error!("Could not read columns from file {}:  {}", COLUMNS_FILE, e);
+            return None;
+        }
+    };
+
+    match serde_json::from_str::<SerializableColumns>(&columns_string) {
+        Ok(s) => {
+            info!("Successfully loaded columns from {}", COLUMNS_FILE);
+            Some(s)
+        }
+        Err(e) => {
+            error!("Could not deserialize columns: {}", e);
+            None
+        }
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,7 +1,9 @@
+mod columns;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 mod file_key_storage;
 mod file_storage;
 
+pub use columns::{load_columns, save_columns};
 pub use file_key_storage::FileKeyStorage;
 pub use file_storage::write_file;
 pub use file_storage::DataPaths;

--- a/src/timeline/kind.rs
+++ b/src/timeline/kind.rs
@@ -5,16 +5,17 @@ use crate::timeline::Timeline;
 use crate::ui::profile::preview::get_profile_displayname_string;
 use enostr::{Filter, Pubkey};
 use nostrdb::{Ndb, Transaction};
+use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use tracing::{error, warn};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum PubkeySource {
     Explicit(Pubkey),
     DeckAuthor,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ListKind {
     Contact(PubkeySource),
 }
@@ -27,7 +28,7 @@ pub enum ListKind {
 ///   - filter
 ///   - ... etc
 ///
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TimelineKind {
     List(ListKind),
 

--- a/src/timeline/route.rs
+++ b/src/timeline/route.rs
@@ -21,7 +21,7 @@ use crate::{
 use enostr::{NoteId, Pubkey, RelayPool};
 use nostrdb::{Ndb, Transaction};
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub enum TimelineRoute {
     Timeline(TimelineId),
     Thread(NoteId),

--- a/src/ui/add_column.rs
+++ b/src/ui/add_column.rs
@@ -178,11 +178,7 @@ impl<'a> AddColumnView<'a> {
         });
 
         if let Some(acc) = self.cur_account {
-            let source = if acc.secret_key.is_some() {
-                PubkeySource::DeckAuthor
-            } else {
-                PubkeySource::Explicit(acc.pubkey)
-            };
+            let source = PubkeySource::Explicit(acc.pubkey);
 
             vec.push(ColumnOptionData {
                 title: "Home timeline",


### PR DESCRIPTION
Allows for writing and loading columns to/from disk. Currently it writes all `Route`s except for threads and profiles.

The `Column::as_serializable_columns` method will probably have to change after #377 but it should be minimal