### PR TITLE
Fix new timelines with non-ready filter states

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,7 +1192,7 @@ dependencies = [
 [[package]]
 name = "egui_nav"
 version = "0.1.0"
-source = "git+https://github.com/damus-io/egui-nav?rev=6ba42de2bae384d10e35c532f3856b81d2e9f645#6ba42de2bae384d10e35c532f3856b81d2e9f645"
+source = "git+https://github.com/damus-io/egui-nav?rev=956338a90e09c7cda951d554626483e0cdbc7825#956338a90e09c7cda951d554626483e0cdbc7825"
 dependencies = [
  "egui",
  "egui_extras",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ eframe = { git = "https://github.com/emilk/egui", rev = "fcb7764e48ce00f8f8e58da
 egui_extras = { git = "https://github.com/emilk/egui", rev = "fcb7764e48ce00f8f8e58da10f937410d65b0bfb", package = "egui_extras", features = ["all_loaders"] }
 ehttp = "0.2.0"
 egui_tabs = { git = "https://github.com/damus-io/egui-tabs", branch = "egui-0.28" }
-egui_nav = { git = "https://github.com/damus-io/egui-nav", rev = "6ba42de2bae384d10e35c532f3856b81d2e9f645" }
+egui_nav = { git = "https://github.com/damus-io/egui-nav", rev = "956338a90e09c7cda951d554626483e0cdbc7825" }
 egui_virtual_list = { git = "https://github.com/jb55/hello_egui", branch = "egui-0.28", package = "egui_virtual_list" }
 reqwest = { version = "0.12.4", default-features = false, features = [ "rustls-tls-native-roots" ] }
 image = { version = "0.25", features = ["jpeg", "png", "webp"] }

--- a/enostr/src/relay/pool.rs
+++ b/enostr/src/relay/pool.rs
@@ -18,6 +18,20 @@ pub struct PoolEvent<'a> {
     pub event: ewebsock::WsEvent,
 }
 
+impl<'a> PoolEvent<'a> {
+    pub fn into_owned(self) -> PoolEventBuf {
+        PoolEventBuf {
+            relay: self.relay.to_owned(),
+            event: self.event
+        }
+    }
+}
+
+pub struct PoolEventBuf {
+    pub relay: String,
+    pub event: ewebsock::WsEvent,
+}
+
 pub struct PoolRelay {
     pub relay: Relay,
     pub last_ping: Instant,

--- a/enostr/src/relay/pool.rs
+++ b/enostr/src/relay/pool.rs
@@ -22,7 +22,7 @@ impl<'a> PoolEvent<'a> {
     pub fn into_owned(self) -> PoolEventBuf {
         PoolEventBuf {
             relay: self.relay.to_owned(),
-            event: self.event
+            event: self.event,
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -223,12 +223,13 @@ fn update_damus(damus: &mut Damus, ctx: &egui::Context) {
             damus
                 .subscriptions()
                 .insert("unknownids".to_string(), SubKind::OneShot);
-            timeline::setup_initial_nostrdb_subs(
+            if let Err(err) = timeline::setup_initial_nostrdb_subs(
                 &damus.ndb,
                 &mut damus.note_cache,
                 &mut damus.columns,
-            )
-            .expect("home subscription failed");
+            ) {
+                warn!("update_damus init: {err}");
+            }
         }
 
         DamusState::Initialized => (),

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -72,9 +72,9 @@ impl FilterStates {
     pub fn set_relay_state(&mut self, relay: String, state: FilterState) {
         if self.states.contains_key(&relay) {
             let current_state = self.states.get(&relay).unwrap();
-            warn!(
-                "set_relay_state: we already have the {:?} state set for {}. overriding with {:?}",
-                current_state, &relay, state
+            debug!(
+                "set_relay_state: {:?} -> {:?} on {}",
+                current_state, state, &relay,
             );
         }
         self.states.insert(relay, state);

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -2,6 +2,7 @@ use crate::error::{Error, FilterError};
 use crate::note::NoteRef;
 use crate::Result;
 use nostrdb::{Filter, FilterBuilder, Note, Subscription};
+use std::collections::HashMap;
 use tracing::{debug, warn};
 
 /// A unified subscription has a local and remote component. The remote subid
@@ -10,6 +11,74 @@ use tracing::{debug, warn};
 pub struct UnifiedSubscription {
     pub local: Subscription,
     pub remote: String,
+}
+
+/// Each relay can have a different filter state. For example, some
+/// relays may have the contact list, some may not. Let's capture all of
+/// these states so that some relays don't stop the states of other
+/// relays.
+#[derive(Debug)]
+pub struct FilterStates {
+    pub initial_state: FilterState,
+    pub states: HashMap<String, FilterState>,
+}
+
+impl FilterStates {
+    pub fn get(&mut self, relay: &str) -> &FilterState {
+        // if our initial state is ready, then just use that
+        if let FilterState::Ready(_) = self.initial_state {
+            &self.initial_state
+        } else {
+            // otherwise we look at relay states
+            if !self.states.contains_key(relay) {
+                self.states
+                    .insert(relay.to_string(), self.initial_state.clone());
+            }
+            self.states.get(relay).unwrap()
+        }
+    }
+
+    pub fn get_any_gotremote(&self) -> Option<(&str, Subscription)> {
+        for (k, v) in self.states.iter() {
+            if let FilterState::GotRemote(sub) = v {
+                return Some((k, *sub));
+            }
+        }
+
+        None
+    }
+
+    pub fn get_any_ready(&self) -> Option<&Vec<Filter>> {
+        if let FilterState::Ready(fs) = &self.initial_state {
+            Some(fs)
+        } else {
+            for (_k, v) in self.states.iter() {
+                if let FilterState::Ready(ref fs) = v {
+                    return Some(fs);
+                }
+            }
+
+            None
+        }
+    }
+
+    pub fn new(initial_state: FilterState) -> Self {
+        Self {
+            initial_state,
+            states: HashMap::new(),
+        }
+    }
+
+    pub fn set_relay_state(&mut self, relay: String, state: FilterState) {
+        if self.states.contains_key(&relay) {
+            let current_state = self.states.get(&relay).unwrap();
+            warn!(
+                "set_relay_state: we already have the {:?} state set for {}. overriding with {:?}",
+                current_state, &relay, state
+            );
+        }
+        self.states.insert(relay, state);
+    }
 }
 
 /// We may need to fetch some data from relays before our filter is ready.

--- a/src/nav.rs
+++ b/src/nav.rs
@@ -42,8 +42,9 @@ pub fn render_nav(col: usize, app: &mut Damus, ui: &mut egui::Ui) -> bool {
     let nav_response = Nav::new(routes)
         .navigating(app.columns_mut().column_mut(col).router_mut().navigating)
         .returning(app.columns_mut().column_mut(col).router_mut().returning)
+        .id_source(egui::Id::new(col_id))
         .title(48.0, title_bar)
-        .show_mut(col_id, ui, |ui, nav| {
+        .show_mut(ui, |ui, nav| {
             let column = app.columns.column_mut(col);
             match &nav.top().route {
                 Route::Timeline(tlr) => render_timeline_route(

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -2,13 +2,12 @@ use enostr::{Filter, Pubkey};
 use nostrdb::{FilterBuilder, Ndb, ProfileRecord, Transaction};
 
 use crate::{
-    app::copy_notes_into_timeline,
     filter::{self, FilterState},
     multi_subscriber::MultiSubscriber,
     note::NoteRef,
     notecache::NoteCache,
     notes_holder::NotesHolder,
-    timeline::{PubkeySource, Timeline, TimelineKind},
+    timeline::{copy_notes_into_timeline, PubkeySource, Timeline, TimelineKind},
 };
 
 pub enum DisplayName<'a> {

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -1,5 +1,6 @@
 use crate::timeline::{TimelineId, TimelineKind};
 use std::collections::HashMap;
+use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub enum SubKind {
@@ -24,4 +25,8 @@ pub enum SubKind {
 #[derive(Default)]
 pub struct Subscriptions {
     pub subs: HashMap<String, SubKind>,
+}
+
+pub fn new_sub_id() -> String {
+    Uuid::new_v4().to_string()
 }

--- a/src/ui/add_column.rs
+++ b/src/ui/add_column.rs
@@ -361,10 +361,16 @@ pub fn render_add_column_routes(
 
     if let Some(resp) = resp {
         match resp {
-            AddColumnResponse::Timeline(timeline) => {
-                let id = timeline.id;
+            AddColumnResponse::Timeline(mut timeline) => {
+                crate::timeline::setup_new_timeline(
+                    &mut timeline,
+                    &app.ndb,
+                    &mut app.subscriptions,
+                    &mut app.pool,
+                    &mut app.note_cache,
+                    app.since_optimize,
+                );
                 app.columns_mut().add_timeline_to_column(col, timeline);
-                app.subscribe_new_timeline(id);
             }
             AddColumnResponse::UndecidedNotification => {
                 app.columns_mut().column_mut(col).router_mut().route_to(


### PR DESCRIPTION
Fix filter states when adding columns
    
    This fixes various issues with filter states when adding columns. We now
    maintain multiple states per relay so that we don't lose track of
    anything.
    
Fixes: https://github.com/damus-io/notedeck/issues/431
Fixes: https://github.com/damus-io/notedeck/issues/359