### PR TITLE
onboarding: lookup profile after accounts are added

### DIFF
--- a/enostr/src/pubkey.rs
+++ b/enostr/src/pubkey.rs
@@ -3,12 +3,21 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::Error;
 use nostr::bech32::Hrp;
 use std::fmt;
+use std::ops::Deref;
 use tracing::debug;
 
 #[derive(Eq, PartialEq, Clone, Copy, Hash)]
 pub struct Pubkey([u8; 32]);
 
 static HRP_NPUB: Hrp = Hrp::parse_unchecked("npub");
+
+impl Deref for Pubkey {
+    type Target = [u8; 32];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 impl Pubkey {
     pub fn new(data: [u8; 32]) -> Self {

--- a/src/bin/notedeck.rs
+++ b/src/bin/notedeck.rs
@@ -18,9 +18,7 @@ fn setup_logging(path: &DataPath) {
     let (maybe_non_blocking, maybe_guard) = {
         let log_path = path.path(DataPathType::Log);
         // Setup logging to file
-        use std::panic;
 
-        use tracing::error;
         use tracing_appender::{
             non_blocking,
             rolling::{RollingFileAppender, Rotation},
@@ -31,9 +29,6 @@ fn setup_logging(path: &DataPath) {
             log_path,
             format!("notedeck-{}.log", env!("CARGO_PKG_VERSION")),
         );
-        panic::set_hook(Box::new(|panic_info| {
-            error!("Notedeck panicked: {:?}", panic_info);
-        }));
 
         let (non_blocking, _guard) = non_blocking(file_appender);
 

--- a/src/nav.rs
+++ b/src/nav.rs
@@ -84,7 +84,7 @@ pub fn render_nav(col: usize, app: &mut Damus, ui: &mut egui::Ui) -> Option<Rend
                     ui,
                 ),
                 Route::Accounts(amr) => {
-                    render_accounts_route(
+                    let action = render_accounts_route(
                         ui,
                         &app.ndb,
                         col,
@@ -94,6 +94,8 @@ pub fn render_nav(col: usize, app: &mut Damus, ui: &mut egui::Ui) -> Option<Rend
                         &mut app.view_state.login,
                         *amr,
                     );
+                    let txn = Transaction::new(&app.ndb).expect("txn");
+                    action.process_action(&mut app.unknown_ids, &app.ndb, &txn);
                     None
                 }
                 Route::Relays => {

--- a/src/test_data.rs
+++ b/src/test_data.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use enostr::{FullKeypair, Pubkey, RelayPool};
-use nostrdb::ProfileRecord;
+use nostrdb::{ProfileRecord, Transaction};
 
 use crate::{user_account::UserAccount, Damus};
 
@@ -100,8 +100,11 @@ pub fn test_app() -> Damus {
     let mut app = Damus::mock(path);
 
     let accounts = get_test_accounts();
+    let txn = Transaction::new(&app.ndb).expect("txn");
     for account in accounts {
-        app.accounts_mut().add_account(account);
+        app.accounts_mut()
+            .add_account(account)
+            .process_action(&mut app.unknown_ids, &app.ndb, &txn)
     }
 
     app


### PR DESCRIPTION
onboarding: lookup profile after accounts are added
    
To reduce the side effects of this change, we introduce a new UnknownId
action type:

  - `SingleUnkIdAction`

This can be returned from functions to signal that we need to do some
work to look for things. We add a `must_use` directive to this type
to ensure callers handle it.

Changelog-Fixed: Fix missing profiles when new accounts are added
Fixes: https://github.com/damus-io/notedeck/issues/356
