### PR TITLE
refactor: unify note, post and nav actions

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -744,8 +744,10 @@ fn render_damus_mobile(ctx: &egui::Context, app: &mut Damus) {
     //let routes = app.timelines[0].routes.clone();
 
     main_panel(&ctx.style(), ui::is_narrow(ctx)).show(ctx, |ui| {
-        if !app.columns.columns().is_empty() {
-            nav::render_nav(0, app, ui).process_render_nav_response(app);
+        if !app.columns.columns().is_empty()
+            && nav::render_nav(0, app, ui).process_render_nav_response(app)
+        {
+            storage::save_columns(&app.path, app.columns().as_serializable_columns());
         }
     });
 }
@@ -822,6 +824,7 @@ fn timelines_view(ui: &mut egui::Ui, sizes: Size, app: &mut Damus) {
                 );
             });
 
+            let mut save_cols = false;
             let mut responses = Vec::with_capacity(app.columns.num_columns());
             for col_index in 0..app.columns.num_columns() {
                 strip.cell(|ui| {
@@ -840,7 +843,12 @@ fn timelines_view(ui: &mut egui::Ui, sizes: Size, app: &mut Damus) {
             }
 
             for response in responses {
-                response.process_render_nav_response(app);
+                let save = response.process_render_nav_response(app);
+                save_cols = save_cols || save;
+            }
+
+            if save_cols {
+                storage::save_columns(&app.path, app.columns().as_serializable_columns());
             }
         });
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -745,9 +745,7 @@ fn render_damus_mobile(ctx: &egui::Context, app: &mut Damus) {
 
     main_panel(&ctx.style(), ui::is_narrow(ctx)).show(ctx, |ui| {
         if !app.columns.columns().is_empty() {
-            if let Some(r) = nav::render_nav(0, app, ui) {
-                r.process_nav_response(&app.path, &mut app.columns)
-            }
+            nav::render_nav(0, app, ui).process_render_nav_response(app);
         }
     });
 }
@@ -824,13 +822,11 @@ fn timelines_view(ui: &mut egui::Ui, sizes: Size, app: &mut Damus) {
                 );
             });
 
-            let mut nav_resp: Option<nav::RenderNavResponse> = None;
+            let mut responses = Vec::with_capacity(app.columns.num_columns());
             for col_index in 0..app.columns.num_columns() {
                 strip.cell(|ui| {
                     let rect = ui.available_rect_before_wrap();
-                    if let Some(r) = nav::render_nav(col_index, app, ui) {
-                        nav_resp = Some(r);
-                    }
+                    responses.push(nav::render_nav(col_index, app, ui));
 
                     // vertical line
                     ui.painter().vline(
@@ -843,8 +839,8 @@ fn timelines_view(ui: &mut egui::Ui, sizes: Size, app: &mut Damus) {
                 //strip.cell(|ui| timeline::timeline_view(ui, app, timeline_ind));
             }
 
-            if let Some(r) = nav_resp {
-                r.process_nav_response(&app.path, &mut app.columns);
+            for response in responses {
+                response.process_render_nav_response(app);
             }
         });
 }

--- a/src/column.rs
+++ b/src/column.rs
@@ -261,9 +261,6 @@ impl SerializableColumns {
                     Route::Timeline(TimelineRoute::Thread(_thread)) => {
                         // TODO: open thread before pushing route
                     }
-                    Route::Profile(_profile) => {
-                        // TODO: open profile before pushing route
-                    }
                     _ => routes.push(*route),
                 }
             }

--- a/src/draft.rs
+++ b/src/draft.rs
@@ -1,3 +1,4 @@
+use crate::ui::note::PostType;
 use std::collections::HashMap;
 
 #[derive(Default)]
@@ -17,6 +18,14 @@ impl Drafts {
         &mut self.compose
     }
 
+    pub fn get_from_post_type(&mut self, post_type: &PostType) -> &mut Draft {
+        match post_type {
+            PostType::New => self.compose_mut(),
+            PostType::Quote(note_id) => self.quote_mut(note_id.bytes()),
+            PostType::Reply(note_id) => self.reply_mut(note_id.bytes()),
+        }
+    }
+
     pub fn reply_mut(&mut self, id: &[u8; 32]) -> &mut Draft {
         self.replies.entry(*id).or_default()
     }
@@ -25,23 +34,6 @@ impl Drafts {
         self.quotes.entry(*id).or_default()
     }
 }
-
-pub enum DraftSource<'a> {
-    Compose,
-    Reply(&'a [u8; 32]), // note id
-    Quote(&'a [u8; 32]), // note id
-}
-
-/*
-impl<'a> DraftSource<'a> {
-    pub fn draft(&self, drafts: &'a mut Drafts) -> &'a mut Draft {
-        match self {
-            DraftSource::Compose => drafts.compose_mut(),
-            DraftSource::Reply(id) => drafts.reply_mut(id),
-        }
-    }
-}
-*/
 
 impl Draft {
     pub fn new() -> Self {

--- a/src/nav.rs
+++ b/src/nav.rs
@@ -7,7 +7,6 @@ use crate::{
     profile::Profile,
     relay_pool_manager::RelayPoolManager,
     route::Route,
-    storage::{self},
     thread::Thread,
     timeline::{
         route::{render_timeline_route, TimelineRoute},
@@ -60,7 +59,8 @@ impl RenderNavResponse {
         RenderNavResponse { column, response }
     }
 
-    pub fn process_render_nav_response(&self, app: &mut Damus) {
+    #[must_use = "Make sure to save columns if result is true"]
+    pub fn process_render_nav_response(&self, app: &mut Damus) -> bool {
         let mut col_changed: bool = false;
         let col = self.column;
 
@@ -146,9 +146,7 @@ impl RenderNavResponse {
             }
         }
 
-        if col_changed {
-            storage::save_columns(&app.path, app.columns().as_serializable_columns());
-        }
+        col_changed
     }
 }
 

--- a/src/route.rs
+++ b/src/route.rs
@@ -21,7 +21,6 @@ pub enum Route {
     Relays,
     ComposeNote,
     AddColumn(AddColumnRoute),
-    Profile(Pubkey),
     Support,
 }
 
@@ -58,6 +57,10 @@ impl Route {
         Route::Timeline(TimelineRoute::Thread(thread_root))
     }
 
+    pub fn profile(pubkey: Pubkey) -> Self {
+        Route::Timeline(TimelineRoute::Profile(pubkey))
+    }
+
     pub fn reply(replying_to: NoteId) -> Self {
         Route::Timeline(TimelineRoute::Reply(replying_to))
     }
@@ -92,6 +95,9 @@ impl Route {
                 TimelineRoute::Quote(id) => {
                     format!("{}'s Quote", get_note_users_displayname_string(ndb, id))
                 }
+                TimelineRoute::Profile(pubkey) => {
+                    format!("{}'s Profile", get_profile_displayname_string(ndb, pubkey))
+                }
             },
 
             Route::Relays => "Relays".to_owned(),
@@ -108,9 +114,6 @@ impl Route {
                     "Add External Notifications Column".to_owned()
                 }
             },
-            Route::Profile(pubkey) => {
-                format!("{}'s Profile", get_profile_displayname_string(ndb, pubkey))
-            }
             Route::Support => "Damus Support".to_owned(),
         };
 
@@ -207,6 +210,7 @@ impl fmt::Display for Route {
             Route::Timeline(tlr) => match tlr {
                 TimelineRoute::Timeline(name) => write!(f, "{}", name),
                 TimelineRoute::Thread(_id) => write!(f, "Thread"),
+                TimelineRoute::Profile(_id) => write!(f, "Profile"),
                 TimelineRoute::Reply(_id) => write!(f, "Reply"),
                 TimelineRoute::Quote(_id) => write!(f, "Quote"),
             },
@@ -220,7 +224,6 @@ impl fmt::Display for Route {
             Route::ComposeNote => write!(f, "Compose Note"),
 
             Route::AddColumn(_) => write!(f, "Add Column"),
-            Route::Profile(_) => write!(f, "Profile"),
             Route::Support => write!(f, "Support"),
         }
     }

--- a/src/ui/note/contents.rs
+++ b/src/ui/note/contents.rs
@@ -1,4 +1,4 @@
-use crate::actionbar::NoteActionResponse;
+use crate::actionbar::NoteAction;
 use crate::images::ImageType;
 use crate::imgcache::ImageCache;
 use crate::notecache::NoteCache;
@@ -17,7 +17,7 @@ pub struct NoteContents<'a> {
     note: &'a Note<'a>,
     note_key: NoteKey,
     options: NoteOptions,
-    action: NoteActionResponse,
+    action: Option<NoteAction>,
 }
 
 impl<'a> NoteContents<'a> {
@@ -38,11 +38,11 @@ impl<'a> NoteContents<'a> {
             note,
             note_key,
             options,
-            action: NoteActionResponse::default(),
+            action: None,
         }
     }
 
-    pub fn action(&self) -> &NoteActionResponse {
+    pub fn action(&self) -> &Option<NoteAction> {
         &self.action
     }
 }
@@ -212,7 +212,7 @@ fn render_note_contents(
     let note_action = if let Some((id, block_str)) = inline_note {
         render_note_preview(ui, ndb, note_cache, img_cache, txn, id, block_str).action
     } else {
-        NoteActionResponse::default()
+        None
     };
 
     if !images.is_empty() && !options.has_textmode() {

--- a/src/ui/note/quote_repost.rs
+++ b/src/ui/note/quote_repost.rs
@@ -1,9 +1,9 @@
-use enostr::FilledKeypair;
+use enostr::{FilledKeypair, NoteId};
 use nostrdb::Ndb;
 
 use crate::{draft::Draft, imgcache::ImageCache, notecache::NoteCache, ui};
 
-use super::PostResponse;
+use super::{PostResponse, PostType};
 
 pub struct QuoteRepostView<'a> {
     ndb: &'a Ndb,
@@ -43,7 +43,7 @@ impl<'a> QuoteRepostView<'a> {
         ui::PostView::new(
             self.ndb,
             self.draft,
-            crate::draft::DraftSource::Quote(quoting_note_id),
+            PostType::Quote(NoteId::new(quoting_note_id.to_owned())),
             self.img_cache,
             self.note_cache,
             self.poster,

--- a/src/ui/note/reply.rs
+++ b/src/ui/note/reply.rs
@@ -2,8 +2,8 @@ use crate::draft::Draft;
 use crate::imgcache::ImageCache;
 use crate::notecache::NoteCache;
 use crate::ui;
-use crate::ui::note::PostResponse;
-use enostr::FilledKeypair;
+use crate::ui::note::{PostResponse, PostType};
+use enostr::{FilledKeypair, NoteId};
 use nostrdb::Ndb;
 
 pub struct PostReplyView<'a> {
@@ -79,7 +79,7 @@ impl<'a> PostReplyView<'a> {
                 ui::PostView::new(
                     self.ndb,
                     self.draft,
-                    crate::draft::DraftSource::Reply(replying_to),
+                    PostType::Reply(NoteId::new(*replying_to)),
                     self.img_cache,
                     self.note_cache,
                     self.poster,

--- a/src/ui/profile/mod.rs
+++ b/src/ui/profile/mod.rs
@@ -9,7 +9,7 @@ pub use picture::ProfilePic;
 pub use preview::ProfilePreview;
 
 use crate::{
-    actionbar::NoteActionResponse, imgcache::ImageCache, notecache::NoteCache,
+    actionbar::NoteAction, imgcache::ImageCache, notecache::NoteCache,
     notes_holder::NotesHolderStorage, profile::Profile,
 };
 
@@ -46,7 +46,7 @@ impl<'a> ProfileView<'a> {
         }
     }
 
-    pub fn ui(&mut self, ui: &mut egui::Ui) -> NoteActionResponse {
+    pub fn ui(&mut self, ui: &mut egui::Ui) -> Option<NoteAction> {
         let scroll_id = egui::Id::new(("profile_scroll", self.col_id, self.pubkey));
 
         ScrollArea::vertical()

--- a/src/ui/thread.rs
+++ b/src/ui/thread.rs
@@ -1,5 +1,5 @@
 use crate::{
-    actionbar::NoteActionResponse,
+    actionbar::NoteAction,
     imgcache::ImageCache,
     notecache::NoteCache,
     notes_holder::{NotesHolder, NotesHolderStorage},
@@ -52,7 +52,7 @@ impl<'a> ThreadView<'a> {
         self
     }
 
-    pub fn ui(&mut self, ui: &mut egui::Ui) -> NoteActionResponse {
+    pub fn ui(&mut self, ui: &mut egui::Ui) -> Option<NoteAction> {
         let txn = Transaction::new(self.ndb).expect("txn");
 
         let selected_note_key = if let Ok(key) = self
@@ -63,7 +63,7 @@ impl<'a> ThreadView<'a> {
             key
         } else {
             // TODO: render 404 ?
-            return NoteActionResponse::default();
+            return None;
         };
 
         ui.label(
@@ -80,7 +80,7 @@ impl<'a> ThreadView<'a> {
                 let note = if let Ok(note) = self.ndb.get_note_by_key(&txn, selected_note_key) {
                     note
                 } else {
-                    return NoteActionResponse::default();
+                    return None;
                 };
 
                 let root_id = {

--- a/src/ui/timeline.rs
+++ b/src/ui/timeline.rs
@@ -1,4 +1,4 @@
-use crate::actionbar::{BarAction, NoteActionResponse};
+use crate::actionbar::NoteAction;
 use crate::timeline::TimelineTab;
 use crate::{
     column::Columns, imgcache::ImageCache, notecache::NoteCache, timeline::TimelineId, ui,
@@ -41,7 +41,7 @@ impl<'a> TimelineView<'a> {
         }
     }
 
-    pub fn ui(&mut self, ui: &mut egui::Ui) -> NoteActionResponse {
+    pub fn ui(&mut self, ui: &mut egui::Ui) -> Option<NoteAction> {
         timeline_ui(
             ui,
             self.ndb,
@@ -70,7 +70,7 @@ fn timeline_ui(
     img_cache: &mut ImageCache,
     reversed: bool,
     note_options: NoteOptions,
-) -> NoteActionResponse {
+) -> Option<NoteAction> {
     //padding(4.0, ui, |ui| ui.heading("Notifications"));
     /*
     let font_id = egui::TextStyle::Body.resolve(ui.style());
@@ -85,7 +85,7 @@ fn timeline_ui(
             error!("tried to render timeline in column, but timeline was missing");
             // TODO (jb55): render error when timeline is missing?
             // this shouldn't happen...
-            return NoteActionResponse::default();
+            return None;
         };
 
         timeline.selected_view = tabs_ui(ui);
@@ -108,7 +108,7 @@ fn timeline_ui(
                 error!("tried to render timeline in column, but timeline was missing");
                 // TODO (jb55): render error when timeline is missing?
                 // this shouldn't happen...
-                return NoteActionResponse::default();
+                return None;
             };
 
             let txn = Transaction::new(ndb).expect("failed to create txn");
@@ -241,9 +241,8 @@ impl<'a> TimelineTabView<'a> {
         }
     }
 
-    pub fn show(&mut self, ui: &mut egui::Ui) -> NoteActionResponse {
-        let mut open_profile = None;
-        let mut bar_action: Option<BarAction> = None;
+    pub fn show(&mut self, ui: &mut egui::Ui) -> Option<NoteAction> {
+        let mut action: Option<NoteAction> = None;
         let len = self.tab.notes.len();
 
         self.tab
@@ -274,8 +273,9 @@ impl<'a> TimelineTabView<'a> {
                         .note_options(self.note_options)
                         .show(ui);
 
-                    bar_action = bar_action.or(resp.action.bar_action);
-                    open_profile = open_profile.or(resp.action.open_profile);
+                    if let Some(note_action) = resp.action {
+                        action = Some(note_action)
+                    }
 
                     if let Some(context) = resp.context_selection {
                         context.process(ui, &note);
@@ -288,9 +288,6 @@ impl<'a> TimelineTabView<'a> {
                 1
             });
 
-        NoteActionResponse {
-            open_profile,
-            bar_action,
-        }
+        action
     }
 }


### PR DESCRIPTION
There was a bunch of redundant responses. Let's unify them under the RenderNavAction enum. We unify all action processing under this type.