### PR TITLE
Generate RPM package

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -103,3 +103,31 @@ jobs:
 #        run: wget -qO- https://github.com/thedodd/trunk/releases/latest/download/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
 #      - name: Build
 #        run: ./trunk build
+
+  rpm:
+    name: Build RPM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install RPM Build Tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm binutils
+          cargo install cargo-generate-rpm
+
+      - name: Build Rust Project
+        run: cargo build --release
+
+      - name: Strip Debug Symbols
+        run: strip target/release/notedeck
+
+      - name: Build RPM
+        run: cargo generate-rpm
+
+      - name: Upload RPM Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: notedeck-rpm
+          path: target/generate-rpm/*.rpm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["William Casarin <jb55@jb55.com>"]
 edition = "2021"
 default-run = "notedeck"
 #rust-version = "1.60"
+license = "GPLv3"
+description = "A multiplatform nostr client"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -113,6 +115,11 @@ name = "android.permission.INTERNET"
 
 [package.metadata.android.application]
 label = "Damus"
+
+[package.metadata.generate-rpm]
+assets = [
+    { source = "target/release/notedeck", dest = "/usr/bin/notedeck", mode = "755" },
+]
 
 [[bin]]
 name = "notedeck"


### PR DESCRIPTION
This PR uses `cargo-generate-rpm` to avoid needing a `notedeck.spec` file.  It is also possible to build the RPM using the more traditional SPEC flow ...

IMPORTANT - I added to the top-level `Cargo.toml` package:
```
license = "GPLv3"
description = "A multiplatform nostr client"
```
... don't know if those are ok ...

This generates an RPM artifact as part of the CI flow.