### PR TITLE
Fix quote repost hitbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,6 +1112,7 @@ source = "git+https://github.com/emilk/egui?rev=fcb7764e48ce00f8f8e58da10f937410
 dependencies = [
  "accesskit",
  "ahash",
+ "backtrace",
  "emath",
  "epaint",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,7 +1193,7 @@ dependencies = [
 [[package]]
 name = "egui_nav"
 version = "0.1.0"
-source = "git+https://github.com/damus-io/egui-nav?rev=956338a90e09c7cda951d554626483e0cdbc7825#956338a90e09c7cda951d554626483e0cdbc7825"
+source = "git+https://github.com/damus-io/egui-nav?rev=fd0900bdff4be35709372e921f2b49f68b261469#fd0900bdff4be35709372e921f2b49f68b261469"
 dependencies = [
  "egui",
  "egui_extras",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,8 @@ security-framework = "2.11.0"
 [features]
 default = []
 profiling = ["puffin", "puffin_egui", "eframe/puffin"]
+debug-widget-callstack = ["egui/callstack"]
+debug-interactive-widgets = []
 
 [profile.small]
 inherits = 'release'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ eframe = { workspace = true }
 egui_extras = { workspace = true }
 ehttp = "0.2.0"
 egui_tabs = { git = "https://github.com/damus-io/egui-tabs", branch = "egui-0.28" }
-egui_nav = { git = "https://github.com/damus-io/egui-nav", rev = "956338a90e09c7cda951d554626483e0cdbc7825" }
+egui_nav = { git = "https://github.com/damus-io/egui-nav", rev = "fd0900bdff4be35709372e921f2b49f68b261469" }
 egui_virtual_list = { git = "https://github.com/jb55/hello_egui", branch = "egui-0.28", package = "egui_virtual_list" }
 reqwest = { version = "0.12.4", default-features = false, features = [ "rustls-tls-native-roots" ] }
 image = { version = "0.25", features = ["jpeg", "png", "webp"] }

--- a/src/app_style.rs
+++ b/src/app_style.rs
@@ -69,6 +69,19 @@ pub fn create_custom_style(ctx: &Context, font_size: fn(&NotedeckTextStyle) -> f
         ..Interaction::default()
     };
 
+    // debug: show callstack for the current widget on hover if all
+    // modifier keys are pressed down.
+    #[cfg(feature = "debug-widget-callstack")]
+    {
+        style.debug.debug_on_hover_with_all_modifiers = true;
+    }
+
+    // debug: show an overlay on all interactive widgets
+    #[cfg(feature = "debug-interactive-widgets")]
+    {
+        style.debug.show_interactive_widgets = true;
+    }
+
     style
 }
 

--- a/src/ui/note/contents.rs
+++ b/src/ui/note/contents.rs
@@ -73,7 +73,7 @@ pub fn render_note_preview(
     img_cache: &mut ImageCache,
     txn: &Transaction,
     id: &[u8; 32],
-    _id_str: &str,
+    parent: NoteKey,
 ) -> NoteResponse {
     #[cfg(feature = "profiling")]
     puffin::profile_function!();
@@ -117,6 +117,7 @@ pub fn render_note_preview(
                 .wide(true)
                 .note_previews(false)
                 .options_button(true)
+                .parent(parent)
                 .show(ui)
         })
         .inner
@@ -213,8 +214,8 @@ fn render_note_contents(
         }
     });
 
-    let note_action = if let Some((id, block_str)) = inline_note {
-        render_note_preview(ui, ndb, note_cache, img_cache, txn, id, block_str).action
+    let note_action = if let Some((id, _block_str)) = inline_note {
+        render_note_preview(ui, ndb, note_cache, img_cache, txn, id, note_key).action
     } else {
         None
     };

--- a/src/ui/note/mod.rs
+++ b/src/ui/note/mod.rs
@@ -451,64 +451,68 @@ impl<'a> NoteView<'a> {
 
         // wide design
         let response = if self.options().has_wide() {
-            ui.horizontal(|ui| {
-                if self.pfp(note_key, &profile, ui).clicked() {
-                    note_action = Some(NoteAction::OpenProfile(Pubkey::new(*self.note.pubkey())));
-                };
+            ui.vertical(|ui| {
+                ui.horizontal(|ui| {
+                    if self.pfp(note_key, &profile, ui).clicked() {
+                        note_action =
+                            Some(NoteAction::OpenProfile(Pubkey::new(*self.note.pubkey())));
+                    };
 
-                let size = ui.available_size();
-                ui.vertical(|ui| {
-                    ui.add_sized([size.x, self.options().pfp_size()], |ui: &mut egui::Ui| {
-                        ui.horizontal_centered(|ui| {
-                            selected_option = NoteView::note_header(
-                                ui,
-                                self.note_cache,
-                                self.note,
-                                &profile,
-                                self.options(),
-                                container_right,
-                            )
-                            .context_selection;
-                        })
-                        .response
-                    });
-
-                    let note_reply = self
-                        .note_cache
-                        .cached_note_or_insert_mut(note_key, self.note)
-                        .reply
-                        .borrow(self.note.tags());
-
-                    if note_reply.reply().is_some() {
-                        ui.horizontal(|ui| {
-                            reply_desc(ui, txn, &note_reply, self.ndb, self.img_cache);
+                    let size = ui.available_size();
+                    ui.vertical(|ui| {
+                        ui.add_sized([size.x, self.options().pfp_size()], |ui: &mut egui::Ui| {
+                            ui.horizontal_centered(|ui| {
+                                selected_option = NoteView::note_header(
+                                    ui,
+                                    self.note_cache,
+                                    self.note,
+                                    &profile,
+                                    self.options(),
+                                    container_right,
+                                )
+                                .context_selection;
+                            })
+                            .response
                         });
-                    }
+
+                        let note_reply = self
+                            .note_cache
+                            .cached_note_or_insert_mut(note_key, self.note)
+                            .reply
+                            .borrow(self.note.tags());
+
+                        if note_reply.reply().is_some() {
+                            ui.horizontal(|ui| {
+                                reply_desc(ui, txn, &note_reply, self.ndb, self.img_cache);
+                            });
+                        }
+                    });
                 });
-            });
 
-            let mut contents = NoteContents::new(
-                self.ndb,
-                self.img_cache,
-                self.note_cache,
-                txn,
-                self.note,
-                note_key,
-                self.options(),
-            );
-            let resp = ui.add(&mut contents);
+                let mut contents = NoteContents::new(
+                    self.ndb,
+                    self.img_cache,
+                    self.note_cache,
+                    txn,
+                    self.note,
+                    note_key,
+                    self.options(),
+                );
 
-            if let Some(action) = contents.action() {
-                note_action = Some(*action);
-            }
+                ui.add(&mut contents);
 
-            if self.options().has_actionbar() {
-                if let Some(action) = render_note_actionbar(ui, self.note.id(), note_key).inner {
-                    note_action = Some(action);
+                if let Some(action) = contents.action() {
+                    note_action = Some(*action);
                 }
-            }
 
-            resp
+                if self.options().has_actionbar() {
+                    if let Some(action) = render_note_actionbar(ui, self.note.id(), note_key).inner
+                    {
+                        note_action = Some(action);
+                    }
+                }
+            })
+            .response
         } else {
             // main design
             ui.with_layout(egui::Layout::left_to_right(egui::Align::TOP), |ui| {

--- a/src/ui/note/post.rs
+++ b/src/ui/note/post.rs
@@ -200,7 +200,7 @@ impl<'a> PostView<'a> {
                                                 self.img_cache,
                                                 txn,
                                                 id.bytes(),
-                                                "",
+                                                nostrdb::NoteKey::new(0),
                                             );
                                         });
                                     });


### PR DESCRIPTION
The response from the wide rendered note was incorrect, leading to and
incorrectly sized hitbox. This fixes that.

Additionally, we include note options and note parent into the hitbox
key, as this may influence the size of the note.

|Before|After|
|------|-----|
|![](https://cdn.jb55.com/s/b2464c22a65adb12.png)|![](https://cdn.jb55.com/s/52545564d98d278e.png)|

Fixes: #519
Closes: #537
Changelog-Fixed: Fix broken quote repost hitbox
Signed-off-by: William Casarin <jb55@jb55.com>
