### PR TITLE
anim: smoothly animate delete button from 0 size

### DIFF
--- a/src/nav.rs
+++ b/src/nav.rs
@@ -377,13 +377,12 @@ fn delete_column_button(
 
     let helper = AnimationHelper::new_from_rect(ui, "delete-column-button", button_rect);
 
-    let cur_img_size = helper.scale_1d_pos(img_size);
+    let cur_img_size = helper.scale_1d_pos_min_max(0.0, img_size);
 
     let animation_rect = helper.get_animation_rect();
     let animation_resp = helper.take_animation_response();
-    if allocation_response.union(animation_resp.clone()).hovered() {
-        img.paint_at(ui, animation_rect.shrink((max_size - cur_img_size) / 2.0));
-    }
+
+    img.paint_at(ui, animation_rect.shrink((max_size - cur_img_size) / 2.0));
 
     animation_resp
 }

--- a/src/ui/anim.rs
+++ b/src/ui/anim.rs
@@ -130,4 +130,9 @@ impl AnimationHelper {
     pub fn scale_pos_from_center(&self, min_pos: Pos2) -> Pos2 {
         self.scale_from_center(min_pos.x, min_pos.y)
     }
+
+    /// New method for min/max scaling when needed
+    pub fn scale_1d_pos_min_max(&self, min_object_size: f32, max_object_size: f32) -> f32 {
+        min_object_size + ((max_object_size - min_object_size) * self.animation_progress)
+    }
 }


### PR DESCRIPTION
This is a much cleaner animation for the delete column button.

Split off from

- #12 

since it was getting big


https://github.com/user-attachments/assets/293582ab-90e4-4e11-a009-e264f505b036

