### PR TITLE
prevent users from running as debug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,7 +1149,6 @@ checksum = "53eafabcce0cb2325a59a98736efe0bf060585b437763f8c476957fb274bb974"
 dependencies = [
  "accesskit",
  "ahash",
- "backtrace",
  "emath",
  "epaint",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,6 @@ security-framework = "2.11.0"
 [features]
 default = []
 profiling = ["puffin", "puffin_egui", "eframe/puffin"]
-debug-widget-callstack = ["egui/callstack"]
-debug-interactive-widgets = []
 
 [profile.small]
 inherits = 'release'

--- a/src/app.rs
+++ b/src/app.rs
@@ -375,6 +375,16 @@ impl Damus {
         let parsed_args = Args::parse(&args);
         let is_mobile = parsed_args.is_mobile.unwrap_or(ui::is_compiled_as_mobile());
 
+        // Some people have been running notedeck in debug, let's catch that!
+        if cfg!(debug_assertions) && !parsed_args.debug {
+            println!("--- WELCOME TO DAMUS NOTEDECK! ---");
+            println!("It looks like are running notedeck in debug mode, unless you are a developer, this is not likely what you want.");
+            println!("If you are a developer, run `cargo run -- --debug` to skip this message.");
+            println!("For everyone else, try again with `cargo run --release`. Enjoy!");
+            println!("---------------------------------");
+            panic!();
+        }
+
         setup_cc(ctx, is_mobile, parsed_args.light);
 
         let data_path = parsed_args

--- a/src/app_style.rs
+++ b/src/app_style.rs
@@ -70,17 +70,10 @@ pub fn create_custom_style(ctx: &Context, font_size: fn(&NotedeckTextStyle) -> f
         ..Interaction::default()
     };
 
-    // debug: show callstack for the current widget on hover if all
-    // modifier keys are pressed down.
-    #[cfg(feature = "debug-widget-callstack")]
-    {
-        style.debug.debug_on_hover_with_all_modifiers = true;
-    }
-
-    // debug: show an overlay on all interactive widgets
-    #[cfg(feature = "debug-interactive-widgets")]
+    #[cfg(debug_assertions)]
     {
         style.debug.show_interactive_widgets = true;
+        style.debug.debug_on_hover_with_all_modifiers = true;
     }
 
     style


### PR DESCRIPTION
We give a friendly message now. If it didn't crash when fiatjaf ran in debug mode he probably would have thought it was horribly slow.

If you need to run as debug, use `cargo run -- --debug` or `./target/debug/notedeck --debug`.

We also remove the callstack feature because it doesn't seem like you need it for widget callstacks. We also enable the debug ui stuff by default in debug mode because its really the only time you should be using it.

Fixes: aafddf5acbae ("debug: add crate features which enable egui DebugOptions")