### PR TITLE
log: only show notedeck logs

### DIFF
--- a/src/bin/notedeck.rs
+++ b/src/bin/notedeck.rs
@@ -47,7 +47,7 @@ fn setup_logging(path: &DataPath) {
             .with_writer(non_blocking_writer);
 
         let env_filter =
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("notedeck=info"));
 
         // Set up the subscriber to combine both layers
         tracing_subscriber::registry()


### PR DESCRIPTION
showing logs for other packages (especially wgpu_core) makes the logs borderline unusable