### PR TITLE
theme: persist across app close

### DIFF
--- a/crates/notedeck_columns/src/app_style.rs
+++ b/crates/notedeck_columns/src/app_style.rs
@@ -6,7 +6,7 @@ use crate::{
 use egui::{
     epaint::Shadow,
     style::{Interaction, Selection, WidgetVisuals, Widgets},
-    Button, FontFamily, FontId, Rounding, Stroke, Style, TextStyle, Ui, Visuals,
+    FontFamily, FontId, Rounding, Stroke, Style, TextStyle, Visuals,
 };
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
@@ -26,29 +26,6 @@ pub fn dark_mode(mobile: bool) -> Visuals {
         },
         Visuals::dark(),
     )
-}
-
-pub fn user_requested_visuals_change(
-    oled: bool,
-    cur_darkmode: bool,
-    ui: &mut Ui,
-) -> Option<Visuals> {
-    if cur_darkmode {
-        if ui
-            .add(Button::new("☀").frame(false))
-            .on_hover_text("Switch to light mode")
-            .clicked()
-        {
-            return Some(light_mode());
-        }
-    } else if ui
-        .add(Button::new("🌙").frame(false))
-        .on_hover_text("Switch to dark mode")
-        .clicked()
-    {
-        return Some(dark_mode(oled));
-    }
-    None
 }
 
 /// Create custom text sizes for any FontSizes

--- a/crates/notedeck_columns/src/lib.rs
+++ b/crates/notedeck_columns/src/lib.rs
@@ -36,6 +36,7 @@ mod route;
 mod subscriptions;
 mod support;
 mod test_data;
+mod theme_handler;
 mod thread;
 mod time;
 mod timecache;

--- a/crates/notedeck_columns/src/theme_handler.rs
+++ b/crates/notedeck_columns/src/theme_handler.rs
@@ -1,0 +1,76 @@
+use egui::ThemePreference;
+use tracing::{error, info};
+
+use crate::storage::{write_file, DataPath, DataPathType, Directory};
+
+pub struct ThemeHandler {
+    directory: Directory,
+    fallback_theme: ThemePreference,
+}
+
+const THEME_FILE: &str = "theme.txt";
+
+impl ThemeHandler {
+    pub fn new(path: &DataPath) -> Self {
+        let directory = Directory::new(path.path(DataPathType::Setting));
+        let fallback_theme = ThemePreference::Light;
+        Self {
+            directory,
+            fallback_theme,
+        }
+    }
+
+    pub fn load(&self) -> ThemePreference {
+        match self.directory.get_file(THEME_FILE.to_owned()) {
+            Ok(contents) => match deserialize_theme(contents) {
+                Some(theme) => theme,
+                None => {
+                    error!(
+                        "Could not deserialize theme. Using fallback {:?} instead",
+                        self.fallback_theme
+                    );
+                    self.fallback_theme
+                }
+            },
+            Err(e) => {
+                error!(
+                    "Could not read {} file: {:?}\nUsing fallback {:?} instead",
+                    THEME_FILE, e, self.fallback_theme
+                );
+                self.fallback_theme
+            }
+        }
+    }
+
+    pub fn save(&self, theme: ThemePreference) {
+        match write_file(
+            &self.directory.file_path,
+            THEME_FILE.to_owned(),
+            &theme_to_serialized(&theme),
+        ) {
+            Ok(_) => info!(
+                "Successfully saved {:?} theme change to {}",
+                theme, THEME_FILE
+            ),
+            Err(_) => error!("Could not save {:?} theme change to {}", theme, THEME_FILE),
+        }
+    }
+}
+
+fn theme_to_serialized(theme: &ThemePreference) -> String {
+    match theme {
+        ThemePreference::Dark => "dark",
+        ThemePreference::Light => "light",
+        ThemePreference::System => "system",
+    }
+    .to_owned()
+}
+
+fn deserialize_theme(serialized_theme: String) -> Option<ThemePreference> {
+    match serialized_theme.as_str() {
+        "dark" => Some(ThemePreference::Dark),
+        "light" => Some(ThemePreference::Light),
+        "system" => Some(ThemePreference::System),
+        _ => None,
+    }
+}


### PR DESCRIPTION
makes use of theme changes in egui 0.29 and loads/saves theme to disk so the user's choice persists on app close and re-open