### PR TITLE
Remove reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,7 +1835,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls 0.23.13",
- "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -2529,7 +2528,6 @@ dependencies = [
  "poll-promise",
  "puffin 0.19.1 (git+https://github.com/jb55/puffin?rev=70ff86d5503815219b01a009afd3669b7903a057)",
  "puffin_egui",
- "reqwest",
  "security-framework",
  "serde",
  "serde_derive",
@@ -2918,12 +2916,6 @@ dependencies = [
  "libc",
  "pathdiff",
 ]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "option-ext"
@@ -3535,7 +3527,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.13",
- "rustls-native-certs 0.7.3",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -3681,32 +3672,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "rustls-pemfile"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3761,15 +3726,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
-dependencies = [
- "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ open = "5.3.0"
 poll-promise = { version = "0.3.0", features = ["tokio"] }
 puffin = { git = "https://github.com/jb55/puffin", package = "puffin", rev = "70ff86d5503815219b01a009afd3669b7903a057" }
 puffin_egui = { git = "https://github.com/jb55/puffin", package = "puffin_egui", rev = "70ff86d5503815219b01a009afd3669b7903a057" }
-reqwest = { version = "0.12.4", default-features = false, features = [ "rustls-tls-native-roots" ] }
 serde = { version = "1", features = ["derive"] } # You only need this if you want app persistence
 serde_derive = "1"
 serde_json = "1.0.89"

--- a/crates/notedeck_columns/Cargo.toml
+++ b/crates/notedeck_columns/Cargo.toml
@@ -32,7 +32,6 @@ open = { workspace = true }
 poll-promise = { workspace = true }
 puffin = { workspace = true, optional = true }
 puffin_egui = { workspace = true, optional = true }
-reqwest = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/notedeck_columns/src/login_manager.rs
+++ b/crates/notedeck_columns/src/login_manager.rs
@@ -45,7 +45,6 @@ impl<'a> AcquireKeyState {
         }
     }
 
-    /// Whether to indicate to the user that there is a network operation occuring
     pub fn is_awaiting_network(&self) -> bool {
         self.promise_query.is_some()
     }
@@ -98,8 +97,8 @@ mod tests {
     use super::*;
     use std::time::{Duration, Instant};
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_retrieve_key() {
+    #[test]
+    fn test_retrieve_key() {
         let mut manager = AcquireKeyState::new();
         let expected_str = "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681";
         let expected_key = Keypair::only_pubkey(Pubkey::from_hex(expected_str).unwrap());
@@ -141,6 +140,6 @@ mod tests {
             }
         }
 
-        panic!("Test failed to get expected key.");
+        panic!();
     }
 }


### PR DESCRIPTION
revert login manager to just use promises with ehttp instead of reqwest and remove the dependencies from our `Cargo.toml`s