### PR TITLE
nostrdb: update to fix profile queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2420,8 +2420,8 @@ dependencies = [
 
 [[package]]
 name = "nostrdb"
-version = "0.3.4"
-source = "git+https://github.com/damus-io/nostrdb-rs?rev=71154e4100775f6932ee517da4350c433ba14ec7#71154e4100775f6932ee517da4350c433ba14ec7"
+version = "0.4.0"
+source = "git+https://github.com/damus-io/nostrdb-rs?rev=46ca13dffdfe2320d4488912506c7bfa02afe284#46ca13dffdfe2320d4488912506c7bfa02afe284"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ image = { version = "0.25", features = ["jpeg", "png", "webp"] }
 indexmap = "2.6.0"
 log = "0.4.17"
 nostr = { version = "0.37.0", default-features = false, features = ["std", "nip49"] }
-nostrdb = { git = "https://github.com/damus-io/nostrdb-rs", rev = "71154e4100775f6932ee517da4350c433ba14ec7" }
+nostrdb = { git = "https://github.com/damus-io/nostrdb-rs", rev = "46ca13dffdfe2320d4488912506c7bfa02afe284" }
 notedeck = { path = "crates/notedeck" } 
 notedeck_chrome = { path = "crates/notedeck_chrome" } 
 notedeck_columns = { path = "crates/notedeck_columns" } 

--- a/crates/notedeck_columns/src/ui/profile/mod.rs
+++ b/crates/notedeck_columns/src/ui/profile/mod.rs
@@ -1,12 +1,14 @@
 pub mod picture;
 pub mod preview;
 
+use crate::notes_holder::NotesHolder;
 use crate::ui::note::NoteOptions;
 use egui::{ScrollArea, Widget};
 use enostr::Pubkey;
 use nostrdb::{Ndb, Transaction};
 pub use picture::ProfilePic;
 pub use preview::ProfilePreview;
+use tracing::error;
 
 use crate::{actionbar::NoteAction, notes_holder::NotesHolderStorage, profile::Profile};
 
@@ -66,6 +68,11 @@ impl<'a> ProfileView<'a> {
                     .get_ptr();
 
                 profile.timeline.selected_view = tabs_ui(ui);
+
+                // poll for new notes and insert them into our existing notes
+                if let Err(e) = profile.poll_notes_into_view(&txn, self.ndb, is_muted) {
+                    error!("Profile::poll_notes_into_view: {e}");
+                }
 
                 let reversed = false;
 


### PR DESCRIPTION
before profile queries were not working at the database level, because there was no note_pubkey or note_pubkey_kind index. Now there is! So profiles should be much faster to query now, and will actually return results.

See:

- https://github.com/damus-io/nostrdb/pull/57

There still appears to be an issue with the profile NotesHolder which is preventing it from updating, via the logic in poll_notes_into_view. The original Timeline version of this function works fine, but it looks like the NotesHolder one is broken:

- [x] #576 

Going to work on refactoring the notes holder next to fix:

- [x] #377 