### PR TITLE
ignore packages dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ queries/damus-notifs.json
 .git
 cache
 /dist
+/packages
 .direnv/
 src/camera.rs
 scripts/macos_build_secrets.sh


### PR DESCRIPTION
simple PR to ignore the `packages` dir for macos dmg