### PR TITLE
Add t tags for hashtags

### DIFF
--- a/crates/notedeck_columns/src/post.rs
+++ b/crates/notedeck_columns/src/post.rs
@@ -132,7 +132,7 @@ impl NewPost {
         for word in content.split_whitespace() {
             if word.starts_with('#') && word.len() > 1 {
                 let tag = word[1..]
-                    .trim_end_matches(|c: char| !c.is_alphanumeric())
+                    .trim_end_matches(|c: char| c.is_ascii_punctuation())
                     .to_lowercase();
                 if !tag.is_empty() {
                     hashtags.insert(tag);
@@ -155,9 +155,8 @@ mod tests {
             ("No hashtags here", vec![]),
             ("#tag1 with #tag2!", vec!["tag1", "tag2"]),
             ("Ignore # empty", vec![]),
-            ("Keep #alphanumeric123", vec!["alphanumeric123"]),
-            ("Testing emoji #🍌sfd", vec!["🍌sfd"]),
-            ("Testing emoji with space #🍌 sfd", vec!["🍌"]),
+            ("Testing emoji #🍌banana", vec!["🍌banana"]),
+            ("Testing emoji #🍌", vec!["🍌"]),
             ("Duplicate #tag #tag #tag", vec!["tag"]),
             ("Mixed case #TaG #tag #TAG", vec!["tag"]),
             (

--- a/crates/notedeck_columns/src/post.rs
+++ b/crates/notedeck_columns/src/post.rs
@@ -25,16 +25,10 @@ impl NewPost {
             .content(&self.content);
 
         for hashtag in Self::extract_hashtags(&self.content) {
-            builder = builder
-                .start_tag()
-                .tag_str("t")
-                .tag_str(&hashtag);
+            builder = builder.start_tag().tag_str("t").tag_str(&hashtag);
         }
 
-        builder
-            .sign(seckey)
-            .build()
-            .expect("note should be ok")
+        builder.sign(seckey).build().expect("note should be ok")
     }
 
     pub fn to_reply(&self, seckey: &[u8; 32], replying_to: &Note) -> Note {
@@ -115,15 +109,10 @@ impl NewPost {
             enostr::NoteId::new(*quoting.id()).to_bech().unwrap()
         );
 
-        let mut builder = NoteBuilder::new()
-            .kind(1)
-            .content(&new_content);
+        let mut builder = NoteBuilder::new().kind(1).content(&new_content);
 
         for hashtag in Self::extract_hashtags(&self.content) {
-            builder = builder
-                .start_tag()
-                .tag_str("t")
-                .tag_str(&hashtag);
+            builder = builder.start_tag().tag_str("t").tag_str(&hashtag);
         }
 
         builder
@@ -142,7 +131,8 @@ impl NewPost {
         let mut hashtags = HashSet::new();
         for word in content.split_whitespace() {
             if word.starts_with('#') && word.len() > 1 {
-                let tag = word[1..].trim_end_matches(|c: char| !c.is_alphanumeric())
+                let tag = word[1..]
+                    .trim_end_matches(|c: char| !c.is_alphanumeric())
                     .to_lowercase();
                 if !tag.is_empty() {
                     hashtags.insert(tag);
@@ -170,17 +160,16 @@ mod tests {
             ("Testing emoji with space #🍌 sfd", vec!["🍌"]),
             ("Duplicate #tag #tag #tag", vec!["tag"]),
             ("Mixed case #TaG #tag #TAG", vec!["tag"]),
+            (
+                "#tag1, #tag2, #tag3 with commas",
+                vec!["tag1", "tag2", "tag3"],
+            ),
         ];
 
         for (input, expected) in test_cases {
             let result = NewPost::extract_hashtags(input);
             let expected: HashSet<String> = expected.into_iter().map(String::from).collect();
-            assert_eq!(
-                result,
-                expected,
-                "Failed for input: {}",
-                input
-            );
+            assert_eq!(result, expected, "Failed for input: {}", input);
         }
     }
 }

--- a/crates/notedeck_columns/src/post.rs
+++ b/crates/notedeck_columns/src/post.rs
@@ -129,11 +129,11 @@ impl NewPost {
 
     fn extract_hashtags(content: &str) -> HashSet<String> {
         let mut hashtags = HashSet::new();
-        for word in content.split_whitespace() {
+        for word in
+            content.split(|c: char| c.is_whitespace() || (c.is_ascii_punctuation() && c != '#'))
+        {
             if word.starts_with('#') && word.len() > 1 {
-                let tag = word[1..]
-                    .trim_end_matches(|c: char| c.is_ascii_punctuation())
-                    .to_lowercase();
+                let tag = word[1..].to_lowercase();
                 if !tag.is_empty() {
                     hashtags.insert(tag);
                 }
@@ -163,6 +163,9 @@ mod tests {
                 "#tag1, #tag2, #tag3 with commas",
                 vec!["tag1", "tag2", "tag3"],
             ),
+            ("Separated by commas #tag1,#tag2", vec!["tag1", "tag2"]),
+            ("Separated by periods #tag1.#tag2", vec!["tag1", "tag2"]),
+            ("Separated by semicolons #tag1;#tag2", vec!["tag1", "tag2"]),
         ];
 
         for (input, expected) in test_cases {

--- a/crates/notedeck_columns/src/post.rs
+++ b/crates/notedeck_columns/src/post.rs
@@ -138,14 +138,14 @@ impl NewPost {
             .expect("expected build to work")
     }
 
-    fn extract_hashtags(content: &str) -> Vec<String> {
-        let mut hashtags = Vec::new();
+    fn extract_hashtags(content: &str) -> HashSet<String> {
+        let mut hashtags = HashSet::new();
         for word in content.split_whitespace() {
             if word.starts_with('#') && word.len() > 1 {
                 let tag = word[1..].trim_end_matches(|c: char| !c.is_alphanumeric())
-                    .to_string();
+                    .to_lowercase();
                 if !tag.is_empty() {
-                    hashtags.push(tag);
+                    hashtags.insert(tag);
                 }
             }
         }
@@ -166,13 +166,18 @@ mod tests {
             ("#tag1 with #tag2!", vec!["tag1", "tag2"]),
             ("Ignore # empty", vec![]),
             ("Keep #alphanumeric123", vec!["alphanumeric123"]),
+            ("Testing emoji #🍌sfd", vec!["🍌sfd"]),
+            ("Testing emoji with space #🍌 sfd", vec!["🍌"]),
+            ("Duplicate #tag #tag #tag", vec!["tag"]),
+            ("Mixed case #TaG #tag #TAG", vec!["tag"]),
         ];
 
         for (input, expected) in test_cases {
             let result = NewPost::extract_hashtags(input);
+            let expected: HashSet<String> = expected.into_iter().map(String::from).collect();
             assert_eq!(
                 result,
-                expected.into_iter().map(String::from).collect::<Vec<_>>(),
+                expected,
                 "Failed for input: {}",
                 input
             );


### PR DESCRIPTION
`$ cargo test -p notedeck_columns test_extract_hashtags`

```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.25s
     Running unittests src/lib.rs (target/debug/deps/notedeck_columns-dfddfaabc1efa03f)

running 1 test
test post::tests::test_extract_hashtags ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 22 filtered out; finished in 0.00s
```

Also tested manually in Notedeck and it seems to work.

Relates to https://github.com/damus-io/notedeck/issues/286