### PR TITLE
ui: customizable tabs per column view

### DIFF
--- a/crates/notedeck_columns/src/app.rs
+++ b/crates/notedeck_columns/src/app.rs
@@ -57,7 +57,7 @@ pub struct Damus {
     pub textmode: bool,
 }
 
-fn handle_key_events(input: &egui::InputState, _pixels_per_point: f32, columns: &mut Columns) {
+fn handle_key_events(input: &egui::InputState, columns: &mut Columns) {
     for event in &input.raw.events {
         if let egui::Event::Key {
             key, pressed: true, ..
@@ -87,9 +87,8 @@ fn try_process_event(
     app_ctx: &mut AppContext<'_>,
     ctx: &egui::Context,
 ) -> Result<()> {
-    let ppp = ctx.pixels_per_point();
     let current_columns = get_active_columns_mut(app_ctx.accounts, &mut damus.decks_cache);
-    ctx.input(|i| handle_key_events(i, ppp, current_columns));
+    ctx.input(|i| handle_key_events(i, current_columns));
 
     let ctx2 = ctx.clone();
     let wakeup = move || {

--- a/crates/notedeck_columns/src/args.rs
+++ b/crates/notedeck_columns/src/args.rs
@@ -1,6 +1,6 @@
 use notedeck::FilterState;
 
-use crate::timeline::{PubkeySource, Timeline, TimelineKind};
+use crate::timeline::{PubkeySource, Timeline, TimelineKind, TimelineTab};
 use enostr::{Filter, Pubkey};
 use nostrdb::Ndb;
 use tracing::{debug, error, info};
@@ -151,6 +151,7 @@ impl ArgColumn {
             ArgColumn::Generic(filters) => Some(Timeline::new(
                 TimelineKind::Generic,
                 FilterState::ready(filters),
+                TimelineTab::full_tabs(),
             )),
             ArgColumn::Timeline(tk) => tk.into_timeline(ndb, user),
         }

--- a/crates/notedeck_columns/src/profile.rs
+++ b/crates/notedeck_columns/src/profile.rs
@@ -6,7 +6,7 @@ use notedeck::{filter::default_limit, FilterState, MuteFun, NoteCache, NoteRef};
 use crate::{
     multi_subscriber::MultiSubscriber,
     notes_holder::NotesHolder,
-    timeline::{copy_notes_into_timeline, PubkeySource, Timeline, TimelineKind},
+    timeline::{copy_notes_into_timeline, PubkeySource, Timeline, TimelineKind, TimelineTab},
 };
 
 pub enum DisplayName<'a> {
@@ -62,8 +62,11 @@ impl Profile {
         notes: Vec<NoteRef>,
         is_muted: &MuteFun,
     ) -> Self {
-        let mut timeline =
-            Timeline::new(TimelineKind::profile(source), FilterState::ready(filters));
+        let mut timeline = Timeline::new(
+            TimelineKind::profile(source),
+            FilterState::ready(filters),
+            TimelineTab::full_tabs(),
+        );
 
         copy_notes_into_timeline(&mut timeline, txn, ndb, note_cache, notes, is_muted);
 

--- a/crates/notedeck_columns/src/timeline/kind.rs
+++ b/crates/notedeck_columns/src/timeline/kind.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::timeline::Timeline;
+use crate::timeline::{Timeline, TimelineTab};
 use enostr::{Filter, Pubkey};
 use nostrdb::{Ndb, Transaction};
 use notedeck::{filter::default_limit, FilterError, FilterState};
@@ -119,6 +119,7 @@ impl TimelineKind {
                     .kinds([1])
                     .limit(default_limit())
                     .build()]),
+                TimelineTab::no_replies(),
             )),
 
             TimelineKind::Generic => {
@@ -141,6 +142,7 @@ impl TimelineKind {
                 Some(Timeline::new(
                     TimelineKind::profile(pk_src),
                     FilterState::ready(vec![filter]),
+                    TimelineTab::full_tabs(),
                 ))
             }
 
@@ -159,6 +161,7 @@ impl TimelineKind {
                 Some(Timeline::new(
                     TimelineKind::notifications(pk_src),
                     FilterState::ready(vec![notifications_filter]),
+                    TimelineTab::only_notes_and_replies(),
                 ))
             }
 
@@ -181,6 +184,7 @@ impl TimelineKind {
                     return Some(Timeline::new(
                         TimelineKind::contact_list(pk_src),
                         FilterState::needs_remote(vec![contact_filter.clone()]),
+                        TimelineTab::full_tabs(),
                     ));
                 }
 
@@ -189,6 +193,7 @@ impl TimelineKind {
                         Some(Timeline::new(
                             TimelineKind::contact_list(pk_src),
                             FilterState::needs_remote(vec![contact_filter]),
+                            TimelineTab::full_tabs(),
                         ))
                     }
                     Err(e) => {

--- a/crates/notedeck_columns/src/ui/note/mod.rs
+++ b/crates/notedeck_columns/src/ui/note/mod.rs
@@ -4,6 +4,7 @@ pub mod options;
 pub mod post;
 pub mod quote_repost;
 pub mod reply;
+pub mod reply_description;
 
 pub use contents::NoteContents;
 pub use context::{NoteContextButton, NoteContextSelection};
@@ -11,6 +12,7 @@ pub use options::NoteOptions;
 pub use post::{PostAction, PostResponse, PostType, PostView};
 pub use quote_repost::QuoteRepostView;
 pub use reply::PostReplyView;
+pub use reply_description::reply_desc;
 
 use crate::{
     actionbar::NoteAction,
@@ -20,7 +22,7 @@ use crate::{
 use egui::emath::{pos2, Vec2};
 use egui::{Id, Label, Pos2, Rect, Response, RichText, Sense};
 use enostr::{NoteId, Pubkey};
-use nostrdb::{Ndb, Note, NoteKey, NoteReply, Transaction};
+use nostrdb::{Ndb, Note, NoteKey, Transaction};
 use notedeck::{CachedNote, ImageCache, NoteCache, NotedeckTextStyle};
 
 use super::profile::preview::{get_display_name, one_line_display_name_widget};
@@ -64,159 +66,6 @@ impl View for NoteView<'_> {
     fn ui(&mut self, ui: &mut egui::Ui) {
         self.show(ui);
     }
-}
-
-#[must_use = "Please handle the resulting note action"]
-fn reply_desc(
-    ui: &mut egui::Ui,
-    txn: &Transaction,
-    note_reply: &NoteReply,
-    ndb: &Ndb,
-    img_cache: &mut ImageCache,
-    note_cache: &mut NoteCache,
-) -> Option<NoteAction> {
-    #[cfg(feature = "profiling")]
-    puffin::profile_function!();
-
-    let mut note_action: Option<NoteAction> = None;
-    let size = 10.0;
-    let selectable = false;
-    let visuals = ui.visuals();
-    let color = visuals.noninteractive().fg_stroke.color;
-    let link_color = visuals.hyperlink_color;
-
-    // note link renderer helper
-    let note_link = |ui: &mut egui::Ui,
-                     note_cache: &mut NoteCache,
-                     img_cache: &mut ImageCache,
-                     text: &str,
-                     note: &Note<'_>| {
-        let r = ui.add(
-            Label::new(RichText::new(text).size(size).color(link_color))
-                .sense(Sense::click())
-                .selectable(selectable),
-        );
-
-        if r.clicked() {
-            // TODO: jump to note
-        }
-
-        if r.hovered() {
-            r.on_hover_ui_at_pointer(|ui| {
-                ui.set_max_width(400.0);
-                ui::NoteView::new(ndb, note_cache, img_cache, note)
-                    .actionbar(false)
-                    .wide(true)
-                    .show(ui);
-            });
-        }
-    };
-
-    ui.add(Label::new(RichText::new("replying to").size(size).color(color)).selectable(selectable));
-
-    let reply = note_reply.reply()?;
-
-    let reply_note = if let Ok(reply_note) = ndb.get_note_by_id(txn, reply.id) {
-        reply_note
-    } else {
-        ui.add(Label::new(RichText::new("a note").size(size).color(color)).selectable(selectable));
-        return None;
-    };
-
-    if note_reply.is_reply_to_root() {
-        // We're replying to the root, let's show this
-        let action = ui::Mention::new(ndb, img_cache, txn, reply_note.pubkey())
-            .size(size)
-            .selectable(selectable)
-            .show(ui)
-            .inner;
-
-        if action.is_some() {
-            note_action = action;
-        }
-
-        ui.add(Label::new(RichText::new("'s").size(size).color(color)).selectable(selectable));
-
-        note_link(ui, note_cache, img_cache, "thread", &reply_note);
-    } else if let Some(root) = note_reply.root() {
-        // replying to another post in a thread, not the root
-
-        if let Ok(root_note) = ndb.get_note_by_id(txn, root.id) {
-            if root_note.pubkey() == reply_note.pubkey() {
-                // simply "replying to bob's note" when replying to bob in his thread
-                let action = ui::Mention::new(ndb, img_cache, txn, reply_note.pubkey())
-                    .size(size)
-                    .selectable(selectable)
-                    .show(ui)
-                    .inner;
-
-                if action.is_some() {
-                    note_action = action;
-                }
-
-                ui.add(
-                    Label::new(RichText::new("'s").size(size).color(color)).selectable(selectable),
-                );
-
-                note_link(ui, note_cache, img_cache, "note", &reply_note);
-            } else {
-                // replying to bob in alice's thread
-
-                let action = ui::Mention::new(ndb, img_cache, txn, reply_note.pubkey())
-                    .size(size)
-                    .selectable(selectable)
-                    .show(ui)
-                    .inner;
-
-                if action.is_some() {
-                    note_action = action;
-                }
-
-                ui.add(
-                    Label::new(RichText::new("'s").size(size).color(color)).selectable(selectable),
-                );
-
-                note_link(ui, note_cache, img_cache, "note", &reply_note);
-
-                ui.add(
-                    Label::new(RichText::new("in").size(size).color(color)).selectable(selectable),
-                );
-
-                let action = ui::Mention::new(ndb, img_cache, txn, root_note.pubkey())
-                    .size(size)
-                    .selectable(selectable)
-                    .show(ui)
-                    .inner;
-
-                if action.is_some() {
-                    note_action = action;
-                }
-
-                ui.add(
-                    Label::new(RichText::new("'s").size(size).color(color)).selectable(selectable),
-                );
-
-                note_link(ui, note_cache, img_cache, "thread", &root_note);
-            }
-        } else {
-            let action = ui::Mention::new(ndb, img_cache, txn, reply_note.pubkey())
-                .size(size)
-                .selectable(selectable)
-                .show(ui)
-                .inner;
-
-            if action.is_some() {
-                note_action = action;
-            }
-
-            ui.add(
-                Label::new(RichText::new("in someone's thread").size(size).color(color))
-                    .selectable(selectable),
-            );
-        }
-    }
-
-    note_action
 }
 
 impl<'a> NoteView<'a> {

--- a/crates/notedeck_columns/src/ui/note/options.rs
+++ b/crates/notedeck_columns/src/ui/note/options.rs
@@ -24,8 +24,8 @@ impl Default for NoteOptions {
     }
 }
 
-macro_rules! create_setter {
-    ($fn_name:ident, $option:ident) => {
+macro_rules! create_bit_methods {
+    ($fn_name:ident, $has_name:ident, $option:ident) => {
         #[inline]
         pub fn $fn_name(&mut self, enable: bool) {
             if enable {
@@ -34,69 +34,29 @@ macro_rules! create_setter {
                 *self &= !NoteOptions::$option;
             }
         }
+
+        #[inline]
+        pub fn $has_name(self) -> bool {
+            (self & NoteOptions::$option) == NoteOptions::$option
+        }
     };
 }
 
 impl NoteOptions {
-    create_setter!(set_small_pfp, small_pfp);
-    create_setter!(set_medium_pfp, medium_pfp);
-    create_setter!(set_note_previews, note_previews);
-    create_setter!(set_selectable_text, selectable_text);
-    create_setter!(set_textmode, textmode);
-    create_setter!(set_actionbar, actionbar);
-    create_setter!(set_wide, wide);
-    create_setter!(set_options_button, options_button);
-    create_setter!(set_hide_media, hide_media);
+    create_bit_methods!(set_small_pfp, has_small_pfp, small_pfp);
+    create_bit_methods!(set_medium_pfp, has_medium_pfp, medium_pfp);
+    create_bit_methods!(set_note_previews, has_note_previews, note_previews);
+    create_bit_methods!(set_selectable_text, has_selectable_text, selectable_text);
+    create_bit_methods!(set_textmode, has_textmode, textmode);
+    create_bit_methods!(set_actionbar, has_actionbar, actionbar);
+    create_bit_methods!(set_wide, has_wide, wide);
+    create_bit_methods!(set_options_button, has_options_button, options_button);
+    create_bit_methods!(set_hide_media, has_hide_media, hide_media);
 
     pub fn new(is_universe_timeline: bool) -> Self {
         let mut options = NoteOptions::default();
         options.set_hide_media(is_universe_timeline);
         options
-    }
-
-    #[inline]
-    pub fn has_actionbar(self) -> bool {
-        (self & NoteOptions::actionbar) == NoteOptions::actionbar
-    }
-
-    #[inline]
-    pub fn has_hide_media(self) -> bool {
-        (self & NoteOptions::hide_media) == NoteOptions::hide_media
-    }
-
-    #[inline]
-    pub fn has_selectable_text(self) -> bool {
-        (self & NoteOptions::selectable_text) == NoteOptions::selectable_text
-    }
-
-    #[inline]
-    pub fn has_textmode(self) -> bool {
-        (self & NoteOptions::textmode) == NoteOptions::textmode
-    }
-
-    #[inline]
-    pub fn has_note_previews(self) -> bool {
-        (self & NoteOptions::note_previews) == NoteOptions::note_previews
-    }
-
-    #[inline]
-    pub fn has_small_pfp(self) -> bool {
-        (self & NoteOptions::small_pfp) == NoteOptions::small_pfp
-    }
-
-    #[inline]
-    pub fn has_medium_pfp(self) -> bool {
-        (self & NoteOptions::medium_pfp) == NoteOptions::medium_pfp
-    }
-
-    #[inline]
-    pub fn has_wide(self) -> bool {
-        (self & NoteOptions::wide) == NoteOptions::wide
-    }
-
-    #[inline]
-    pub fn has_options_button(self) -> bool {
-        (self & NoteOptions::options_button) == NoteOptions::options_button
     }
 
     pub fn pfp_size(&self) -> f32 {

--- a/crates/notedeck_columns/src/ui/note/reply_description.rs
+++ b/crates/notedeck_columns/src/ui/note/reply_description.rs
@@ -1,0 +1,157 @@
+use crate::{actionbar::NoteAction, ui};
+use egui::{Label, RichText, Sense};
+use nostrdb::{Ndb, Note, NoteReply, Transaction};
+use notedeck::{ImageCache, NoteCache};
+
+#[must_use = "Please handle the resulting note action"]
+pub fn reply_desc(
+    ui: &mut egui::Ui,
+    txn: &Transaction,
+    note_reply: &NoteReply,
+    ndb: &Ndb,
+    img_cache: &mut ImageCache,
+    note_cache: &mut NoteCache,
+) -> Option<NoteAction> {
+    #[cfg(feature = "profiling")]
+    puffin::profile_function!();
+
+    let mut note_action: Option<NoteAction> = None;
+    let size = 10.0;
+    let selectable = false;
+    let visuals = ui.visuals();
+    let color = visuals.noninteractive().fg_stroke.color;
+    let link_color = visuals.hyperlink_color;
+
+    // note link renderer helper
+    let note_link = |ui: &mut egui::Ui,
+                     note_cache: &mut NoteCache,
+                     img_cache: &mut ImageCache,
+                     text: &str,
+                     note: &Note<'_>| {
+        let r = ui.add(
+            Label::new(RichText::new(text).size(size).color(link_color))
+                .sense(Sense::click())
+                .selectable(selectable),
+        );
+
+        if r.clicked() {
+            // TODO: jump to note
+        }
+
+        if r.hovered() {
+            r.on_hover_ui_at_pointer(|ui| {
+                ui.set_max_width(400.0);
+                ui::NoteView::new(ndb, note_cache, img_cache, note)
+                    .actionbar(false)
+                    .wide(true)
+                    .show(ui);
+            });
+        }
+    };
+
+    ui.add(Label::new(RichText::new("replying to").size(size).color(color)).selectable(selectable));
+
+    let reply = note_reply.reply()?;
+
+    let reply_note = if let Ok(reply_note) = ndb.get_note_by_id(txn, reply.id) {
+        reply_note
+    } else {
+        ui.add(Label::new(RichText::new("a note").size(size).color(color)).selectable(selectable));
+        return None;
+    };
+
+    if note_reply.is_reply_to_root() {
+        // We're replying to the root, let's show this
+        let action = ui::Mention::new(ndb, img_cache, txn, reply_note.pubkey())
+            .size(size)
+            .selectable(selectable)
+            .show(ui)
+            .inner;
+
+        if action.is_some() {
+            note_action = action;
+        }
+
+        ui.add(Label::new(RichText::new("'s").size(size).color(color)).selectable(selectable));
+
+        note_link(ui, note_cache, img_cache, "thread", &reply_note);
+    } else if let Some(root) = note_reply.root() {
+        // replying to another post in a thread, not the root
+
+        if let Ok(root_note) = ndb.get_note_by_id(txn, root.id) {
+            if root_note.pubkey() == reply_note.pubkey() {
+                // simply "replying to bob's note" when replying to bob in his thread
+                let action = ui::Mention::new(ndb, img_cache, txn, reply_note.pubkey())
+                    .size(size)
+                    .selectable(selectable)
+                    .show(ui)
+                    .inner;
+
+                if action.is_some() {
+                    note_action = action;
+                }
+
+                ui.add(
+                    Label::new(RichText::new("'s").size(size).color(color)).selectable(selectable),
+                );
+
+                note_link(ui, note_cache, img_cache, "note", &reply_note);
+            } else {
+                // replying to bob in alice's thread
+
+                let action = ui::Mention::new(ndb, img_cache, txn, reply_note.pubkey())
+                    .size(size)
+                    .selectable(selectable)
+                    .show(ui)
+                    .inner;
+
+                if action.is_some() {
+                    note_action = action;
+                }
+
+                ui.add(
+                    Label::new(RichText::new("'s").size(size).color(color)).selectable(selectable),
+                );
+
+                note_link(ui, note_cache, img_cache, "note", &reply_note);
+
+                ui.add(
+                    Label::new(RichText::new("in").size(size).color(color)).selectable(selectable),
+                );
+
+                let action = ui::Mention::new(ndb, img_cache, txn, root_note.pubkey())
+                    .size(size)
+                    .selectable(selectable)
+                    .show(ui)
+                    .inner;
+
+                if action.is_some() {
+                    note_action = action;
+                }
+
+                ui.add(
+                    Label::new(RichText::new("'s").size(size).color(color)).selectable(selectable),
+                );
+
+                note_link(ui, note_cache, img_cache, "thread", &root_note);
+            }
+        } else {
+            let action = ui::Mention::new(ndb, img_cache, txn, reply_note.pubkey())
+                .size(size)
+                .selectable(selectable)
+                .show(ui)
+                .inner;
+
+            if action.is_some() {
+                note_action = action;
+            }
+
+            ui.add(
+                Label::new(RichText::new("in someone's thread").size(size).color(color))
+                    .selectable(selectable),
+            );
+        }
+    }
+
+    note_action
+}

--- a/crates/notedeck_columns/src/ui/profile/mod.rs
+++ b/crates/notedeck_columns/src/ui/profile/mod.rs
@@ -67,7 +67,8 @@ impl<'a> ProfileView<'a> {
                     )
                     .get_ptr();
 
-                profile.timeline.selected_view = tabs_ui(ui);
+                profile.timeline.selected_view =
+                    tabs_ui(ui, profile.timeline.selected_view, &profile.timeline.views);
 
                 // poll for new notes and insert them into our existing notes
                 if let Err(e) = profile.poll_notes_into_view(&txn, self.ndb, is_muted) {

--- a/crates/notedeck_columns/src/ui/timeline.rs
+++ b/crates/notedeck_columns/src/ui/timeline.rs
@@ -1,6 +1,11 @@
 use crate::actionbar::NoteAction;
 use crate::timeline::TimelineTab;
-use crate::{column::Columns, timeline::TimelineId, ui, ui::note::NoteOptions};
+use crate::{
+    column::Columns,
+    timeline::{TimelineId, ViewFilter},
+    ui,
+    ui::note::NoteOptions,
+};
 use egui::containers::scroll_area::ScrollBarVisibility;
 use egui::{Direction, Layout};
 use egui_tabs::TabColor;
@@ -86,7 +91,7 @@ fn timeline_ui(
             return None;
         };
 
-        timeline.selected_view = tabs_ui(ui);
+        timeline.selected_view = tabs_ui(ui, timeline.selected_view, &timeline.views);
 
         // need this for some reason??
         ui.add_space(3.0);
@@ -124,11 +129,11 @@ fn timeline_ui(
         .inner
 }
 
-pub fn tabs_ui(ui: &mut egui::Ui) -> i32 {
+pub fn tabs_ui(ui: &mut egui::Ui, selected: usize, views: &[TimelineTab]) -> usize {
     ui.spacing_mut().item_spacing.y = 0.0;
 
-    let tab_res = egui_tabs::Tabs::new(2)
-        .selected(1)
+    let tab_res = egui_tabs::Tabs::new(views.len() as i32)
+        .selected(selected as i32)
         .hover_bg(TabColor::none())
         .selected_fg(TabColor::none())
         .selected_bg(TabColor::none())
@@ -141,7 +146,10 @@ pub fn tabs_ui(ui: &mut egui::Ui) -> i32 {
 
             let ind = state.index();
 
-            let txt = if ind == 0 { "Notes" } else { "Notes & Replies" };
+            let txt = match views[ind as usize].filter {
+                ViewFilter::Notes => "Notes",
+                ViewFilter::NotesAndReplies => "Notes & Replies",
+            };
 
             let res = ui.add(egui::Label::new(txt).selectable(false));
 
@@ -189,7 +197,7 @@ pub fn tabs_ui(ui: &mut egui::Ui) -> i32 {
 
     ui.painter().hline(underline, underline_y, stroke);
 
-    sel
+    sel as usize
 }
 
 fn get_label_width(ui: &mut egui::Ui, text: &str) -> f32 {

--- a/crates/notedeck_columns/src/unknowns.rs
+++ b/crates/notedeck_columns/src/unknowns.rs
@@ -1,4 +1,4 @@
-use crate::{column::Columns, timeline::ViewFilter, Result};
+use crate::{column::Columns, Result};
 use nostrdb::{Ndb, NoteKey, Transaction};
 use notedeck::{CachedNote, NoteCache, UnknownIds};
 use tracing::error;
@@ -37,7 +37,7 @@ pub fn get_unknown_ids(
     let mut new_cached_notes: Vec<(NoteKey, CachedNote)> = vec![];
 
     for timeline in columns.timelines() {
-        for noteref in timeline.notes(ViewFilter::NotesAndReplies) {
+        for noteref in timeline.all_or_any_notes() {
             let note = ndb.get_note_by_key(txn, noteref.key)?;
             let note_key = note.key().unwrap();
             let cached_note = note_cache.cached_note(noteref.key);


### PR DESCRIPTION

```
ui: customizable tabs per column view

This reduces the number of choices the user needs to make. Some of these
filters were redundant anyways. This also saves memory.

Universe: Notes
Notificaitons: Notes & Replies
Everything else: Notes, Notes & Replies

Changelog-Changed: Simplified tab selections on some columns
```

Fixes:

- https://github.com/damus-io/notedeck/issues/517


![](https://cdn.jb55.com/s/389b5677a549466a.png)
