### PR TITLE
Mute threads by altering rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,6 +1050,7 @@ checksum = "53eafabcce0cb2325a59a98736efe0bf060585b437763f8c476957fb274bb974"
 dependencies = [
  "accesskit",
  "ahash",
+ "backtrace",
  "emath",
  "epaint",
  "log",

--- a/crates/notedeck_chrome/Cargo.toml
+++ b/crates/notedeck_chrome/Cargo.toml
@@ -42,6 +42,8 @@ path = "src/preview.rs"
 [features]
 default = []
 profiling = ["notedeck_columns/puffin", "puffin", "puffin_egui"]
+debug-widget-callstack = ["egui/callstack"]
+debug-interactive-widgets = []
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = "0.11.1"

--- a/crates/notedeck_chrome/src/theme.rs
+++ b/crates/notedeck_chrome/src/theme.rs
@@ -124,9 +124,26 @@ pub fn add_custom_style(is_mobile: bool, style: &mut Style) {
         ..Interaction::default()
     };
 
-    #[cfg(debug_assertions)]
+    // debug: show callstack for the current widget on hover if all
+    // modifier keys are pressed down.
+    #[cfg(feature = "debug-widget-callstack")]
     {
-        style.debug.show_interactive_widgets = true;
+        #[cfg(not(debug_assertions))]
+        compile_error!(
+            "The `debug-widget-callstack` feature requires a debug build, \
+             release builds are unsupported."
+        );
         style.debug.debug_on_hover_with_all_modifiers = true;
+    }
+
+    // debug: show an overlay on all interactive widgets
+    #[cfg(feature = "debug-interactive-widgets")]
+    {
+        #[cfg(not(debug_assertions))]
+        compile_error!(
+            "The `debug-interactive-widgets` feature requires a debug build, \
+             release builds are unsupported."
+        );
+        style.debug.show_interactive_widgets = true;
     }
 }

--- a/crates/notedeck_columns/src/app.rs
+++ b/crates/notedeck_columns/src/app.rs
@@ -138,7 +138,6 @@ fn try_process_event(
                 app_ctx.pool,
                 app_ctx.note_cache,
                 timeline,
-                &app_ctx.accounts.mutefun(),
                 app_ctx
                     .accounts
                     .get_selected_account()
@@ -157,7 +156,6 @@ fn try_process_event(
                 &txn,
                 app_ctx.unknown_ids,
                 app_ctx.note_cache,
-                &app_ctx.accounts.mutefun(),
             ) {
                 error!("poll_notes_into_view: {err}");
             }
@@ -198,7 +196,6 @@ fn update_damus(damus: &mut Damus, app_ctx: &mut AppContext<'_>, ctx: &egui::Con
                 app_ctx.ndb,
                 app_ctx.note_cache,
                 &mut damus.decks_cache,
-                &app_ctx.accounts.mutefun(),
             ) {
                 warn!("update_damus init: {err}");
             }

--- a/crates/notedeck_columns/src/multi_subscriber.rs
+++ b/crates/notedeck_columns/src/multi_subscriber.rs
@@ -4,7 +4,7 @@ use tracing::{debug, error, info};
 use uuid::Uuid;
 
 use crate::Error;
-use notedeck::{MuteFun, NoteRef, UnifiedSubscription};
+use notedeck::{NoteRef, UnifiedSubscription};
 
 pub struct MultiSubscriber {
     filters: Vec<Filter>,
@@ -106,12 +106,7 @@ impl MultiSubscriber {
         }
     }
 
-    pub fn poll_for_notes(
-        &mut self,
-        ndb: &Ndb,
-        txn: &Transaction,
-        is_muted: &MuteFun,
-    ) -> Result<Vec<NoteRef>, Error> {
+    pub fn poll_for_notes(&mut self, ndb: &Ndb, txn: &Transaction) -> Result<Vec<NoteRef>, Error> {
         let sub = self.sub.as_ref().ok_or(notedeck::Error::no_active_sub())?;
         let new_note_keys = ndb.poll_for_notes(sub.local, 500);
 
@@ -128,10 +123,6 @@ impl MultiSubscriber {
             } else {
                 continue;
             };
-
-            if is_muted(&note) {
-                continue;
-            }
 
             notes.push(note);
         }

--- a/crates/notedeck_columns/src/nav.rs
+++ b/crates/notedeck_columns/src/nav.rs
@@ -161,7 +161,6 @@ impl RenderNavResponse {
                         ctx.note_cache,
                         ctx.pool,
                         &txn,
-                        &ctx.accounts.mutefun(),
                     );
                 }
 
@@ -196,7 +195,6 @@ impl RenderNavResponse {
                             &mut app.threads,
                             ctx.pool,
                             root_id,
-                            &ctx.accounts.mutefun(),
                         );
                     }
 
@@ -208,7 +206,6 @@ impl RenderNavResponse {
                             &mut app.profiles,
                             ctx.pool,
                             pubkey.bytes(),
-                            &ctx.accounts.mutefun(),
                         );
                     }
 

--- a/crates/notedeck_columns/src/profile.rs
+++ b/crates/notedeck_columns/src/profile.rs
@@ -1,7 +1,7 @@
 use enostr::{Filter, Pubkey};
 use nostrdb::{FilterBuilder, Ndb, ProfileRecord, Transaction};
 
-use notedeck::{filter::default_limit, FilterState, MuteFun, NoteCache, NoteRef};
+use notedeck::{filter::default_limit, FilterState, NoteCache, NoteRef};
 
 use crate::{
     multi_subscriber::MultiSubscriber,
@@ -60,7 +60,6 @@ impl Profile {
         source: PubkeySource,
         filters: Vec<Filter>,
         notes: Vec<NoteRef>,
-        is_muted: &MuteFun,
     ) -> Self {
         let mut timeline = Timeline::new(
             TimelineKind::profile(source),
@@ -68,7 +67,7 @@ impl Profile {
             TimelineTab::full_tabs(),
         );
 
-        copy_notes_into_timeline(&mut timeline, txn, ndb, note_cache, notes, is_muted);
+        copy_notes_into_timeline(&mut timeline, txn, ndb, note_cache, notes);
 
         Profile {
             timeline,
@@ -114,7 +113,6 @@ impl NotesHolder for Profile {
         id: &[u8; 32],
         filters: Vec<Filter>,
         notes: Vec<NoteRef>,
-        is_muted: &MuteFun,
     ) -> Self {
         Profile::new(
             txn,
@@ -123,7 +121,6 @@ impl NotesHolder for Profile {
             PubkeySource::Explicit(Pubkey::new(*id)),
             filters,
             notes,
-            is_muted,
         )
     }
 

--- a/crates/notedeck_columns/src/thread.rs
+++ b/crates/notedeck_columns/src/thread.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 use nostrdb::{Filter, FilterBuilder, Ndb, Transaction};
-use notedeck::{MuteFun, NoteCache, NoteRef};
+use notedeck::{NoteCache, NoteRef};
 
 #[derive(Default)]
 pub struct Thread {
@@ -74,7 +74,6 @@ impl NotesHolder for Thread {
         _: &[u8; 32],
         _: Vec<Filter>,
         notes: Vec<NoteRef>,
-        _: &MuteFun,
     ) -> Self {
         Thread::new(notes)
     }

--- a/crates/notedeck_columns/src/timeline/route.rs
+++ b/crates/notedeck_columns/src/timeline/route.rs
@@ -64,7 +64,7 @@ pub fn render_timeline_route(
                 img_cache,
                 note_options,
             )
-            .ui(ui);
+            .ui(ui, &accounts.mutefun());
 
             note_action.map(RenderNavAction::NoteAction)
         }

--- a/crates/notedeck_columns/src/ui/add_column.rs
+++ b/crates/notedeck_columns/src/ui/add_column.rs
@@ -503,7 +503,6 @@ pub fn render_add_column_routes(
                     ctx.pool,
                     ctx.note_cache,
                     app.since_optimize,
-                    &ctx.accounts.mutefun(),
                     ctx.accounts
                         .get_selected_account()
                         .as_ref()

--- a/crates/notedeck_columns/src/ui/profile/mod.rs
+++ b/crates/notedeck_columns/src/ui/profile/mod.rs
@@ -58,20 +58,14 @@ impl<'a> ProfileView<'a> {
                 }
                 let profile = self
                     .profiles
-                    .notes_holder_mutated(
-                        self.ndb,
-                        self.note_cache,
-                        &txn,
-                        self.pubkey.bytes(),
-                        is_muted,
-                    )
+                    .notes_holder_mutated(self.ndb, self.note_cache, &txn, self.pubkey.bytes())
                     .get_ptr();
 
                 profile.timeline.selected_view =
                     tabs_ui(ui, profile.timeline.selected_view, &profile.timeline.views);
 
                 // poll for new notes and insert them into our existing notes
-                if let Err(e) = profile.poll_notes_into_view(&txn, self.ndb, is_muted) {
+                if let Err(e) = profile.poll_notes_into_view(&txn, self.ndb) {
                     error!("Profile::poll_notes_into_view: {e}");
                 }
 
@@ -86,7 +80,7 @@ impl<'a> ProfileView<'a> {
                     self.note_cache,
                     self.img_cache,
                 )
-                .show(ui)
+                .show(ui, is_muted)
             })
             .inner
     }

--- a/crates/notedeck_columns/src/ui/thread.rs
+++ b/crates/notedeck_columns/src/ui/thread.rs
@@ -93,13 +93,13 @@ impl<'a> ThreadView<'a> {
 
                 let thread = self
                     .threads
-                    .notes_holder_mutated(self.ndb, self.note_cache, &txn, root_id, is_muted)
+                    .notes_holder_mutated(self.ndb, self.note_cache, &txn, root_id)
                     .get_ptr();
 
                 // TODO(jb55): skip poll if ThreadResult is fresh?
 
                 // poll for new notes and insert them into our existing notes
-                match thread.poll_notes_into_view(&txn, self.ndb, is_muted) {
+                match thread.poll_notes_into_view(&txn, self.ndb) {
                     Ok(action) => {
                         action.process_action(&txn, self.ndb, self.unknown_ids, self.note_cache)
                     }
@@ -120,7 +120,7 @@ impl<'a> ThreadView<'a> {
                     self.note_cache,
                     self.img_cache,
                 )
-                .show(ui)
+                .show(ui, is_muted)
             })
             .inner
     }


### PR DESCRIPTION
Previous approach was to keep muted content from getting inserted.
    
Instead, this version alters it's display.  This makes toggling mutes on and off externally much more stable (the display changes but we don't have to rebuild content trees)

For now muted content is collapsed to a red "Muted" tombstone.

This PR replaces #604 
