### PR TITLE
Last note per pubkey algo feed

### DIFF
--- a/crates/notedeck/src/filter.rs
+++ b/crates/notedeck/src/filter.rs
@@ -190,6 +190,60 @@ impl FilteredTags {
     }
 }
 
+/// Create a "last N notes per pubkey" query.
+pub fn last_n_per_pubkey_from_tags(
+    note: &Note,
+    kind: u64,
+    notes_per_pubkey: u64,
+) -> Result<Vec<Filter>> {
+    let mut filters: Vec<Filter> = vec![];
+
+    for tag in note.tags() {
+        // TODO: fix arbitrary MAX_FILTER limit in nostrdb
+        if filters.len() == 15 {
+            break;
+        }
+
+        if tag.count() < 2 {
+            continue;
+        }
+
+        let t = if let Some(t) = tag.get_unchecked(0).variant().str() {
+            t
+        } else {
+            continue;
+        };
+
+        if t == "p" {
+            let author = if let Some(author) = tag.get_unchecked(1).variant().id() {
+                author
+            } else {
+                continue;
+            };
+
+            let mut filter = Filter::new();
+            filter.start_authors_field()?;
+            filter.add_id_element(author)?;
+            filter.end_field();
+            filters.push(filter.kinds([kind]).limit(notes_per_pubkey).build());
+        } else if t == "t" {
+            let hashtag = if let Some(hashtag) = tag.get_unchecked(1).variant().str() {
+                hashtag
+            } else {
+                continue;
+            };
+
+            let mut filter = Filter::new();
+            filter.start_tags_field('t')?;
+            filter.add_str_element(hashtag)?;
+            filter.end_field();
+            filters.push(filter.kinds([kind]).limit(notes_per_pubkey).build());
+        }
+    }
+
+    Ok(filters)
+}
+
 /// Create a filter from tags. This can be used to create a filter
 /// from a contact list
 pub fn filter_from_tags(note: &Note, add_pubkey: Option<&[u8; 32]>) -> Result<FilteredTags> {

--- a/crates/notedeck_columns/src/route.rs
+++ b/crates/notedeck_columns/src/route.rs
@@ -5,7 +5,7 @@ use crate::{
     accounts::AccountsRoute,
     column::Columns,
     timeline::{kind::ColumnTitle, TimelineId, TimelineRoute},
-    ui::add_column::AddColumnRoute,
+    ui::add_column::{AddAlgoRoute, AddColumnRoute},
 };
 
 /// App routing. These describe different places you can go inside Notedeck.
@@ -88,6 +88,10 @@ impl Route {
             Route::ComposeNote => ColumnTitle::simple("Compose Note"),
             Route::AddColumn(c) => match c {
                 AddColumnRoute::Base => ColumnTitle::simple("Add Column"),
+                AddColumnRoute::Algo(r) => match r {
+                    AddAlgoRoute::Base => ColumnTitle::simple("Add Algo Column"),
+                    AddAlgoRoute::LastPerPubkey => ColumnTitle::simple("Add Last Notes Column"),
+                },
                 AddColumnRoute::UndecidedNotification => {
                     ColumnTitle::simple("Add Notifications Column")
                 }

--- a/crates/notedeck_columns/src/storage/mod.rs
+++ b/crates/notedeck_columns/src/storage/mod.rs
@@ -1,5 +1,8 @@
 mod decks;
 mod migration;
+mod token_parser;
 
 pub use decks::{load_decks_cache, save_decks_cache, DECKS_CACHE_FILE};
 pub use migration::{deserialize_columns, COLUMNS_FILE};
+
+pub use token_parser::{ParseError, TokenParser, TokenSerializable};

--- a/crates/notedeck_columns/src/storage/mod.rs
+++ b/crates/notedeck_columns/src/storage/mod.rs
@@ -5,4 +5,4 @@ mod token_parser;
 pub use decks::{load_decks_cache, save_decks_cache, DECKS_CACHE_FILE};
 pub use migration::{deserialize_columns, COLUMNS_FILE};
 
-pub use token_parser::{ParseError, TokenParser, TokenSerializable};
+pub use token_parser::{ParseError, TokenParser, TokenSerializable, TokenWriter};

--- a/crates/notedeck_columns/src/storage/token_parser.rs
+++ b/crates/notedeck_columns/src/storage/token_parser.rs
@@ -1,0 +1,177 @@
+use crate::timeline::kind::PubkeySource;
+use enostr::Pubkey;
+
+#[derive(Debug, Clone)]
+pub struct UnexpectedToken<'fnd, 'exp> {
+    pub expected: &'exp str,
+    pub found: &'fnd str,
+}
+
+#[derive(Debug, Clone)]
+pub enum ParseError<'a> {
+    /// Not done parsing yet
+    Incomplete,
+
+    /// All parsing options failed
+    AltAllFailed,
+
+    /// There was some issue decoding the data
+    DecodeFailed,
+
+    /// We encountered an unexpected token
+    UnexpectedToken(UnexpectedToken<'a, 'static>),
+
+    /// No more tokens
+    EOF,
+}
+
+#[derive(Clone)]
+pub struct TokenParser<'a> {
+    tokens: &'a [&'a str],
+    index: usize,
+}
+
+fn _parse_pubkey_src_tokens<'a>(
+    parser: &mut TokenParser<'a>,
+) -> Result<PubkeySource, ParseError<'a>> {
+    match parser.pull_token() {
+        // we handle bare payloads and assume they are explicit pubkey sources
+        Ok("explicit") => {
+            let hex_str = parser.pull_token()?;
+            Pubkey::from_hex(hex_str)
+                .map_err(|_| ParseError::DecodeFailed)
+                .map(PubkeySource::Explicit)
+        }
+
+        Err(ParseError::EOF) | Ok("deck_author") => Ok(PubkeySource::DeckAuthor),
+
+        Ok(hex_payload) => Pubkey::from_hex(hex_payload)
+            .map_err(|_| ParseError::DecodeFailed)
+            .map(PubkeySource::Explicit),
+
+        Err(e) => Err(e),
+    }
+}
+
+impl<'a> TokenParser<'a> {
+    /// alt tries each parser in `routes` until one succeeds.
+    /// If all fail, returns `ParseError::AltAllFailed`.
+    #[allow(clippy::type_complexity)]
+    pub fn alt<R>(
+        parser: &mut TokenParser<'a>,
+        routes: &[fn(&mut TokenParser<'a>) -> Result<R, ParseError<'a>>],
+    ) -> Result<R, ParseError<'a>> {
+        let start = parser.index;
+        for route in routes {
+            match route(parser) {
+                Ok(r) => return Ok(r), // if success, stop trying more routes
+                Err(_) => {
+                    // revert index & try next route
+                    parser.index = start;
+                }
+            }
+        }
+        // if we tried them all and none succeeded
+        Err(ParseError::AltAllFailed)
+    }
+
+    pub fn new(tokens: &'a [&'a str]) -> Self {
+        let index = 0;
+        Self { tokens, index }
+    }
+
+    pub fn parse_token(&mut self, expected: &'static str) -> Result<&'a str, ParseError<'a>> {
+        let found = self.pull_token()?;
+        if found == expected {
+            Ok(found)
+        } else {
+            Err(ParseError::UnexpectedToken(UnexpectedToken {
+                expected,
+                found,
+            }))
+        }
+    }
+
+    /// “Parse all” meaning: run the provided closure. If it fails, revert
+    /// the index.
+    pub fn parse_all<R>(
+        &mut self,
+        parse_fn: impl FnOnce(&mut Self) -> Result<R, ParseError<'a>>,
+    ) -> Result<R, ParseError<'a>> {
+        let start = self.index;
+        let result = parse_fn(self);
+
+        // If the parser closure fails, revert the index
+        if result.is_err() {
+            self.index = start;
+            result
+        } else if !self.is_eof() {
+            Err(ParseError::Incomplete)
+        } else {
+            result
+        }
+    }
+
+    pub fn pull_token(&mut self) -> Result<&'a str, ParseError<'a>> {
+        let token = self
+            .tokens
+            .get(self.index)
+            .copied()
+            .ok_or(ParseError::EOF)?;
+        self.index += 1;
+        Ok(token)
+    }
+
+    pub fn unpop_token(&mut self) {
+        if (self.index as isize) - 1 < 0 {
+            return;
+        }
+
+        self.index -= 1;
+    }
+
+    #[inline]
+    pub fn tokens(&self) -> &'a [&'a str] {
+        let min_index = self.index.min(self.tokens.len());
+        &self.tokens[min_index..]
+    }
+
+    #[inline]
+    pub fn is_eof(&self) -> bool {
+        self.tokens().is_empty()
+    }
+}
+
+pub trait TokenSerializable: Sized {
+    /// Return a list of serialization plans for a type. We do this for
+    /// type safety and assume constructing these types are lightweight
+    fn parse<'a>(parser: &mut TokenParser<'a>) -> Result<Self, ParseError<'a>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_column_serialize() {
+        use crate::ui::add_column::{AddAlgoRoute, AddColumnRoute};
+
+        {
+            let data = &"column:algo_selection:last_per_pubkey"
+                .split(":")
+                .collect::<Vec<&str>>();
+            let mut parser = TokenParser::new(&data);
+            let parsed = AddColumnRoute::parse(&mut parser).unwrap();
+            let expected = AddColumnRoute::Algo(AddAlgoRoute::LastPerPubkey);
+            assert_eq!(expected, parsed)
+        }
+
+        {
+            let data: &[&str] = &["column"];
+            let mut parser = TokenParser::new(data);
+            let parsed = AddColumnRoute::parse(&mut parser).unwrap();
+            let expected = AddColumnRoute::Base;
+            assert_eq!(expected, parsed)
+        }
+    }
+}

--- a/crates/notedeck_columns/src/storage/token_parser.rs
+++ b/crates/notedeck_columns/src/storage/token_parser.rs
@@ -25,6 +25,42 @@ pub enum ParseError<'a> {
     EOF,
 }
 
+pub struct TokenWriter {
+    delim: &'static str,
+    tokens_written: usize,
+    buf: Vec<u8>,
+}
+
+impl Default for TokenWriter {
+    fn default() -> Self {
+        Self::new(":")
+    }
+}
+
+impl TokenWriter {
+    pub fn new(delim: &'static str) -> Self {
+        let buf = vec![];
+        let tokens_written = 0;
+        Self {
+            buf,
+            tokens_written,
+            delim,
+        }
+    }
+
+    pub fn write_token(&mut self, token: &str) {
+        if self.tokens_written > 0 {
+            self.buf.extend_from_slice(self.delim.as_bytes())
+        }
+        self.buf.extend_from_slice(token.as_bytes());
+        self.tokens_written += 1;
+    }
+
+    pub fn buffer(&self) -> &[u8] {
+        &self.buf
+    }
+}
+
 #[derive(Clone)]
 pub struct TokenParser<'a> {
     tokens: &'a [&'a str],
@@ -146,7 +182,7 @@ pub trait TokenSerializable: Sized {
     /// Return a list of serialization plans for a type. We do this for
     /// type safety and assume constructing these types are lightweight
     fn parse<'a>(parser: &mut TokenParser<'a>) -> Result<Self, ParseError<'a>>;
-    fn serialize(&self, write_token: fn(&str) -> Result<(), std::io::Error>) -> Result<(), std::io::Error>;
+    fn serialize(&self, writer: &mut TokenWriter);
 }
 
 #[cfg(test)]

--- a/crates/notedeck_columns/src/storage/token_parser.rs
+++ b/crates/notedeck_columns/src/storage/token_parser.rs
@@ -146,6 +146,7 @@ pub trait TokenSerializable: Sized {
     /// Return a list of serialization plans for a type. We do this for
     /// type safety and assume constructing these types are lightweight
     fn parse<'a>(parser: &mut TokenParser<'a>) -> Result<Self, ParseError<'a>>;
+    fn serialize(&self, write_token: fn(&str) -> Result<(), std::io::Error>) -> Result<(), std::io::Error>;
 }
 
 #[cfg(test)]

--- a/crates/notedeck_columns/src/ui/add_column.rs
+++ b/crates/notedeck_columns/src/ui/add_column.rs
@@ -97,14 +97,14 @@ impl AddColumnRoute {
     /// Route tokens use in both serialization and deserialization
     fn tokens(&self) -> &'static [&'static str] {
         match self {
-            Self::Base => &[],
-            Self::UndecidedNotification => &["notification_selection"],
-            Self::ExternalNotification => &["external_notif_selection"],
-            Self::UndecidedIndividual => &["individual_selection"],
-            Self::ExternalIndividual => &["external_individual_selection"],
-            Self::Hashtag => &["hashtag"],
-            Self::Algo(AddAlgoRoute::Base) => &["algo_selection"],
-            Self::Algo(AddAlgoRoute::LastPerPubkey) => &["algo_selection", "last_per_pubkey"],
+            Self::Base => &["column"],
+            Self::UndecidedNotification => &["column", "notification_selection"],
+            Self::ExternalNotification => &["column", "external_notif_selection"],
+            Self::UndecidedIndividual => &["column", "individual_selection"],
+            Self::ExternalIndividual => &["column", "external_individual_selection"],
+            Self::Hashtag => &["column", "hashtag"],
+            Self::Algo(AddAlgoRoute::Base) => &["column", "algo_selection"],
+            Self::Algo(AddAlgoRoute::LastPerPubkey) => &["column", "algo_selection", "last_per_pubkey"],
             // NOTE!!! When adding to this, update the parser for TokenSerializable below
         }
     }
@@ -118,17 +118,10 @@ impl TokenSerializable for AddColumnRoute {
     }
 
     fn parse<'a>(parser: &mut TokenParser<'a>) -> Result<Self, ParseError<'a>> {
-        // all start with column
-        parser.parse_token("column")?;
-
-        // if we're done then we have the base
-        if parser.is_eof() {
-            return Ok(AddColumnRoute::Base);
-        }
-
         TokenParser::alt(
             parser,
             &[
+                |p| parse_column_route(p, AddColumnRoute::Base),
                 |p| parse_column_route(p, AddColumnRoute::UndecidedNotification),
                 |p| parse_column_route(p, AddColumnRoute::ExternalNotification),
                 |p| parse_column_route(p, AddColumnRoute::UndecidedIndividual),

--- a/crates/notedeck_columns/src/ui/add_column.rs
+++ b/crates/notedeck_columns/src/ui/add_column.rs
@@ -11,7 +11,7 @@ use nostrdb::{Ndb, Transaction};
 use crate::{
     login_manager::AcquireKeyState,
     route::Route,
-    storage::{ParseError, TokenParser, TokenSerializable},
+    storage::{ParseError, TokenParser, TokenSerializable, TokenWriter},
     timeline::{kind::ListKind, PubkeySource, Timeline, TimelineKind},
     ui::anim::ICON_EXPANSION_MULTIPLE,
     Damus,
@@ -111,14 +111,10 @@ impl AddColumnRoute {
 }
 
 impl TokenSerializable for AddColumnRoute {
-    fn serialize(
-        &self,
-        write_token: fn(&str) -> Result<(), std::io::Error>,
-    ) -> Result<(), std::io::Error> {
+    fn serialize(&self, writer: &mut TokenWriter) {
         for token in self.tokens() {
-            write_token(token)?;
+            writer.write_token(token);
         }
-        Ok(())
     }
 
     fn parse<'a>(parser: &mut TokenParser<'a>) -> Result<Self, ParseError<'a>> {


### PR DESCRIPTION
This is damus' first algo feed.

## What's left to do

- [ ] https://github.com/damus-io/nostrdb/issues/67

### Optional

- [ ] Switch over to token parser combinator 

I noticed I was missing many parts of the codebase related to column serialization. In an effort to have a more direct parsing style, I created a new token parser combinator.

## The algo

```
algos: introduce last_n_per_pubkey_from_tags

This function creates filters for the base our first algo in Damus:

Called "last N note per pubkey". I don't have a better name for it.

This function generates a query in the form:

[
  {"authors": ["author_a"], "limit": 1, "kinds": [1]
, {"authors": ["author_b"], "limit": 1, "kinds": [1]
, {"authors": ["author_c"], "limit": 1, "kinds": [1]
, {"authors": ["author_c"], "limit": 1, "kinds": [1]
  ...
]

Due to an unfortunate restriction currently in nostrdb and strfry, we
can only do about 16 to 20 of these at any given time. I have made
this limit configurable in strfry[1]. I just need to do the same in
nostrdb now.

[1] https://github.com/hoytech/strfry/pull/133
```
