### PR TITLE
Note multicasting (p2p nostr)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,12 +1211,14 @@ dependencies = [
  "bech32",
  "ewebsock",
  "hex",
+ "mio",
  "nostr",
  "nostrdb",
  "serde",
  "serde_derive",
  "serde_json",
  "thiserror 2.0.7",
+ "tokio",
  "tracing",
  "url",
 ]
@@ -2352,6 +2354,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "naga"
 version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2508,9 +2522,8 @@ dependencies = [
 
 [[package]]
 name = "nostrdb"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775484658a10d646c5e835fb9132a7528d1bf546a791d1176b052f1be69c04b2"
+version = "0.5.1"
+source = "git+https://github.com/damus-io/nostrdb-rs?rev=2111948b078b24a1659d0bd5d8570f370269c99b#2111948b078b24a1659d0bd5d8570f370269c99b"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,24 +134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
-name = "android_log-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85965b6739a430150bdd138e2374a98af0c3ee0d030b3bb7fc3bddff58d0102e"
-
-[[package]]
-name = "android_logger"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8619b80c242aa7bd638b5c7ddd952addeecb71f69c75e33f1d47b2804f8f883a"
-dependencies = [
- "android_log-sys",
- "env_logger",
- "log",
- "once_cell",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,19 +1238,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "epaint"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,12 +1759,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2030,17 +1993,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2566,7 +2518,6 @@ name = "notedeck_chrome"
 version = "0.2.0"
 dependencies = [
  "android-activity 0.4.3",
- "android_logger",
  "eframe",
  "egui",
  "egui_extras",
@@ -2583,6 +2534,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-appender",
+ "tracing-logcat",
  "tracing-subscriber",
  "winit",
 ]
@@ -2601,7 +2553,6 @@ dependencies = [
  "egui_virtual_list",
  "ehttp 0.2.0",
  "enostr",
- "env_logger",
  "hex",
  "image",
  "indexmap",
@@ -4352,6 +4303,17 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-logcat"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678d561ce3d4b33dfcfb1c6bd13c422aad89be5bf0e66e20d518a5a254345b54"
+dependencies = [
+ "rustix",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,9 @@ image = { version = "0.25", features = ["jpeg", "png", "webp"] }
 indexmap = "2.6.0"
 log = "0.4.17"
 nostr = { version = "0.37.0", default-features = false, features = ["std", "nip49"] }
-#nostrdb = { git = "https://github.com/damus-io/nostrdb-rs", rev = "b1bc794e9e5f2fb27dad0f95b6974ed2b81872d0" }
-nostrdb = "0.5.2"
+mio = { version = "1.0.3", features = ["os-poll", "net"] }
+nostrdb = { git = "https://github.com/damus-io/nostrdb-rs", rev = "2111948b078b24a1659d0bd5d8570f370269c99b" }
+#nostrdb = "0.5.2"
 notedeck = { path = "crates/notedeck" }
 notedeck_chrome = { path = "crates/notedeck_chrome" }
 notedeck_columns = { path = "crates/notedeck_columns" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ egui_tabs = "0.2.0"
 egui_virtual_list = "0.5.0"
 ehttp = "0.2.0"
 enostr = { path = "crates/enostr" } 
-env_logger = "0.10.0"
 ewebsock = { version = "0.2.0", features = ["tls"] }
 hex = "0.4.3"
 image = { version = "0.25", features = ["jpeg", "png", "webp"] }

--- a/crates/enostr/Cargo.toml
+++ b/crates/enostr/Cargo.toml
@@ -17,3 +17,5 @@ hex = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }
+mio = { workspace = true }
+tokio = { workspace = true }

--- a/crates/enostr/src/client/mod.rs
+++ b/crates/enostr/src/client/mod.rs
@@ -1,3 +1,3 @@
 mod message;
 
-pub use message::ClientMessage;
+pub use message::{ClientMessage, EventClientMessage};

--- a/crates/enostr/src/error.rs
+++ b/crates/enostr/src/error.rs
@@ -29,6 +29,9 @@ pub enum Error {
     #[error("json error: {0}")]
     Json(#[from] serde_json::Error),
 
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
     #[error("nostrdb error: {0}")]
     Nostrdb(#[from] nostrdb::Error),
 

--- a/crates/enostr/src/lib.rs
+++ b/crates/enostr/src/lib.rs
@@ -7,7 +7,7 @@ mod profile;
 mod pubkey;
 mod relay;
 
-pub use client::ClientMessage;
+pub use client::{ClientMessage, EventClientMessage};
 pub use error::Error;
 pub use ewebsock;
 pub use filter::Filter;
@@ -17,7 +17,7 @@ pub use note::{Note, NoteId};
 pub use profile::Profile;
 pub use pubkey::Pubkey;
 pub use relay::message::{RelayEvent, RelayMessage};
-pub use relay::pool::{PoolEvent, RelayPool};
+pub use relay::pool::{PoolEvent, PoolRelay, RelayPool};
 pub use relay::{Relay, RelayStatus};
 
 pub type Result<T> = std::result::Result<T, error::Error>;

--- a/crates/enostr/src/relay/mod.rs
+++ b/crates/enostr/src/relay/mod.rs
@@ -1,19 +1,150 @@
-use ewebsock::{Options, WsMessage, WsReceiver, WsSender};
+use ewebsock::{Options, WsEvent, WsMessage, WsReceiver, WsSender};
+use mio::net::UdpSocket;
+use std::io;
+use std::net::IpAddr;
+use std::net::{SocketAddr, SocketAddrV4};
+use std::time::{Duration, Instant};
 
-use crate::{ClientMessage, Result};
-use nostrdb::Filter;
+use crate::{ClientMessage, EventClientMessage, Result};
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use tracing::{debug, error, info};
+use std::net::Ipv4Addr;
+use tracing::{debug, error};
 
 pub mod message;
 pub mod pool;
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum RelayStatus {
     Connected,
     Connecting,
     Disconnected,
+}
+
+pub struct MulticastRelay {
+    last_join: Instant,
+    status: RelayStatus,
+    address: SocketAddrV4,
+    socket: UdpSocket,
+    interface: Ipv4Addr,
+}
+
+impl MulticastRelay {
+    pub fn new(address: SocketAddrV4, socket: UdpSocket, interface: Ipv4Addr) -> Self {
+        let last_join = Instant::now();
+        let status = RelayStatus::Connected;
+        MulticastRelay {
+            status,
+            address,
+            socket,
+            interface,
+            last_join,
+        }
+    }
+
+    /// Multicast seems to fail every 260 seconds. We force a rejoin every 200 seconds or
+    /// so to ensure we are always in the group
+    pub fn rejoin(&mut self) -> Result<()> {
+        self.last_join = Instant::now();
+        self.status = RelayStatus::Disconnected;
+        self.socket
+            .leave_multicast_v4(self.address.ip(), &self.interface)?;
+        self.socket
+            .join_multicast_v4(self.address.ip(), &self.interface)?;
+        self.status = RelayStatus::Connected;
+        Ok(())
+    }
+
+    pub fn should_rejoin(&self) -> bool {
+        (Instant::now() - self.last_join) >= Duration::from_secs(200)
+    }
+
+    pub fn try_recv(&self) -> Option<WsEvent> {
+        let mut buffer = [0u8; 65535];
+        // Read the size header
+        match self.socket.recv_from(&mut buffer) {
+            Ok((size, src)) => {
+                let parsed_size = u32::from_be_bytes(buffer[0..4].try_into().ok()?) as usize;
+                debug!("multicast: read size {} from start of header", size - 4);
+
+                if size != parsed_size + 4 {
+                    error!(
+                        "multicast: partial data received: expected {}, got {}",
+                        parsed_size, size
+                    );
+                    return None;
+                }
+
+                let text = String::from_utf8_lossy(&buffer[4..size]);
+                debug!("multicast: received {} bytes from {}: {}", size, src, &text);
+                Some(WsEvent::Message(WsMessage::Text(text.to_string())))
+            }
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                // No data available, continue
+                None
+            }
+            Err(e) => {
+                error!("multicast: error receiving data: {}", e);
+                None
+            }
+        }
+    }
+
+    pub fn send(&self, msg: &EventClientMessage) -> Result<()> {
+        let json = msg.to_json()?;
+        let len = json.len();
+
+        debug!("writing to multicast relay");
+        let mut buf: Vec<u8> = Vec::with_capacity(4 + len);
+
+        // Write the length of the message as 4 bytes (big-endian)
+        buf.extend_from_slice(&(len as u32).to_be_bytes());
+
+        // Append the JSON message bytes
+        buf.extend_from_slice(json.as_bytes());
+
+        self.socket.send_to(&buf, SocketAddr::V4(self.address))?;
+        Ok(())
+    }
+}
+
+pub fn setup_multicast_relay(
+    wakeup: impl Fn() + Send + Sync + Clone + 'static,
+) -> Result<MulticastRelay> {
+    use mio::{Events, Interest, Poll, Token};
+
+    let port = 9797;
+    let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
+    let multicast_ip = Ipv4Addr::new(239, 19, 88, 1);
+
+    let mut socket = UdpSocket::bind(address)?;
+    let interface = Ipv4Addr::UNSPECIFIED;
+    let multicast_address = SocketAddrV4::new(multicast_ip, port);
+
+    socket.join_multicast_v4(&multicast_ip, &interface)?;
+
+    let mut poll = Poll::new()?;
+    poll.registry().register(
+        &mut socket,
+        Token(0),
+        Interest::READABLE | Interest::WRITABLE,
+    )?;
+
+    // wakeup our render thread when we have new stuff on the socket
+    std::thread::spawn(move || {
+        let mut events = Events::with_capacity(1);
+        loop {
+            if let Err(err) = poll.poll(&mut events, Some(Duration::from_millis(100))) {
+                error!("multicast socket poll error: {err}. ending multicast poller.");
+                return;
+            }
+            wakeup();
+
+            std::thread::yield_now();
+        }
+    });
+
+    Ok(MulticastRelay::new(multicast_address, socket, interface))
 }
 
 pub struct Relay {
@@ -88,13 +219,5 @@ impl Relay {
     pub fn ping(&mut self) {
         let msg = WsMessage::Ping(vec![]);
         self.sender.send(msg);
-    }
-
-    pub fn subscribe(&mut self, subid: String, filters: Vec<Filter>) {
-        info!(
-            "sending '{}' subscription to relay pool: {:?}",
-            subid, filters
-        );
-        self.send(&ClientMessage::req(subid, filters));
     }
 }

--- a/crates/notedeck/src/accounts.rs
+++ b/crates/notedeck/src/accounts.rs
@@ -517,13 +517,18 @@ impl Accounts {
         debug!("desired relays: {:?}", desired_relays);
 
         let add: BTreeSet<String> = desired_relays.difference(&pool.urls()).cloned().collect();
-        let sub: BTreeSet<String> = pool.urls().difference(&desired_relays).cloned().collect();
+        let mut sub: BTreeSet<String> = pool.urls().difference(&desired_relays).cloned().collect();
         if !add.is_empty() {
             debug!("configuring added relays: {:?}", add);
             let _ = pool.add_urls(add, wakeup);
         }
         if !sub.is_empty() {
             debug!("removing unwanted relays: {:?}", sub);
+
+            // certain relays are persistent like the multicast relay,
+            // although we should probably have a way to explicitly
+            // disable it
+            sub.remove("multicast");
             pool.remove_urls(&sub);
         }
 

--- a/crates/notedeck_chrome/Cargo.toml
+++ b/crates/notedeck_chrome/Cargo.toml
@@ -44,7 +44,7 @@ default = []
 profiling = ["notedeck_columns/puffin", "puffin", "puffin_egui"]
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_logger = "0.11.1"
+tracing-logcat = "0.1.0"
 log = { workspace = true }
 android-activity = { version = "0.4", features = [ "native-activity" ] }
 winit = { version = "0.30.5", features = [ "android-native-activity" ] }

--- a/crates/notedeck_chrome/src/app.rs
+++ b/crates/notedeck_chrome/src/app.rs
@@ -10,7 +10,7 @@ use nostrdb::{Config, Ndb, Transaction};
 use std::cell::RefCell;
 use std::path::Path;
 use std::rc::Rc;
-use tracing::info;
+use tracing::{error, info};
 
 /// Our browser app state
 pub struct Notedeck {
@@ -182,7 +182,13 @@ impl Notedeck {
         }
 
         // AccountManager will setup the pool on first update
-        let pool = RelayPool::new();
+        let mut pool = RelayPool::new();
+        {
+            let ctx = ctx.clone();
+            if let Err(err) = pool.add_multicast_relay(move || ctx.request_repaint()) {
+                error!("error setting up multicast relay: {err}");
+            }
+        }
 
         let img_cache = ImageCache::new(imgcache_dir);
         let note_cache = NoteCache::default();

--- a/crates/notedeck_chrome/src/app.rs
+++ b/crates/notedeck_chrome/src/app.rs
@@ -114,10 +114,12 @@ impl Notedeck {
 
         let data_path = parsed_args
             .datapath
+            .clone()
             .unwrap_or(data_path.as_ref().to_str().expect("db path ok").to_string());
         let path = DataPath::new(&data_path);
         let dbpath_str = parsed_args
             .dbpath
+            .clone()
             .unwrap_or_else(|| path.path(DataPathType::Db).to_str().unwrap().to_string());
 
         let _ = std::fs::create_dir_all(&dbpath_str);
@@ -158,7 +160,7 @@ impl Notedeck {
             KeyStorageType::None
         };
 
-        let mut accounts = Accounts::new(keystore, parsed_args.relays);
+        let mut accounts = Accounts::new(keystore, parsed_args.relays.clone());
 
         let num_keys = parsed_args.keys.len();
 
@@ -167,10 +169,10 @@ impl Notedeck {
 
         {
             let txn = Transaction::new(&ndb).expect("txn");
-            for key in parsed_args.keys {
-                info!("adding account: {}", key.pubkey);
+            for key in &parsed_args.keys {
+                info!("adding account: {}", &key.pubkey);
                 accounts
-                    .add_account(key)
+                    .add_account(key.clone())
                     .process_action(&mut unknown_ids, &ndb, &txn);
             }
         }
@@ -186,7 +188,6 @@ impl Notedeck {
         let note_cache = NoteCache::default();
         let unknown_ids = UnknownIds::default();
         let tabs = Tabs::new(None);
-        let parsed_args = Args::parse(args);
         let app_rect_handler = AppSizeHandler::new(&path);
 
         Self {

--- a/crates/notedeck_columns/Cargo.toml
+++ b/crates/notedeck_columns/Cargo.toml
@@ -23,7 +23,6 @@ egui_tabs = { workspace = true }
 egui_virtual_list = { workspace = true }
 ehttp = { workspace = true }
 enostr = { workspace = true } 
-env_logger = { workspace = true }
 hex = { workspace = true }
 image = { workspace = true }
 indexmap = { workspace = true }

--- a/crates/notedeck_columns/src/relay_pool_manager.rs
+++ b/crates/notedeck_columns/src/relay_pool_manager.rs
@@ -9,7 +9,7 @@ pub struct RelayPoolManager<'a> {
 
 pub struct RelayInfo<'a> {
     pub relay_url: &'a str,
-    pub status: &'a RelayStatus,
+    pub status: RelayStatus,
 }
 
 impl<'a> RelayPoolManager<'a> {
@@ -22,8 +22,8 @@ impl<'a> RelayPoolManager<'a> {
             .relays
             .iter()
             .map(|relay| RelayInfo {
-                relay_url: &relay.relay.url,
-                status: &relay.relay.status,
+                relay_url: relay.url(),
+                status: relay.status(),
             })
             .collect()
     }

--- a/crates/notedeck_columns/src/ui/note/post.rs
+++ b/crates/notedeck_columns/src/ui/note/post.rs
@@ -6,7 +6,6 @@ use egui::widgets::text_edit::TextEdit;
 use egui::{Frame, Layout};
 use enostr::{FilledKeypair, FullKeypair, NoteId, RelayPool};
 use nostrdb::{Ndb, Transaction};
-use tracing::info;
 
 use notedeck::{ImageCache, NoteCache};
 
@@ -62,9 +61,7 @@ impl PostAction {
             }
         };
 
-        let raw_msg = format!("[\"EVENT\",{}]", note.json().unwrap());
-        info!("sending {}", raw_msg);
-        pool.send(&enostr::ClientMessage::raw(raw_msg));
+        pool.send(&enostr::ClientMessage::event(note));
         drafts.get_from_post_type(&self.post_type).clear();
 
         Ok(())

--- a/crates/notedeck_columns/src/ui/relay.rs
+++ b/crates/notedeck_columns/src/ui/relay.rs
@@ -104,7 +104,7 @@ impl<'a> RelayView<'a> {
     }
 }
 
-fn get_right_side_width(status: &RelayStatus) -> f32 {
+fn get_right_side_width(status: RelayStatus) -> f32 {
     match status {
         RelayStatus::Connected => 150.0,
         RelayStatus::Connecting => 160.0,
@@ -138,7 +138,7 @@ fn relay_frame(ui: &mut Ui) -> Frame {
         .stroke(ui.style().visuals.noninteractive().bg_stroke)
 }
 
-fn show_connection_status(ui: &mut Ui, status: &RelayStatus) {
+fn show_connection_status(ui: &mut Ui, status: RelayStatus) {
     let fg_color = match status {
         RelayStatus::Connected => ui.visuals().selection.bg_fill,
         RelayStatus::Connecting => ui.visuals().warn_fg_color,
@@ -163,7 +163,7 @@ fn show_connection_status(ui: &mut Ui, status: &RelayStatus) {
     });
 }
 
-fn get_connection_icon(status: &RelayStatus) -> egui::Image<'static> {
+fn get_connection_icon(status: RelayStatus) -> egui::Image<'static> {
     let img_data = match status {
         RelayStatus::Connected => {
             egui::include_image!("../../../../assets/icons/connected_icon_4x.png")


### PR DESCRIPTION
Note multicasting

This is an initial implementation of note multicast, which sends posted
notes to other notedecks on the same network.

This came about after I nerd sniped myself thinking about p2p nostr on
local networks[1]

You can test this exclusively without joining any other relays by
passing -r multicast on the command line.

[1] https://damus.io/note1j50pseqwma38g3aqrsnhvld0m0ysdgppw6fjnvvcj0haeulgswgq80lpca

Signed-off-by: William Casarin <jb55@jb55.com>
