### PR TITLE
image-cache: use sha256 hash of url for key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2505,6 +2505,7 @@ dependencies = [
  "security-framework",
  "serde",
  "serde_json",
+ "sha2",
  "strum",
  "strum_macros",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ url = "2.5.2"
 urlencoding = "2.1.3"
 uuid = { version = "1.10.0", features = ["v4"] }
 security-framework = "2.11.0"
+sha2 = "0.10.8"
 
 [profile.small]
 inherits = 'release'

--- a/crates/notedeck/Cargo.toml
+++ b/crates/notedeck/Cargo.toml
@@ -22,6 +22,7 @@ serde = { workspace = true }
 hex = { workspace = true }
 thiserror = { workspace = true }
 puffin = { workspace = true, optional = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/notedeck/src/imgcache.rs
+++ b/crates/notedeck/src/imgcache.rs
@@ -82,33 +82,37 @@ impl ImageCache {
     /// Migrate from base32 encoded url to sha256 url + sub-dir structure
     pub fn migrate_v0(&self) -> Result<()> {
         for file in std::fs::read_dir(&self.cache_dir)? {
-            if let Ok(file) = file {
-                if !file.path().is_file() {
-                    continue;
-                }
-                let old_filename = file.file_name().to_string_lossy().to_string();
-                let old_url = if let Some(u) =
-                    base32::decode(base32::Alphabet::Crockford, &old_filename)
-                        .and_then(|s| String::from_utf8(s).ok())
-                {
-                    u
-                } else {
-                    warn!("Invalid base32 filename: {}", &old_filename);
-                    continue;
-                };
-                let new_path = self.cache_dir.join(Self::key(&old_url));
-                if let Some(p) = new_path.parent() {
-                    create_dir_all(p)?;
-                }
+            let file = if let Ok(f) = file {
+                f
+            } else {
+                // not sure how this could fail, skip entry
+                continue;
+            };
+            if !file.path().is_file() {
+                continue;
+            }
+            let old_filename = file.file_name().to_string_lossy().to_string();
+            let old_url = if let Some(u) =
+                base32::decode(base32::Alphabet::Crockford, &old_filename)
+                    .and_then(|s| String::from_utf8(s).ok())
+            {
+                u
+            } else {
+                warn!("Invalid base32 filename: {}", &old_filename);
+                continue;
+            };
+            let new_path = self.cache_dir.join(Self::key(&old_url));
+            if let Some(p) = new_path.parent() {
+                create_dir_all(p)?;
+            }
 
-                if let Err(e) = std::fs::rename(file.path(), &new_path) {
-                    warn!(
-                        "Failed to migrate file from {} to {}: {:?}",
-                        file.path().display(),
-                        new_path.display(),
-                        e
-                    );
-                }
+            if let Err(e) = std::fs::rename(file.path(), &new_path) {
+                warn!(
+                    "Failed to migrate file from {} to {}: {:?}",
+                    file.path().display(),
+                    new_path.display(),
+                    e
+                );
             }
         }
         Ok(())

--- a/crates/notedeck_chrome/src/app.rs
+++ b/crates/notedeck_chrome/src/app.rs
@@ -207,6 +207,9 @@ impl Notedeck {
         let tabs = Tabs::new(None);
         let app_rect_handler = AppSizeHandler::new(&path);
 
+        // migrate
+        img_cache.migrate_v0().expect("img-cache migration");
+
         Self {
             ndb,
             img_cache,

--- a/crates/notedeck_chrome/src/app.rs
+++ b/crates/notedeck_chrome/src/app.rs
@@ -208,7 +208,9 @@ impl Notedeck {
         let app_rect_handler = AppSizeHandler::new(&path);
 
         // migrate
-        img_cache.migrate_v0().expect("img-cache migration");
+        if let Err(e) = img_cache.migrate_v0() {
+            error!("error migrating image cache: {e}");
+        }
 
         Self {
             ndb,


### PR DESCRIPTION
closes #630 

Also added sub-dirs to avoid very large file numbers in a single dir which can cause issues down the line.