### PR TITLE
Fix assorted relay problems

### DIFF
--- a/crates/notedeck_columns/src/accounts/mod.rs
+++ b/crates/notedeck_columns/src/accounts/mod.rs
@@ -97,7 +97,7 @@ pub fn process_accounts_view_response(
             router.route_to(Route::add_account());
         }
     }
-
+    accounts.needs_relay_config();
     selection
 }
 

--- a/crates/notedeck_columns/src/relay_pool_manager.rs
+++ b/crates/notedeck_columns/src/relay_pool_manager.rs
@@ -41,6 +41,7 @@ impl<'a> RelayPoolManager<'a> {
         indices.iter().for_each(|index| self.remove_relay(*index));
     }
 
+    // FIXME - this is not ever called?
     pub fn add_relay(&mut self, ctx: &egui::Context, relay_url: String) {
         let _ = self.pool.add_url(relay_url, create_wakeup(ctx));
     }


### PR DESCRIPTION
Includes the following (mostly independent) fixes:
- Use the current selected account only to determine desired relays.  Previously the desired relay list was determined from the union of all accounts.
- Update the relay configuration immediately when the user switches accounts.
- Delete relays from the account (instead of the relay pool directly).  This results in the relay being removed in the pool as well, but is persisted correctly.