### PR TITLE
Explicitly Activate and Deactivate account relay list use

### DIFF
--- a/crates/notedeck/src/app.rs
+++ b/crates/notedeck/src/app.rs
@@ -69,7 +69,7 @@ impl eframe::App for Notedeck {
         puffin::GlobalProfiler::lock().new_frame();
 
         // handle account updates
-        self.accounts.update(&self.ndb, &mut self.pool, ctx);
+        self.accounts.update(&mut self.ndb, &mut self.pool, ctx);
 
         main_panel(&ctx.style(), crate::ui::is_narrow(ctx)).show(ctx, |ui| {
             // render app

--- a/crates/notedeck_chrome/src/notedeck.rs
+++ b/crates/notedeck_chrome/src/notedeck.rs
@@ -194,7 +194,7 @@ mod tests {
             .timeline_id()
             .unwrap();
 
-        let timelines = app.timeline_cache.timelines.len() == 2;
+        assert_eq!(app.timeline_cache.timelines.len(), 2);
         assert!(app.timeline_cache.timelines.get(&tl1).is_some());
         assert!(app.timeline_cache.timelines.get(&tl2).is_some());
 

--- a/crates/notedeck_columns/src/timeline/route.rs
+++ b/crates/notedeck_columns/src/timeline/route.rs
@@ -141,7 +141,7 @@ pub fn render_profile_route(
 #[cfg(test)]
 mod tests {
     use enostr::NoteId;
-    use tokenator::{TokenParser, TokenSerializable, TokenWriter};
+    use tokenator::{TokenParser, TokenWriter};
 
     use crate::timeline::{ThreadSelection, TimelineKind};
     use enostr::Pubkey;
@@ -149,8 +149,6 @@ mod tests {
 
     #[test]
     fn test_timeline_route_serialize() {
-        use super::TimelineKind;
-
         let note_id_hex = "1c54e5b0c386425f7e017d9e068ddef8962eb2ce1bb08ed27e24b93411c12e60";
         let note_id = NoteId::from_hex(note_id_hex).unwrap();
         let data_str = format!("thread:{}", note_id_hex);


### PR DESCRIPTION
- ensures only one active at a time
- stops leaking relay list subs
