### PR TITLE
Add UnknownId relay hints to Mention::{Profile,Event}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2728,7 +2728,7 @@ dependencies = [
 [[package]]
 name = "nostrdb"
 version = "0.5.1"
-source = "git+https://github.com/damus-io/nostrdb-rs?rev=2111948b078b24a1659d0bd5d8570f370269c99b#2111948b078b24a1659d0bd5d8570f370269c99b"
+source = "git+https://github.com/damus-io/nostrdb-rs?rev=ad3b345416d17ec75362fbfe82309c8196f5ad4b#ad3b345416d17ec75362fbfe82309c8196f5ad4b"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ indexmap = "2.6.0"
 log = "0.4.17"
 nostr = { version = "0.37.0", default-features = false, features = ["std", "nip49"] }
 mio = { version = "1.0.3", features = ["os-poll", "net"] }
-nostrdb = { git = "https://github.com/damus-io/nostrdb-rs", rev = "2111948b078b24a1659d0bd5d8570f370269c99b" }
+nostrdb = { git = "https://github.com/damus-io/nostrdb-rs", rev = "ad3b345416d17ec75362fbfe82309c8196f5ad4b" }
 #nostrdb = "0.5.2"
 notedeck = { path = "crates/notedeck" }
 notedeck_chrome = { path = "crates/notedeck_chrome" }

--- a/crates/notedeck_chrome/src/notedeck.rs
+++ b/crates/notedeck_chrome/src/notedeck.rs
@@ -194,7 +194,7 @@ mod tests {
             .timeline_id()
             .unwrap();
 
-        let timelines = app.timeline_cache.timelines.len() == 2;
+        assert_eq!(app.timeline_cache.timelines.len(), 2);
         assert!(app.timeline_cache.timelines.get(&tl1).is_some());
         assert!(app.timeline_cache.timelines.get(&tl2).is_some());
 

--- a/crates/notedeck_columns/src/app.rs
+++ b/crates/notedeck_columns/src/app.rs
@@ -25,7 +25,7 @@ use nostrdb::{Ndb, Transaction};
 use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
-use tracing::{error, info, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum DamusState {
@@ -158,10 +158,11 @@ fn try_process_event(
 }
 
 fn unknown_id_send(unknown_ids: &mut UnknownIds, pool: &mut RelayPool) {
+    debug!("unknown_id_send called on: {:?}", &unknown_ids);
     let filter = unknown_ids.filter().expect("filter");
     info!(
         "Getting {} unknown ids from relays",
-        unknown_ids.ids().len()
+        unknown_ids.ids_iter().len()
     );
     let msg = ClientMessage::req("unknownids".to_string(), filter);
     unknown_ids.clear();

--- a/crates/notedeck_columns/src/timeline/route.rs
+++ b/crates/notedeck_columns/src/timeline/route.rs
@@ -141,7 +141,7 @@ pub fn render_profile_route(
 #[cfg(test)]
 mod tests {
     use enostr::NoteId;
-    use tokenator::{TokenParser, TokenSerializable, TokenWriter};
+    use tokenator::{TokenParser, TokenWriter};
 
     use crate::timeline::{ThreadSelection, TimelineKind};
     use enostr::Pubkey;
@@ -149,8 +149,6 @@ mod tests {
 
     #[test]
     fn test_timeline_route_serialize() {
-        use super::TimelineKind;
-
         let note_id_hex = "1c54e5b0c386425f7e017d9e068ddef8962eb2ce1bb08ed27e24b93411c12e60";
         let note_id = NoteId::from_hex(note_id_hex).unwrap();
         let data_str = format!("thread:{}", note_id_hex);

--- a/crates/notedeck_columns/src/unknowns.rs
+++ b/crates/notedeck_columns/src/unknowns.rs
@@ -10,11 +10,11 @@ pub fn update_from_columns(
     ndb: &Ndb,
     note_cache: &mut NoteCache,
 ) -> bool {
-    let before = unknown_ids.ids().len();
+    let before = unknown_ids.ids_iter().len();
     if let Err(e) = get_unknown_ids(txn, unknown_ids, timeline_cache, ndb, note_cache) {
         error!("UnknownIds::update {e}");
     }
-    let after = unknown_ids.ids().len();
+    let after = unknown_ids.ids_iter().len();
 
     if before != after {
         unknown_ids.mark_updated();


### PR DESCRIPTION
I marked this as WIP because it depends on https://github.com/damus-io/nostrdb-rs/pull/37

It also does not use the relay hints in the `unknown_id_send` method yet.  I'm unsure how much we want to package in this PR; it is ready to go if we want to enhance `unknown_id_send` in a follow-on PR.