### PR TITLE
Origin/rename nostr address

### DIFF
--- a/crates/notedeck_columns/src/ui/profile/edit.rs
+++ b/crates/notedeck_columns/src/ui/profile/edit.rs
@@ -116,10 +116,10 @@ impl<'a> EditProfileView<'a> {
                     ui.colored_label(
                         ui.visuals().noninteractive().fg_stroke.color,
                         RichText::new(if use_domain {
-                            format!("\"{}\" will be used for verification", suffix)
+                            format!("\"{}\" will be used for identification", suffix)
                         } else {
                             format!(
-                                "\"{}\" at \"{}\" will be used for verification",
+                                "\"{}\" at \"{}\" will be used for identification",
                                 prefix, suffix
                             )
                         }),

--- a/crates/notedeck_columns/src/ui/profile/edit.rs
+++ b/crates/notedeck_columns/src/ui/profile/edit.rs
@@ -101,7 +101,7 @@ impl<'a> EditProfileView<'a> {
         });
 
         in_frame(ui, |ui| {
-            ui.add(label("NIP-05 verification"));
+            ui.add(label("Nostr address (NIP-05 identity)"));
             ui.add(singleline_textedit(&mut self.state.nip05));
             let split = &mut self.state.nip05.split('@');
             let prefix = split.next();


### PR DESCRIPTION
renamed NIP-05 to Nostr address. renamed verification to identification. this better reflects what NIP-05 does as it's not a true verification in the traditional sense, it's more of an identity. 