### PR TITLE
Url Mime Caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2371,7 +2371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2506,6 +2506,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "mime_guess2"
@@ -2742,6 +2752,7 @@ dependencies = [
  "enostr",
  "hex",
  "image",
+ "mime_guess",
  "nostrdb",
  "poll-promise",
  "puffin 0.19.1 (git+https://github.com/jb55/puffin?rev=70ff86d5503815219b01a009afd3669b7903a057)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,7 +1269,7 @@ checksum = "bf3c1f5cd8dfe2ade470a218696c66cf556fcfd701e7830fa2e9f4428292a2a1"
 dependencies = [
  "ahash",
  "egui",
- "ehttp 0.5.0",
+ "ehttp",
  "enum-map",
  "image",
  "log",
@@ -1324,19 +1324,6 @@ checksum = "8191e9cbf6cc7b111655fc115725505fc09d7698c04c36897950c46d6e69521b"
 dependencies = [
  "egui",
  "web-time 1.1.0",
-]
-
-[[package]]
-name = "ehttp"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b69a6f9168b96c0ae04763bec27a8b06b34343c334dd2703a4ec21f0f5e110"
-dependencies = [
- "js-sys",
- "ureq",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -2809,7 +2796,7 @@ dependencies = [
  "egui_nav",
  "egui_tabs",
  "egui_virtual_list",
- "ehttp 0.2.0",
+ "ehttp",
  "enostr",
  "hex",
  "image",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2747,6 +2747,7 @@ name = "notedeck"
 version = "0.3.1"
 dependencies = [
  "base32",
+ "bincode",
  "dirs",
  "eframe",
  "egui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2738,6 +2738,7 @@ dependencies = [
  "dirs",
  "eframe",
  "egui",
+ "ehttp",
  "enostr",
  "hex",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ uuid = { version = "1.10.0", features = ["v4"] }
 security-framework = "2.11.0"
 sha2 = "0.10.8"
 bincode = "1.3.3"
+mime_guess = "2.0.5"
 
 [patch.crates-io]
 egui = { git = "https://github.com/damus-io/egui", branch = "update_layouter_0.29.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ egui_extras = { version = "0.29.1", features = ["all_loaders"] }
 egui_nav = { git = "https://github.com/damus-io/egui-nav", rev = "ac7d663307b76634757024b438dd4b899790da99" }
 egui_tabs = "0.2.0"
 egui_virtual_list = "0.5.0"
-ehttp = "0.2.0"
+ehttp = "0.5.0"
 enostr = { path = "crates/enostr" } 
 ewebsock = { version = "0.2.0", features = ["tls"] }
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ urlencoding = "2.1.3"
 uuid = { version = "1.10.0", features = ["v4"] }
 security-framework = "2.11.0"
 sha2 = "0.10.8"
+bincode = "1.3.3"
 
 [patch.crates-io]
 egui = { git = "https://github.com/damus-io/egui", branch = "update_layouter_0.29.1" }

--- a/crates/notedeck/Cargo.toml
+++ b/crates/notedeck/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = { workspace = true }
 puffin = { workspace = true, optional = true }
 puffin_egui = { workspace = true, optional = true }
 sha2 = { workspace = true }
+bincode = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/notedeck/Cargo.toml
+++ b/crates/notedeck/Cargo.toml
@@ -26,6 +26,7 @@ puffin = { workspace = true, optional = true }
 puffin_egui = { workspace = true, optional = true }
 sha2 = { workspace = true }
 bincode = { workspace = true }
+ehttp = {workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/notedeck/Cargo.toml
+++ b/crates/notedeck/Cargo.toml
@@ -27,6 +27,7 @@ puffin_egui = { workspace = true, optional = true }
 sha2 = { workspace = true }
 bincode = { workspace = true }
 ehttp = {workspace = true }
+mime_guess = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/notedeck/src/context.rs
+++ b/crates/notedeck/src/context.rs
@@ -1,4 +1,4 @@
-use crate::{Accounts, Args, DataPath, ImageCache, NoteCache, ThemeHandler, UnknownIds};
+use crate::{Accounts, Args, DataPath, ImageCache, NoteCache, ThemeHandler, UnknownIds, UrlMimes};
 
 use enostr::RelayPool;
 use nostrdb::Ndb;
@@ -8,6 +8,7 @@ use nostrdb::Ndb;
 pub struct AppContext<'a> {
     pub ndb: &'a mut Ndb,
     pub img_cache: &'a mut ImageCache,
+    pub urls: &'a mut UrlMimes,
     pub unknown_ids: &'a mut UnknownIds,
     pub pool: &'a mut RelayPool,
     pub note_cache: &'a mut NoteCache,

--- a/crates/notedeck/src/lib.rs
+++ b/crates/notedeck/src/lib.rs
@@ -47,7 +47,7 @@ pub use theme::ColorTheme;
 pub use time::time_ago_since;
 pub use timecache::TimeCached;
 pub use unknowns::{get_unknown_note_ids, NoteRefsUnkIdAction, SingleUnkIdAction, UnknownIds};
-pub use urls::UrlMimes;
+pub use urls::{supported_mime_hosted_at_url, UrlMimes};
 pub use user_account::UserAccount;
 
 // export libs

--- a/crates/notedeck/src/lib.rs
+++ b/crates/notedeck/src/lib.rs
@@ -47,6 +47,7 @@ pub use theme::ColorTheme;
 pub use time::time_ago_since;
 pub use timecache::TimeCached;
 pub use unknowns::{get_unknown_note_ids, NoteRefsUnkIdAction, SingleUnkIdAction, UnknownIds};
+pub use urls::UrlMimes;
 pub use user_account::UserAccount;
 
 // export libs

--- a/crates/notedeck/src/lib.rs
+++ b/crates/notedeck/src/lib.rs
@@ -21,6 +21,7 @@ mod timecache;
 mod timed_serializer;
 pub mod ui;
 mod unknowns;
+mod urls;
 mod user_account;
 
 pub use accounts::{AccountData, Accounts, AccountsAction, AddAccountAction, SwitchAccountAction};

--- a/crates/notedeck/src/lib.rs
+++ b/crates/notedeck/src/lib.rs
@@ -47,7 +47,7 @@ pub use theme::ColorTheme;
 pub use time::time_ago_since;
 pub use timecache::TimeCached;
 pub use unknowns::{get_unknown_note_ids, NoteRefsUnkIdAction, SingleUnkIdAction, UnknownIds};
-pub use urls::{supported_mime_hosted_at_url, UrlMimes};
+pub use urls::{supported_mime_hosted_at_url, SupportedMimeType, UrlMimes};
 pub use user_account::UserAccount;
 
 // export libs

--- a/crates/notedeck/src/urls.rs
+++ b/crates/notedeck/src/urls.rs
@@ -1,0 +1,191 @@
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{Read, Write},
+    path::PathBuf,
+    sync::{Arc, RwLock},
+    time::{Duration, SystemTime},
+};
+
+use egui::TextBuffer;
+use poll_promise::Promise;
+
+use crate::Error;
+
+const FILE_NAME: &str = "urls.bin";
+const SAVE_INTERVAL: Duration = Duration::from_secs(60);
+
+type UrlsToMime = HashMap<String, String>;
+
+/// caches mime type for a URL. saves to disk on interval [`SAVE_INTERVAL`]
+pub struct UrlCache {
+    last_saved: SystemTime,
+    path: PathBuf,
+    cache: Arc<RwLock<UrlsToMime>>,
+    from_disk_promise: Option<Promise<Option<UrlsToMime>>>,
+}
+
+impl UrlCache {
+    pub fn rel_dir() -> &'static str {
+        FILE_NAME
+    }
+
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            last_saved: SystemTime::now(),
+            path: path.clone(),
+            cache: Default::default(),
+            from_disk_promise: Some(read_from_disk(path)),
+        }
+    }
+
+    pub fn get_type(&self, url: &str) -> Option<String> {
+        self.cache.read().ok()?.get(url).cloned()
+    }
+
+    pub fn set_type(&mut self, url: String, mime_type: String) {
+        if let Ok(mut locked_cache) = self.cache.write() {
+            locked_cache.insert(url, mime_type);
+        }
+    }
+
+    pub fn handle_io(&mut self) {
+        if let Some(promise) = &mut self.from_disk_promise {
+            if let Some(maybe_cache) = promise.ready_mut() {
+                if let Some(cache) = maybe_cache.take() {
+                    merge_cache(self.cache.clone(), cache)
+                }
+
+                self.from_disk_promise = None;
+            }
+        }
+
+        if let Ok(cur_duration) = SystemTime::now().duration_since(self.last_saved) {
+            if cur_duration >= SAVE_INTERVAL {
+                save_to_disk(self.path.clone(), self.cache.clone());
+                self.last_saved = SystemTime::now();
+            }
+        }
+    }
+}
+
+fn merge_cache(cur_cache: Arc<RwLock<UrlsToMime>>, from_disk: UrlsToMime) {
+    std::thread::spawn(move || {
+        if let Ok(mut locked_cache) = cur_cache.write() {
+            locked_cache.extend(from_disk);
+        }
+    });
+}
+
+fn read_from_disk(path: PathBuf) -> Promise<Option<UrlsToMime>> {
+    let (sender, promise) = Promise::new();
+
+    std::thread::spawn(move || {
+        let result: Result<UrlsToMime, Error> = (|| {
+            let mut file = File::open(path)?;
+            let mut buffer = Vec::new();
+            file.read_to_end(&mut buffer)?;
+            let data: UrlsToMime =
+                bincode::deserialize(&buffer).map_err(|e| Error::Generic(e.to_string()))?;
+            Ok(data)
+        })();
+
+        match result {
+            Ok(data) => sender.send(Some(data)),
+            Err(e) => {
+                tracing::error!("problem deserializing UrlCache: {e}");
+                sender.send(None)
+            }
+        }
+    });
+
+    promise
+}
+
+fn save_to_disk(path: PathBuf, cache: Arc<RwLock<UrlsToMime>>) {
+    std::thread::spawn(move || {
+        let result: Result<(), Error> = (|| {
+            if let Ok(cache) = cache.read() {
+                let cache = &*cache;
+                let encoded =
+                    bincode::serialize(cache).map_err(|e| Error::Generic(e.to_string()))?;
+                let mut file = File::create(&path)?;
+                file.write_all(&encoded)?;
+                file.sync_all()?;
+                tracing::info!("Saved UrlCache to disk.");
+                Ok(())
+            } else {
+                Err(Error::Generic(
+                    "Could not read UrlCache behind RwLock".to_owned(),
+                ))
+            }
+        })();
+
+        if let Err(e) = result {
+            tracing::error!("Failed to save UrlCache: {}", e);
+        }
+    });
+}
+
+fn ehttp_get_mime_type(url: &str, sender: poll_promise::Sender<String>) {
+    let request = ehttp::Request::head(url);
+
+    let url = url.to_owned();
+    ehttp::fetch(
+        request,
+        move |response: Result<ehttp::Response, String>| match response {
+            Ok(resp) => {
+                if let Some(content_type) = resp.headers.get("content-type") {
+                    sender.send(extract_mime_type(content_type).to_owned());
+                } else {
+                    tracing::error!("Content-Type header not found for {url}");
+                }
+            }
+            Err(err) => {
+                tracing::error!("failed ehttp for UrlCache: {err}");
+            }
+        },
+    );
+}
+
+fn extract_mime_type(content_type: &str) -> &str {
+    content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim()
+}
+
+pub struct UrlMimes {
+    pub cache: UrlCache,
+    in_flight: HashMap<String, Promise<String>>,
+}
+
+impl UrlMimes {
+    pub fn new(url_cache: UrlCache) -> Self {
+        Self {
+            cache: url_cache,
+            in_flight: Default::default(),
+        }
+    }
+
+    pub fn get(&mut self, url: &str) -> Option<String> {
+        if let Some(mime_type) = self.cache.get_type(url) {
+            Some(mime_type)
+        } else if let Some(promise) = self.in_flight.get_mut(url) {
+            if let Some(mime_type) = promise.ready_mut() {
+                let mime_type = mime_type.take();
+                self.cache.set_type(url.to_owned(), mime_type.clone());
+                self.in_flight.remove(url);
+                Some(mime_type)
+            } else {
+                None
+            }
+        } else {
+            let (sender, promise) = Promise::new();
+            ehttp_get_mime_type(url, sender);
+            self.in_flight.insert(url.to_owned(), promise);
+            None
+        }
+    }
+}

--- a/crates/notedeck/src/urls.rs
+++ b/crates/notedeck/src/urls.rs
@@ -191,7 +191,8 @@ impl UrlMimes {
     }
 }
 
-struct SupportedMimeType {
+#[derive(Debug)]
+pub struct SupportedMimeType {
     mime: mime_guess::Mime,
 }
 
@@ -207,7 +208,14 @@ impl SupportedMimeType {
         }
     }
 
-    #[allow(unused)]
+    pub fn from_mime(mime: mime_guess::mime::Mime) -> Result<Self, Error> {
+        if is_mime_supported(&mime) {
+            Ok(Self { mime })
+        } else {
+            Err(Error::Generic("Unsupported mime type".to_owned()))
+        }
+    }
+
     pub fn to_mime(&self) -> &str {
         self.mime.essence_str()
     }

--- a/crates/notedeck/src/urls.rs
+++ b/crates/notedeck/src/urls.rs
@@ -189,3 +189,30 @@ impl UrlMimes {
         }
     }
 }
+
+struct SupportedMimeType {
+    mime: mime_guess::Mime,
+}
+
+impl SupportedMimeType {
+    #[allow(unused)]
+    pub fn from_extension(extension: &str) -> Result<Self, Error> {
+        if let Some(mime) = mime_guess::from_ext(extension)
+            .first()
+            .filter(is_mime_supported)
+        {
+            Ok(Self { mime })
+        } else {
+            Err(Error::Generic("Unsupported mime type".to_owned()))
+        }
+    }
+
+    #[allow(unused)]
+    pub fn to_mime(&self) -> &str {
+        self.mime.essence_str()
+    }
+}
+
+fn is_mime_supported(mime: &mime_guess::Mime) -> bool {
+    mime.type_() == mime_guess::mime::IMAGE
+}

--- a/crates/notedeck_columns/src/accounts/mod.rs
+++ b/crates/notedeck_columns/src/accounts/mod.rs
@@ -3,6 +3,7 @@ use nostrdb::Ndb;
 
 use notedeck::{
     Accounts, AccountsAction, AddAccountAction, ImageCache, SingleUnkIdAction, SwitchAccountAction,
+    UrlMimes,
 };
 
 use crate::app::get_active_columns_mut;
@@ -28,13 +29,14 @@ pub fn render_accounts_route(
     ndb: &Ndb,
     col: usize,
     img_cache: &mut ImageCache,
+    urls: &mut UrlMimes,
     accounts: &mut Accounts,
     decks: &mut DecksCache,
     login_state: &mut AcquireKeyState,
     route: AccountsRoute,
 ) -> AddAccountAction {
     let resp = match route {
-        AccountsRoute::Accounts => AccountsView::new(ndb, accounts, img_cache)
+        AccountsRoute::Accounts => AccountsView::new(ndb, accounts, img_cache, urls)
             .ui(ui)
             .inner
             .map(AccountsRouteResponse::Accounts),

--- a/crates/notedeck_columns/src/app.rs
+++ b/crates/notedeck_columns/src/app.rs
@@ -557,6 +557,7 @@ fn timelines_view(ui: &mut egui::Ui, sizes: Size, app: &mut Damus, ctx: &mut App
                 let side_panel = DesktopSidePanel::new(
                     ctx.ndb,
                     ctx.img_cache,
+                    ctx.urls,
                     ctx.accounts.get_selected_account(),
                     &app.decks_cache,
                 )

--- a/crates/notedeck_columns/src/app.rs
+++ b/crates/notedeck_columns/src/app.rs
@@ -172,6 +172,8 @@ fn unknown_id_send(unknown_ids: &mut UnknownIds, pool: &mut RelayPool) {
 }
 
 fn update_damus(damus: &mut Damus, app_ctx: &mut AppContext<'_>, ctx: &egui::Context) {
+    app_ctx.urls.cache.handle_io();
+
     match damus.state {
         DamusState::Initializing => {
             damus.state = DamusState::Initialized;

--- a/crates/notedeck_columns/src/media_upload.rs
+++ b/crates/notedeck_columns/src/media_upload.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use base64::{prelude::BASE64_URL_SAFE, Engine};
 use ehttp::Request;
 use nostrdb::{Note, NoteBuilder};
+use notedeck::SupportedMimeType;
 use poll_promise::Promise;
 use sha2::{Digest, Sha256};
 use url::Url;
@@ -232,13 +233,13 @@ fn find_nip94_ev_in_json(json: String) -> Result<Nip94Event, Error> {
 pub struct MediaPath {
     full_path: PathBuf,
     file_name: String,
-    media_type: SupportedMediaType,
+    media_type: SupportedMimeType,
 }
 
 impl MediaPath {
     pub fn new(path: PathBuf) -> Result<Self, Error> {
         if let Some(ex) = path.extension().and_then(|f| f.to_str()) {
-            let media_type = SupportedMediaType::from_extension(ex)?;
+            let media_type = SupportedMimeType::from_extension(ex)?;
             let file_name = path
                 .file_name()
                 .and_then(|name| name.to_str())
@@ -255,47 +256,6 @@ impl MediaPath {
                 "{:?} does not have an extension",
                 path
             )))
-        }
-    }
-}
-
-#[derive(Debug)]
-pub enum SupportedMediaType {
-    Png,
-    Jpeg,
-    Webp,
-}
-
-impl SupportedMediaType {
-    pub fn mime_extension(&self) -> &str {
-        match &self {
-            SupportedMediaType::Png => "png",
-            SupportedMediaType::Jpeg => "jpeg",
-            SupportedMediaType::Webp => "webp",
-        }
-    }
-
-    pub fn to_mime(&self) -> String {
-        format!("{}/{}", self.mime_type(), self.mime_extension())
-    }
-
-    fn mime_type(&self) -> String {
-        match &self {
-            SupportedMediaType::Png | SupportedMediaType::Jpeg | SupportedMediaType::Webp => {
-                "image"
-            }
-        }
-        .to_string()
-    }
-
-    fn from_extension(ext: &str) -> Result<Self, Error> {
-        match ext.to_lowercase().as_str() {
-            "jpeg" | "jpg" => Ok(SupportedMediaType::Jpeg),
-            "png" => Ok(SupportedMediaType::Png),
-            "webp" => Ok(SupportedMediaType::Webp),
-            unsupported_type => Err(Error::Generic(format!(
-                "{unsupported_type} is not a valid file type to upload."
-            ))),
         }
     }
 }

--- a/crates/notedeck_columns/src/media_upload.rs
+++ b/crates/notedeck_columns/src/media_upload.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, path::PathBuf};
+use std::path::PathBuf;
 
 use base64::{prelude::BASE64_URL_SAFE, Engine};
 use ehttp::Request;
@@ -104,15 +104,13 @@ fn create_nip96_request(
     body.extend(file_contents);
     body.extend(format!("\r\n--{}--\r\n", boundary).as_bytes());
 
-    let headers = {
-        let mut map = BTreeMap::new();
-        map.insert(
-            "Content-Type".to_owned(),
-            format!("multipart/form-data; boundary={boundary}"),
-        );
-        map.insert("Authorization".to_owned(), format!("Nostr {nip98_base64}"));
-        map
-    };
+    let headers = ehttp::Headers::new(&[
+        (
+            "Content-Type",
+            format!("multipart/form-data; boundary={boundary}").as_str(),
+        ),
+        ("Authorization", format!("Nostr {nip98_base64}").as_str()),
+    ]);
 
     Request {
         method: "POST".to_string(),

--- a/crates/notedeck_columns/src/nav.rs
+++ b/crates/notedeck_columns/src/nav.rs
@@ -247,6 +247,7 @@ fn render_nav_body(
         Route::Timeline(kind) => render_timeline_route(
             ctx.ndb,
             ctx.img_cache,
+            ctx.urls,
             ctx.unknown_ids,
             ctx.note_cache,
             &mut app.timeline_cache,
@@ -263,6 +264,7 @@ fn render_nav_body(
                 ctx.ndb,
                 col,
                 ctx.img_cache,
+                ctx.urls,
                 ctx.accounts,
                 &mut app.decks_cache,
                 &mut app.view_state.login,
@@ -308,6 +310,7 @@ fn render_nav_body(
                         draft,
                         ctx.note_cache,
                         ctx.img_cache,
+                        ctx.urls,
                         &note,
                         inner_rect,
                     )
@@ -342,6 +345,7 @@ fn render_nav_body(
                     poster,
                     ctx.note_cache,
                     ctx.img_cache,
+                    ctx.urls,
                     draft,
                     &note,
                     inner_rect,
@@ -363,6 +367,7 @@ fn render_nav_body(
                 draft,
                 PostType::New,
                 ctx.img_cache,
+                ctx.urls,
                 ctx.note_cache,
                 kp,
                 inner_rect,
@@ -457,7 +462,7 @@ fn render_nav_body(
                             ProfileState::default()
                         }
                     });
-                if EditProfileView::new(state, ctx.img_cache).ui(ui) {
+                if EditProfileView::new(state, ctx.img_cache, ctx.urls).ui(ui) {
                     if let Some(taken_state) =
                         app.view_state.pubkey_to_profile_state.remove(kp.pubkey)
                     {
@@ -506,6 +511,7 @@ pub fn render_nav(
         NavUiType::Title => NavTitle::new(
             ctx.ndb,
             ctx.img_cache,
+            ctx.urls,
             get_active_columns_mut(ctx.accounts, &mut app.decks_cache),
             nav.routes(),
             col,

--- a/crates/notedeck_columns/src/timeline/route.rs
+++ b/crates/notedeck_columns/src/timeline/route.rs
@@ -7,12 +7,13 @@ use crate::{
 
 use enostr::Pubkey;
 use nostrdb::Ndb;
-use notedeck::{Accounts, ImageCache, MuteFun, NoteCache, UnknownIds};
+use notedeck::{Accounts, ImageCache, MuteFun, NoteCache, UnknownIds, UrlMimes};
 
 #[allow(clippy::too_many_arguments)]
 pub fn render_timeline_route(
     ndb: &Ndb,
     img_cache: &mut ImageCache,
+    urls: &mut UrlMimes,
     unknown_ids: &mut UnknownIds,
     note_cache: &mut NoteCache,
     timeline_cache: &mut TimelineCache,
@@ -42,6 +43,7 @@ pub fn render_timeline_route(
                 ndb,
                 note_cache,
                 img_cache,
+                urls,
                 note_options,
                 &accounts.mutefun(),
             )
@@ -58,6 +60,7 @@ pub fn render_timeline_route(
                     ndb,
                     timeline_cache,
                     img_cache,
+                    urls,
                     note_cache,
                     unknown_ids,
                     col,
@@ -72,6 +75,7 @@ pub fn render_timeline_route(
                     ndb,
                     note_cache,
                     img_cache,
+                    urls,
                     note_options,
                     &accounts.mutefun(),
                 )
@@ -87,6 +91,7 @@ pub fn render_timeline_route(
             note_cache,
             unknown_ids,
             img_cache,
+            urls,
             id.selected_or_root(),
             textmode,
             &accounts.mutefun(),
@@ -104,6 +109,7 @@ pub fn render_profile_route(
     ndb: &Ndb,
     timeline_cache: &mut TimelineCache,
     img_cache: &mut ImageCache,
+    urls: &mut UrlMimes,
     note_cache: &mut NoteCache,
     unknown_ids: &mut UnknownIds,
     col: usize,
@@ -118,6 +124,7 @@ pub fn render_profile_route(
         ndb,
         note_cache,
         img_cache,
+        urls,
         unknown_ids,
         is_muted,
         NoteOptions::default(),

--- a/crates/notedeck_columns/src/ui/accounts.rs
+++ b/crates/notedeck_columns/src/ui/accounts.rs
@@ -3,7 +3,7 @@ use egui::{
     Align, Button, Frame, Image, InnerResponse, Layout, RichText, ScrollArea, Ui, UiBuilder, Vec2,
 };
 use nostrdb::{Ndb, Transaction};
-use notedeck::{Accounts, ImageCache};
+use notedeck::{Accounts, ImageCache, UrlMimes};
 
 use super::profile::preview::SimpleProfilePreview;
 
@@ -11,6 +11,7 @@ pub struct AccountsView<'a> {
     ndb: &'a Ndb,
     accounts: &'a Accounts,
     img_cache: &'a mut ImageCache,
+    urls: &'a mut UrlMimes,
 }
 
 #[derive(Clone, Debug)]
@@ -27,11 +28,17 @@ enum ProfilePreviewAction {
 }
 
 impl<'a> AccountsView<'a> {
-    pub fn new(ndb: &'a Ndb, accounts: &'a Accounts, img_cache: &'a mut ImageCache) -> Self {
+    pub fn new(
+        ndb: &'a Ndb,
+        accounts: &'a Accounts,
+        img_cache: &'a mut ImageCache,
+        urls: &'a mut UrlMimes,
+    ) -> Self {
         AccountsView {
             ndb,
             accounts,
             img_cache,
+            urls,
         }
     }
 
@@ -44,7 +51,7 @@ impl<'a> AccountsView<'a> {
             ui.add_space(8.0);
             scroll_area()
                 .show(ui, |ui| {
-                    Self::show_accounts(ui, self.accounts, self.ndb, self.img_cache)
+                    Self::show_accounts(ui, self.accounts, self.ndb, self.img_cache, self.urls)
                 })
                 .inner
         })
@@ -55,6 +62,7 @@ impl<'a> AccountsView<'a> {
         accounts: &Accounts,
         ndb: &Ndb,
         img_cache: &mut ImageCache,
+        urls: &mut UrlMimes,
     ) -> Option<AccountsViewResponse> {
         let mut return_op: Option<AccountsViewResponse> = None;
         ui.allocate_ui_with_layout(
@@ -85,8 +93,12 @@ impl<'a> AccountsView<'a> {
                         let max_size = egui::vec2(ui.available_width(), 77.0);
                         let resp = ui.allocate_response(max_size, egui::Sense::click());
                         ui.allocate_new_ui(UiBuilder::new().max_rect(resp.rect), |ui| {
-                            let preview =
-                                SimpleProfilePreview::new(profile.as_ref(), img_cache, has_nsec);
+                            let preview = SimpleProfilePreview::new(
+                                profile.as_ref(),
+                                img_cache,
+                                urls,
+                                has_nsec,
+                            );
                             show_profile_card(ui, preview, max_size, is_selected, resp)
                         })
                         .inner

--- a/crates/notedeck_columns/src/ui/add_column.rs
+++ b/crates/notedeck_columns/src/ui/add_column.rs
@@ -17,7 +17,7 @@ use crate::{
     Damus,
 };
 
-use notedeck::{AppContext, ImageCache, NotedeckTextStyle, UserAccount};
+use notedeck::{AppContext, ImageCache, NotedeckTextStyle, UrlMimes, UserAccount};
 use tokenator::{ParseError, TokenParser, TokenSerializable, TokenWriter};
 
 use super::{anim::AnimationHelper, padding, ProfilePreview};
@@ -164,6 +164,7 @@ pub struct AddColumnView<'a> {
     key_state_map: &'a mut HashMap<Id, AcquireKeyState>,
     ndb: &'a Ndb,
     img_cache: &'a mut ImageCache,
+    urls: &'a mut UrlMimes,
     cur_account: Option<&'a UserAccount>,
 }
 
@@ -172,12 +173,14 @@ impl<'a> AddColumnView<'a> {
         key_state_map: &'a mut HashMap<Id, AcquireKeyState>,
         ndb: &'a Ndb,
         img_cache: &'a mut ImageCache,
+        urls: &'a mut UrlMimes,
         cur_account: Option<&'a UserAccount>,
     ) -> Self {
         Self {
             key_state_map,
             ndb,
             img_cache,
+            urls,
             cur_account,
         }
     }
@@ -321,7 +324,7 @@ impl<'a> AddColumnView<'a> {
                                 bottom: 32.0,
                             })
                             .show(ui, |ui| {
-                                ProfilePreview::new(&profile, self.img_cache).ui(ui);
+                                ProfilePreview::new(&profile, self.img_cache, self.urls).ui(ui);
                             });
                     }
                 }
@@ -597,6 +600,7 @@ pub fn render_add_column_routes(
         &mut app.view_state.id_state_map,
         ctx.ndb,
         ctx.img_cache,
+        ctx.urls,
         ctx.accounts.get_selected_account(),
     );
     let resp = match route {

--- a/crates/notedeck_columns/src/ui/column/header.rs
+++ b/crates/notedeck_columns/src/ui/column/header.rs
@@ -16,11 +16,13 @@ use egui::Margin;
 use egui::{RichText, Stroke, UiBuilder};
 use enostr::Pubkey;
 use nostrdb::{Ndb, Transaction};
+use notedeck::UrlMimes;
 use notedeck::{ImageCache, NotedeckTextStyle};
 
 pub struct NavTitle<'a> {
     ndb: &'a Ndb,
     img_cache: &'a mut ImageCache,
+    urls: &'a mut UrlMimes,
     columns: &'a Columns,
     routes: &'a [Route],
     col_id: usize,
@@ -30,6 +32,7 @@ impl<'a> NavTitle<'a> {
     pub fn new(
         ndb: &'a Ndb,
         img_cache: &'a mut ImageCache,
+        urls: &'a mut UrlMimes,
         columns: &'a Columns,
         routes: &'a [Route],
         col_id: usize,
@@ -37,6 +40,7 @@ impl<'a> NavTitle<'a> {
         NavTitle {
             ndb,
             img_cache,
+            urls,
             columns,
             routes,
             col_id,
@@ -395,7 +399,7 @@ impl<'a> NavTitle<'a> {
             .as_ref()
             .ok()
             .and_then(move |p| {
-                Some(ui::ProfilePic::from_profile(self.img_cache, p)?.size(pfp_size))
+                Some(ui::ProfilePic::from_profile(self.img_cache, self.urls, p)?.size(pfp_size))
             })
     }
 
@@ -409,7 +413,8 @@ impl<'a> NavTitle<'a> {
             ui.add(pfp);
         } else {
             ui.add(
-                ui::ProfilePic::new(self.img_cache, ui::ProfilePic::no_pfp_url()).size(pfp_size),
+                ui::ProfilePic::new(self.img_cache, self.urls, ui::ProfilePic::no_pfp_url())
+                    .size(pfp_size),
             );
         }
     }
@@ -464,7 +469,8 @@ impl<'a> NavTitle<'a> {
             ui.add(pfp);
         } else {
             ui.add(
-                ui::ProfilePic::new(self.img_cache, ui::ProfilePic::no_pfp_url()).size(pfp_size),
+                ui::ProfilePic::new(self.img_cache, self.urls, ui::ProfilePic::no_pfp_url())
+                    .size(pfp_size),
             );
         };
     }

--- a/crates/notedeck_columns/src/ui/mention.rs
+++ b/crates/notedeck_columns/src/ui/mention.rs
@@ -3,11 +3,12 @@ use crate::{actionbar::NoteAction, profile::get_display_name, timeline::Timeline
 use egui::Sense;
 use enostr::Pubkey;
 use nostrdb::{Ndb, Transaction};
-use notedeck::ImageCache;
+use notedeck::{ImageCache, UrlMimes};
 
 pub struct Mention<'a> {
     ndb: &'a Ndb,
     img_cache: &'a mut ImageCache,
+    urls: &'a mut UrlMimes,
     txn: &'a Transaction,
     pk: &'a [u8; 32],
     selectable: bool,
@@ -18,6 +19,7 @@ impl<'a> Mention<'a> {
     pub fn new(
         ndb: &'a Ndb,
         img_cache: &'a mut ImageCache,
+        urls: &'a mut UrlMimes,
         txn: &'a Transaction,
         pk: &'a [u8; 32],
     ) -> Self {
@@ -26,6 +28,7 @@ impl<'a> Mention<'a> {
         Mention {
             ndb,
             img_cache,
+            urls,
             txn,
             pk,
             selectable,
@@ -47,6 +50,7 @@ impl<'a> Mention<'a> {
         mention_ui(
             self.ndb,
             self.img_cache,
+            self.urls,
             self.txn,
             self.pk,
             ui,
@@ -62,9 +66,11 @@ impl egui::Widget for Mention<'_> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn mention_ui(
     ndb: &Ndb,
     img_cache: &mut ImageCache,
+    urls: &mut UrlMimes,
     txn: &Transaction,
     pk: &[u8; 32],
     ui: &mut egui::Ui,
@@ -102,7 +108,7 @@ fn mention_ui(
         if let Some(rec) = profile.as_ref() {
             resp.on_hover_ui_at_pointer(|ui| {
                 ui.set_max_width(300.0);
-                ui.add(ui::ProfilePreview::new(rec, img_cache));
+                ui.add(ui::ProfilePreview::new(rec, img_cache, urls));
             });
         }
 

--- a/crates/notedeck_columns/src/ui/note/contents.rs
+++ b/crates/notedeck_columns/src/ui/note/contents.rs
@@ -8,7 +8,7 @@ use egui::{Color32, Hyperlink, Image, RichText};
 use nostrdb::{BlockType, Mention, Ndb, Note, NoteKey, Transaction};
 use tracing::warn;
 
-use notedeck::{ImageCache, NoteCache, UrlMimes};
+use notedeck::{supported_mime_hosted_at_url, ImageCache, NoteCache, UrlMimes};
 
 pub struct NoteContents<'a> {
     ndb: &'a Ndb,
@@ -131,10 +131,6 @@ pub fn render_note_preview(
         .inner
 }
 
-fn is_image_link(url: &str) -> bool {
-    url.ends_with("png") || url.ends_with("jpg") || url.ends_with("jpeg")
-}
-
 #[allow(clippy::too_many_arguments)]
 fn render_note_contents(
     ui: &mut egui::Ui,
@@ -217,9 +213,12 @@ fn render_note_contents(
                 }
 
                 BlockType::Url => {
-                    let lower_url = block.as_str().to_lowercase();
-                    if !hide_media && is_image_link(&lower_url) {
-                        images.push(block.as_str().to_string());
+                    if !hide_media {
+                        let url = block.as_str().to_string();
+
+                        if supported_mime_hosted_at_url(urls, &url) {
+                            images.push(url);
+                        }
                     } else {
                         #[cfg(feature = "profiling")]
                         puffin::profile_scope!("url contents");

--- a/crates/notedeck_columns/src/ui/note/quote_repost.rs
+++ b/crates/notedeck_columns/src/ui/note/quote_repost.rs
@@ -1,6 +1,6 @@
 use enostr::{FilledKeypair, NoteId};
 use nostrdb::Ndb;
-use notedeck::{ImageCache, NoteCache};
+use notedeck::{ImageCache, NoteCache, UrlMimes};
 
 use crate::{draft::Draft, ui};
 
@@ -11,6 +11,7 @@ pub struct QuoteRepostView<'a> {
     poster: FilledKeypair<'a>,
     note_cache: &'a mut NoteCache,
     img_cache: &'a mut ImageCache,
+    urls: &'a mut UrlMimes,
     draft: &'a mut Draft,
     quoting_note: &'a nostrdb::Note<'a>,
     id_source: Option<egui::Id>,
@@ -18,11 +19,13 @@ pub struct QuoteRepostView<'a> {
 }
 
 impl<'a> QuoteRepostView<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         ndb: &'a Ndb,
         poster: FilledKeypair<'a>,
         note_cache: &'a mut NoteCache,
         img_cache: &'a mut ImageCache,
+        urls: &'a mut UrlMimes,
         draft: &'a mut Draft,
         quoting_note: &'a nostrdb::Note<'a>,
         inner_rect: egui::Rect,
@@ -33,6 +36,7 @@ impl<'a> QuoteRepostView<'a> {
             poster,
             note_cache,
             img_cache,
+            urls,
             draft,
             quoting_note,
             id_source,
@@ -49,6 +53,7 @@ impl<'a> QuoteRepostView<'a> {
             self.draft,
             PostType::Quote(NoteId::new(quoting_note_id.to_owned())),
             self.img_cache,
+            self.urls,
             self.note_cache,
             self.poster,
             self.inner_rect,

--- a/crates/notedeck_columns/src/ui/note/reply.rs
+++ b/crates/notedeck_columns/src/ui/note/reply.rs
@@ -4,13 +4,14 @@ use crate::ui::note::{PostResponse, PostType};
 use enostr::{FilledKeypair, NoteId};
 use nostrdb::Ndb;
 
-use notedeck::{ImageCache, NoteCache};
+use notedeck::{ImageCache, NoteCache, UrlMimes};
 
 pub struct PostReplyView<'a> {
     ndb: &'a Ndb,
     poster: FilledKeypair<'a>,
     note_cache: &'a mut NoteCache,
     img_cache: &'a mut ImageCache,
+    urls: &'a mut UrlMimes,
     draft: &'a mut Draft,
     note: &'a nostrdb::Note<'a>,
     id_source: Option<egui::Id>,
@@ -18,12 +19,14 @@ pub struct PostReplyView<'a> {
 }
 
 impl<'a> PostReplyView<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         ndb: &'a Ndb,
         poster: FilledKeypair<'a>,
         draft: &'a mut Draft,
         note_cache: &'a mut NoteCache,
         img_cache: &'a mut ImageCache,
+        urls: &'a mut UrlMimes,
         note: &'a nostrdb::Note<'a>,
         inner_rect: egui::Rect,
     ) -> Self {
@@ -35,6 +38,7 @@ impl<'a> PostReplyView<'a> {
             note,
             note_cache,
             img_cache,
+            urls,
             id_source,
             inner_rect,
         }
@@ -67,11 +71,17 @@ impl<'a> PostReplyView<'a> {
             egui::Frame::none()
                 .outer_margin(egui::Margin::same(note_offset))
                 .show(ui, |ui| {
-                    ui::NoteView::new(self.ndb, self.note_cache, self.img_cache, self.note)
-                        .actionbar(false)
-                        .medium_pfp(true)
-                        .options_button(true)
-                        .show(ui);
+                    ui::NoteView::new(
+                        self.ndb,
+                        self.note_cache,
+                        self.img_cache,
+                        self.urls,
+                        self.note,
+                    )
+                    .actionbar(false)
+                    .medium_pfp(true)
+                    .options_button(true)
+                    .show(ui);
                 });
 
             let id = self.id();
@@ -84,6 +94,7 @@ impl<'a> PostReplyView<'a> {
                     self.draft,
                     PostType::Reply(NoteId::new(*replying_to)),
                     self.img_cache,
+                    self.urls,
                     self.note_cache,
                     self.poster,
                     self.inner_rect,

--- a/crates/notedeck_columns/src/ui/note/reply_description.rs
+++ b/crates/notedeck_columns/src/ui/note/reply_description.rs
@@ -1,7 +1,7 @@
 use crate::{actionbar::NoteAction, ui};
 use egui::{Label, RichText, Sense};
 use nostrdb::{Ndb, Note, NoteReply, Transaction};
-use notedeck::{ImageCache, NoteCache};
+use notedeck::{ImageCache, NoteCache, UrlMimes};
 
 #[must_use = "Please handle the resulting note action"]
 pub fn reply_desc(
@@ -10,6 +10,7 @@ pub fn reply_desc(
     note_reply: &NoteReply,
     ndb: &Ndb,
     img_cache: &mut ImageCache,
+    urls: &mut UrlMimes,
     note_cache: &mut NoteCache,
 ) -> Option<NoteAction> {
     #[cfg(feature = "profiling")]
@@ -26,6 +27,7 @@ pub fn reply_desc(
     let note_link = |ui: &mut egui::Ui,
                      note_cache: &mut NoteCache,
                      img_cache: &mut ImageCache,
+                     urls: &mut UrlMimes,
                      text: &str,
                      note: &Note<'_>| {
         let r = ui.add(
@@ -41,7 +43,7 @@ pub fn reply_desc(
         if r.hovered() {
             r.on_hover_ui_at_pointer(|ui| {
                 ui.set_max_width(400.0);
-                ui::NoteView::new(ndb, note_cache, img_cache, note)
+                ui::NoteView::new(ndb, note_cache, img_cache, urls, note)
                     .actionbar(false)
                     .wide(true)
                     .show(ui);
@@ -62,7 +64,7 @@ pub fn reply_desc(
 
     if note_reply.is_reply_to_root() {
         // We're replying to the root, let's show this
-        let action = ui::Mention::new(ndb, img_cache, txn, reply_note.pubkey())
+        let action = ui::Mention::new(ndb, img_cache, urls, txn, reply_note.pubkey())
             .size(size)
             .selectable(selectable)
             .show(ui)
@@ -74,14 +76,14 @@ pub fn reply_desc(
 
         ui.add(Label::new(RichText::new("'s").size(size).color(color)).selectable(selectable));
 
-        note_link(ui, note_cache, img_cache, "thread", &reply_note);
+        note_link(ui, note_cache, img_cache, urls, "thread", &reply_note);
     } else if let Some(root) = note_reply.root() {
         // replying to another post in a thread, not the root
 
         if let Ok(root_note) = ndb.get_note_by_id(txn, root.id) {
             if root_note.pubkey() == reply_note.pubkey() {
                 // simply "replying to bob's note" when replying to bob in his thread
-                let action = ui::Mention::new(ndb, img_cache, txn, reply_note.pubkey())
+                let action = ui::Mention::new(ndb, img_cache, urls, txn, reply_note.pubkey())
                     .size(size)
                     .selectable(selectable)
                     .show(ui)
@@ -95,11 +97,11 @@ pub fn reply_desc(
                     Label::new(RichText::new("'s").size(size).color(color)).selectable(selectable),
                 );
 
-                note_link(ui, note_cache, img_cache, "note", &reply_note);
+                note_link(ui, note_cache, img_cache, urls, "note", &reply_note);
             } else {
                 // replying to bob in alice's thread
 
-                let action = ui::Mention::new(ndb, img_cache, txn, reply_note.pubkey())
+                let action = ui::Mention::new(ndb, img_cache, urls, txn, reply_note.pubkey())
                     .size(size)
                     .selectable(selectable)
                     .show(ui)
@@ -113,13 +115,13 @@ pub fn reply_desc(
                     Label::new(RichText::new("'s").size(size).color(color)).selectable(selectable),
                 );
 
-                note_link(ui, note_cache, img_cache, "note", &reply_note);
+                note_link(ui, note_cache, img_cache, urls, "note", &reply_note);
 
                 ui.add(
                     Label::new(RichText::new("in").size(size).color(color)).selectable(selectable),
                 );
 
-                let action = ui::Mention::new(ndb, img_cache, txn, root_note.pubkey())
+                let action = ui::Mention::new(ndb, img_cache, urls, txn, root_note.pubkey())
                     .size(size)
                     .selectable(selectable)
                     .show(ui)
@@ -133,10 +135,10 @@ pub fn reply_desc(
                     Label::new(RichText::new("'s").size(size).color(color)).selectable(selectable),
                 );
 
-                note_link(ui, note_cache, img_cache, "thread", &root_note);
+                note_link(ui, note_cache, img_cache, urls, "thread", &root_note);
             }
         } else {
-            let action = ui::Mention::new(ndb, img_cache, txn, reply_note.pubkey())
+            let action = ui::Mention::new(ndb, img_cache, urls, txn, reply_note.pubkey())
                 .size(size)
                 .selectable(selectable)
                 .show(ui)

--- a/crates/notedeck_columns/src/ui/profile/edit.rs
+++ b/crates/notedeck_columns/src/ui/profile/edit.rs
@@ -1,7 +1,7 @@
 use core::f32;
 
 use egui::{vec2, Button, Layout, Margin, RichText, Rounding, ScrollArea, TextEdit};
-use notedeck::{ImageCache, NotedeckTextStyle};
+use notedeck::{ImageCache, NotedeckTextStyle, UrlMimes};
 
 use crate::{colors, profile_state::ProfileState};
 
@@ -10,11 +10,20 @@ use super::{banner, unwrap_profile_url, ProfilePic};
 pub struct EditProfileView<'a> {
     state: &'a mut ProfileState,
     img_cache: &'a mut ImageCache,
+    urls: &'a mut UrlMimes,
 }
 
 impl<'a> EditProfileView<'a> {
-    pub fn new(state: &'a mut ProfileState, img_cache: &'a mut ImageCache) -> Self {
-        Self { state, img_cache }
+    pub fn new(
+        state: &'a mut ProfileState,
+        img_cache: &'a mut ImageCache,
+        urls: &'a mut UrlMimes,
+    ) -> Self {
+        Self {
+            state,
+            img_cache,
+            urls,
+        }
     }
 
     // return true to save
@@ -62,7 +71,7 @@ impl<'a> EditProfileView<'a> {
         });
         ui.put(
             pfp_rect,
-            ProfilePic::new(self.img_cache, pfp_url)
+            ProfilePic::new(self.img_cache, self.urls, pfp_url)
                 .size(size)
                 .border(ProfilePic::border_stroke(ui)),
         );
@@ -193,7 +202,7 @@ mod preview {
 
     impl App for EditProfilePreivew {
         fn update(&mut self, ctx: &mut notedeck::AppContext<'_>, ui: &mut egui::Ui) {
-            EditProfileView::new(&mut self.state, ctx.img_cache).ui(ui);
+            EditProfileView::new(&mut self.state, ctx.img_cache, ctx.urls).ui(ui);
         }
     }
 

--- a/crates/notedeck_columns/src/ui/profile/mod.rs
+++ b/crates/notedeck_columns/src/ui/profile/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     NostrName,
 };
 
-use notedeck::{Accounts, ImageCache, MuteFun, NoteCache, NotedeckTextStyle, UnknownIds};
+use notedeck::{Accounts, ImageCache, MuteFun, NoteCache, NotedeckTextStyle, UnknownIds, UrlMimes};
 
 pub struct ProfileView<'a> {
     pubkey: &'a Pubkey,
@@ -34,6 +34,7 @@ pub struct ProfileView<'a> {
     ndb: &'a Ndb,
     note_cache: &'a mut NoteCache,
     img_cache: &'a mut ImageCache,
+    urls: &'a mut UrlMimes,
     unknown_ids: &'a mut UnknownIds,
     is_muted: &'a MuteFun,
 }
@@ -53,6 +54,7 @@ impl<'a> ProfileView<'a> {
         ndb: &'a Ndb,
         note_cache: &'a mut NoteCache,
         img_cache: &'a mut ImageCache,
+        urls: &'a mut UrlMimes,
         unknown_ids: &'a mut UnknownIds,
         is_muted: &'a MuteFun,
         note_options: NoteOptions,
@@ -65,6 +67,7 @@ impl<'a> ProfileView<'a> {
             ndb,
             note_cache,
             img_cache,
+            urls,
             unknown_ids,
             note_options,
             is_muted,
@@ -117,6 +120,7 @@ impl<'a> ProfileView<'a> {
                     self.ndb,
                     self.note_cache,
                     self.img_cache,
+                    self.urls,
                     self.is_muted,
                 )
                 .show(ui)
@@ -149,7 +153,7 @@ impl<'a> ProfileView<'a> {
                 ui.horizontal(|ui| {
                     ui.put(
                         pfp_rect,
-                        ProfilePic::new(self.img_cache, get_profile_url(Some(&profile)))
+                        ProfilePic::new(self.img_cache, self.urls, get_profile_url(Some(&profile)))
                             .size(size)
                             .border(ProfilePic::border_stroke(ui)),
                     );

--- a/crates/notedeck_columns/src/ui/profile/picture.rs
+++ b/crates/notedeck_columns/src/ui/profile/picture.rs
@@ -4,10 +4,11 @@ use egui::{vec2, Sense, Stroke, TextureHandle};
 use nostrdb::{Ndb, Transaction};
 use tracing::info;
 
-use notedeck::{AppContext, ImageCache};
+use notedeck::{AppContext, ImageCache, UrlMimes};
 
 pub struct ProfilePic<'cache, 'url> {
     cache: &'cache mut ImageCache,
+    urls: &'cache mut UrlMimes,
     url: &'url str,
     size: f32,
     border: Option<Stroke>,
@@ -15,15 +16,16 @@ pub struct ProfilePic<'cache, 'url> {
 
 impl egui::Widget for ProfilePic<'_, '_> {
     fn ui(self, ui: &mut egui::Ui) -> egui::Response {
-        render_pfp(ui, self.cache, self.url, self.size, self.border)
+        render_pfp(ui, self.cache, self.urls, self.url, self.size, self.border)
     }
 }
 
 impl<'cache, 'url> ProfilePic<'cache, 'url> {
-    pub fn new(cache: &'cache mut ImageCache, url: &'url str) -> Self {
+    pub fn new(cache: &'cache mut ImageCache, urls: &'cache mut UrlMimes, url: &'url str) -> Self {
         let size = Self::default_size();
         ProfilePic {
             cache,
+            urls,
             url,
             size,
             border: None,
@@ -36,13 +38,14 @@ impl<'cache, 'url> ProfilePic<'cache, 'url> {
 
     pub fn from_profile(
         cache: &'cache mut ImageCache,
+        urls: &'cache mut UrlMimes,
         profile: &nostrdb::ProfileRecord<'url>,
     ) -> Option<Self> {
         profile
             .record()
             .profile()
             .and_then(|p| p.picture())
-            .map(|url| ProfilePic::new(cache, url))
+            .map(|url| ProfilePic::new(cache, urls, url))
     }
 
     #[inline]
@@ -81,6 +84,7 @@ impl<'cache, 'url> ProfilePic<'cache, 'url> {
 fn render_pfp(
     ui: &mut egui::Ui,
     img_cache: &mut ImageCache,
+    _urls: &mut UrlMimes,
     url: &str,
     ui_size: f32,
     border: Option<Stroke>,
@@ -211,13 +215,13 @@ mod preview {
 
                         ui.put(
                             rect,
-                            ui::ProfilePic::new(app.img_cache, url)
+                            ui::ProfilePic::new(app.img_cache, app.urls, url)
                                 .size(size)
                                 .border(ui::ProfilePic::border_stroke(ui)),
                         )
                         .on_hover_ui_at_pointer(|ui| {
                             ui.set_max_width(300.0);
-                            ui.add(ui::ProfilePreview::new(&profile, app.img_cache));
+                            ui.add(ui::ProfilePreview::new(&profile, app.img_cache, app.urls));
                         });
                     }
                 });

--- a/crates/notedeck_columns/src/ui/search_results.rs
+++ b/crates/notedeck_columns/src/ui/search_results.rs
@@ -1,6 +1,6 @@
 use egui::{vec2, FontId, Pos2, Rect, ScrollArea, Vec2b};
 use nostrdb::{Ndb, ProfileRecord, Transaction};
-use notedeck::{fonts::get_font_size, ImageCache, NotedeckTextStyle};
+use notedeck::{fonts::get_font_size, ImageCache, NotedeckTextStyle, UrlMimes};
 use tracing::error;
 
 use crate::{
@@ -14,12 +14,14 @@ pub struct SearchResultsView<'a> {
     ndb: &'a Ndb,
     txn: &'a Transaction,
     img_cache: &'a mut ImageCache,
+    urls: &'a mut UrlMimes,
     results: &'a Vec<&'a [u8; 32]>,
 }
 
 impl<'a> SearchResultsView<'a> {
     pub fn new(
         img_cache: &'a mut ImageCache,
+        urls: &'a mut UrlMimes,
         ndb: &'a Ndb,
         txn: &'a Transaction,
         results: &'a Vec<&'a [u8; 32]>,
@@ -28,6 +30,7 @@ impl<'a> SearchResultsView<'a> {
             ndb,
             txn,
             img_cache,
+            urls,
             results,
         }
     }
@@ -45,7 +48,7 @@ impl<'a> SearchResultsView<'a> {
                 };
 
                 if ui
-                    .add(user_result(&profile, self.img_cache, i, width))
+                    .add(user_result(&profile, self.img_cache, self.urls, i, width))
                     .clicked()
                 {
                     selection = Some(i)
@@ -85,6 +88,7 @@ impl<'a> SearchResultsView<'a> {
 fn user_result<'a>(
     profile: &'a ProfileRecord<'_>,
     cache: &'a mut ImageCache,
+    urls: &'a mut UrlMimes,
     index: usize,
     width: f32,
 ) -> impl egui::Widget + use<'a> {
@@ -106,7 +110,7 @@ fn user_result<'a>(
 
         let pfp_resp = ui.put(
             icon_rect,
-            ProfilePic::new(cache, get_profile_url(Some(profile)))
+            ProfilePic::new(cache, urls, get_profile_url(Some(profile)))
                 .size(helper.scale_1d_pos(min_img_size)),
         );
 

--- a/crates/notedeck_columns/src/ui/side_panel.rs
+++ b/crates/notedeck_columns/src/ui/side_panel.rs
@@ -15,7 +15,7 @@ use crate::{
     support::Support,
 };
 
-use notedeck::{Accounts, ImageCache, NotedeckTextStyle, ThemeHandler, UserAccount};
+use notedeck::{Accounts, ImageCache, NotedeckTextStyle, ThemeHandler, UrlMimes, UserAccount};
 
 use super::{
     anim::{AnimationHelper, ICON_EXPANSION_MULTIPLE},
@@ -30,6 +30,7 @@ static ICON_WIDTH: f32 = 40.0;
 pub struct DesktopSidePanel<'a> {
     ndb: &'a nostrdb::Ndb,
     img_cache: &'a mut ImageCache,
+    urls: &'a mut UrlMimes,
     selected_account: Option<&'a UserAccount>,
     decks_cache: &'a DecksCache,
 }
@@ -71,12 +72,14 @@ impl<'a> DesktopSidePanel<'a> {
     pub fn new(
         ndb: &'a nostrdb::Ndb,
         img_cache: &'a mut ImageCache,
+        urls: &'a mut UrlMimes,
         selected_account: Option<&'a UserAccount>,
         decks_cache: &'a DecksCache,
     ) -> Self {
         Self {
             ndb,
             img_cache,
+            urls,
             selected_account,
             decks_cache,
         }
@@ -266,7 +269,7 @@ impl<'a> DesktopSidePanel<'a> {
         let txn = nostrdb::Transaction::new(self.ndb).expect("should be able to create txn");
         let profile_url = get_account_url(&txn, self.ndb, self.selected_account);
 
-        let widget = ProfilePic::new(self.img_cache, profile_url).size(cur_pfp_size);
+        let widget = ProfilePic::new(self.img_cache, self.urls, profile_url).size(cur_pfp_size);
 
         ui.put(helper.get_animation_rect(), widget);
 

--- a/crates/notedeck_columns/src/ui/thread.rs
+++ b/crates/notedeck_columns/src/ui/thread.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 use nostrdb::{Ndb, Transaction};
-use notedeck::{ImageCache, MuteFun, NoteCache, RootNoteId, UnknownIds};
+use notedeck::{ImageCache, MuteFun, NoteCache, RootNoteId, UnknownIds, UrlMimes};
 use tracing::error;
 
 use super::timeline::TimelineTabView;
@@ -16,6 +16,7 @@ pub struct ThreadView<'a> {
     note_cache: &'a mut NoteCache,
     unknown_ids: &'a mut UnknownIds,
     img_cache: &'a mut ImageCache,
+    urls: &'a mut UrlMimes,
     selected_note_id: &'a [u8; 32],
     textmode: bool,
     id_source: egui::Id,
@@ -30,6 +31,7 @@ impl<'a> ThreadView<'a> {
         note_cache: &'a mut NoteCache,
         unknown_ids: &'a mut UnknownIds,
         img_cache: &'a mut ImageCache,
+        urls: &'a mut UrlMimes,
         selected_note_id: &'a [u8; 32],
         textmode: bool,
         is_muted: &'a MuteFun,
@@ -41,6 +43,7 @@ impl<'a> ThreadView<'a> {
             note_cache,
             unknown_ids,
             img_cache,
+            urls,
             selected_note_id,
             textmode,
             id_source,
@@ -114,6 +117,7 @@ impl<'a> ThreadView<'a> {
                     self.ndb,
                     self.note_cache,
                     self.img_cache,
+                    self.urls,
                     self.is_muted,
                 )
                 .show(ui)

--- a/crates/notedeck_columns/src/ui/timeline.rs
+++ b/crates/notedeck_columns/src/ui/timeline.rs
@@ -12,7 +12,7 @@ use egui::{vec2, Direction, Layout, Pos2, Stroke};
 use egui_tabs::TabColor;
 use nostrdb::{Ndb, Transaction};
 use notedeck::note::root_note_id_from_selected_id;
-use notedeck::{ImageCache, MuteFun, NoteCache};
+use notedeck::{ImageCache, MuteFun, NoteCache, UrlMimes};
 use tracing::{error, warn};
 
 use super::anim::{AnimationHelper, ICON_EXPANSION_MULTIPLE};
@@ -23,18 +23,21 @@ pub struct TimelineView<'a> {
     ndb: &'a Ndb,
     note_cache: &'a mut NoteCache,
     img_cache: &'a mut ImageCache,
+    urls: &'a mut UrlMimes,
     note_options: NoteOptions,
     reverse: bool,
     is_muted: &'a MuteFun,
 }
 
 impl<'a> TimelineView<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         timeline_id: &'a TimelineKind,
         timeline_cache: &'a mut TimelineCache,
         ndb: &'a Ndb,
         note_cache: &'a mut NoteCache,
         img_cache: &'a mut ImageCache,
+        urls: &'a mut UrlMimes,
         note_options: NoteOptions,
         is_muted: &'a MuteFun,
     ) -> TimelineView<'a> {
@@ -45,6 +48,7 @@ impl<'a> TimelineView<'a> {
             timeline_cache,
             note_cache,
             img_cache,
+            urls,
             reverse,
             note_options,
             is_muted,
@@ -59,6 +63,7 @@ impl<'a> TimelineView<'a> {
             self.timeline_cache,
             self.note_cache,
             self.img_cache,
+            self.urls,
             self.reverse,
             self.note_options,
             self.is_muted,
@@ -79,6 +84,7 @@ fn timeline_ui(
     timeline_cache: &mut TimelineCache,
     note_cache: &mut NoteCache,
     img_cache: &mut ImageCache,
+    urls: &mut UrlMimes,
     reversed: bool,
     note_options: NoteOptions,
     is_muted: &MuteFun,
@@ -159,6 +165,7 @@ fn timeline_ui(
             ndb,
             note_cache,
             img_cache,
+            urls,
             is_muted,
         )
         .show(ui)
@@ -322,6 +329,7 @@ pub struct TimelineTabView<'a> {
     ndb: &'a Ndb,
     note_cache: &'a mut NoteCache,
     img_cache: &'a mut ImageCache,
+    urls: &'a mut UrlMimes,
     is_muted: &'a MuteFun,
 }
 
@@ -335,6 +343,7 @@ impl<'a> TimelineTabView<'a> {
         ndb: &'a Ndb,
         note_cache: &'a mut NoteCache,
         img_cache: &'a mut ImageCache,
+        urls: &'a mut UrlMimes,
         is_muted: &'a MuteFun,
     ) -> Self {
         Self {
@@ -345,6 +354,7 @@ impl<'a> TimelineTabView<'a> {
             ndb,
             note_cache,
             img_cache,
+            urls,
             is_muted,
         }
     }
@@ -388,10 +398,15 @@ impl<'a> TimelineTabView<'a> {
 
                 if !muted {
                     ui::padding(8.0, ui, |ui| {
-                        let resp =
-                            ui::NoteView::new(self.ndb, self.note_cache, self.img_cache, &note)
-                                .note_options(self.note_options)
-                                .show(ui);
+                        let resp = ui::NoteView::new(
+                            self.ndb,
+                            self.note_cache,
+                            self.img_cache,
+                            self.urls,
+                            &note,
+                        )
+                        .note_options(self.note_options)
+                        .show(ui);
 
                         if let Some(note_action) = resp.action {
                             action = Some(note_action)


### PR DESCRIPTION
If the mime type hosted at a URL can't be inferred from the URL, a HEAD request is made and the result is cached. Every so often the data structure is saved to disk