### PR TITLE
support Cmd+Enter for posting on macOS

### DIFF
--- a/crates/notedeck_columns/src/ui/note/post.rs
+++ b/crates/notedeck_columns/src/ui/note/post.rs
@@ -362,11 +362,13 @@ impl<'a> PostView<'a> {
                                     )
                                     .clicked();
 
-                                let ctrl_enter_pressed = ui
-                                    .input(|i| i.modifiers.ctrl && i.key_pressed(egui::Key::Enter));
+                                let shortcut_pressed = ui.input(|i| {
+                                    (i.modifiers.ctrl || i.modifiers.command)
+                                        && i.key_pressed(egui::Key::Enter)
+                                });
 
                                 if post_button_clicked
-                                    || (!self.draft.buffer.is_empty() && ctrl_enter_pressed)
+                                    || (!self.draft.buffer.is_empty() && shortcut_pressed)
                                 {
                                     let output = self.draft.buffer.output();
                                     let new_post = NewPost::new(


### PR DESCRIPTION
Add support for Command key (macOS) in addition to Ctrl key for submitting posts via keyboard shortcut

per: https://github.com/damus-io/notedeck/pull/725#issuecomment-2704908810