### PR TITLE
search: auto-focus search field on navigate

### DIFF
--- a/crates/notedeck_columns/src/route.rs
+++ b/crates/notedeck_columns/src/route.rs
@@ -25,7 +25,6 @@ pub enum Route {
     EditProfile(Pubkey),
     Support,
     NewDeck,
-    /// Search screen
     Search,
     EditDeck(usize),
 }

--- a/crates/notedeck_columns/src/ui/search/mod.rs
+++ b/crates/notedeck_columns/src/ui/search/mod.rs
@@ -12,7 +12,7 @@ use tracing::{error, info, warn};
 
 mod state;
 
-pub use state::{SearchQueryState, SearchState};
+pub use state::{FocusState, SearchQueryState, SearchState};
 
 pub struct SearchView<'a> {
     query: &'a mut SearchQueryState,
@@ -57,7 +57,7 @@ impl<'a> SearchView<'a> {
         }
 
         match self.query.state {
-            SearchState::New => None,
+            SearchState::New | SearchState::Navigating => None,
 
             SearchState::Searched | SearchState::Typing => {
                 if self.query.state == SearchState::Typing {
@@ -163,7 +163,7 @@ fn search_box(query: &mut SearchQueryState, ui: &mut egui::Ui) -> bool {
 
                     // Search input field
                     //let font_size = notedeck::fonts::get_font_size(ui.ctx(), &NotedeckTextStyle::Body);
-                    ui.add_sized(
+                    let response = ui.add_sized(
                         [ui.available_width(), search_height],
                         TextEdit::singleline(&mut query.string)
                             .hint_text(RichText::new("Search notes...").weak())
@@ -172,6 +172,11 @@ fn search_box(query: &mut SearchQueryState, ui: &mut egui::Ui) -> bool {
                             .margin(vec2(0.0, 8.0))
                             .frame(false),
                     );
+
+                    if query.focus_state == FocusState::ShouldRequestFocus {
+                        response.request_focus();
+                        query.focus_state = FocusState::RequestedFocus;
+                    }
 
                     let after_len = query.string.len();
 

--- a/crates/notedeck_columns/src/ui/search/state.rs
+++ b/crates/notedeck_columns/src/ui/search/state.rs
@@ -6,7 +6,20 @@ use std::time::Duration;
 pub enum SearchState {
     Typing,
     Searched,
+    Navigating,
     New,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum FocusState {
+    /// Get ready to focus
+    Navigating,
+
+    /// We should request focus when we stop navigating
+    ShouldRequestFocus,
+
+    /// We already focused, we don't need to do that again
+    RequestedFocus,
 }
 
 /// Search query state that exists between frames
@@ -19,6 +32,10 @@ pub struct SearchQueryState {
     /// our state as searchd. This will make sure we don't try to search
     /// again next frames
     pub state: SearchState,
+
+    /// A bit of context to know if we're navigating to the view. We
+    /// can use this to know when to request focus on the textedit
+    pub focus_state: FocusState,
 
     /// When was the input updated? We use this to debounce searches
     pub debouncer: Debouncer,
@@ -39,6 +56,7 @@ impl SearchQueryState {
             string: "".to_string(),
             state: SearchState::New,
             notes: TimelineTab::default(),
+            focus_state: FocusState::Navigating,
             debouncer: Debouncer::new(Duration::from_millis(200)),
         }
     }

--- a/crates/notedeck_columns/src/ui/side_panel.rs
+++ b/crates/notedeck_columns/src/ui/side_panel.rs
@@ -324,7 +324,6 @@ impl<'a> DesktopSidePanel<'a> {
             }
             SidePanelAction::Search => {
                 // TODO
-                info!("Clicked search button");
                 if router.top() == &Route::Search {
                     router.go_back();
                 } else {


### PR DESCRIPTION
I'm going to add a search changelog on this commit since I forgot to do so previously.

Fixes: https://linear.app/damus/issue/DECK-538/auto-focus-search-field-on-search-view
Changelog-Added: Added fulltext search ui