### PR TITLE
Add notifications column to first deck

### DIFF
--- a/crates/notedeck_columns/src/decks.rs
+++ b/crates/notedeck_columns/src/decks.rs
@@ -79,7 +79,8 @@ impl DecksCache {
     }
 
     pub fn add_deck_default(&mut self, key: Pubkey) {
-        self.account_to_decks.insert(key, Decks::default());
+        let default_deck = Deck::new_with_notifications('🇩', String::from("Default Deck"), key);
+        self.account_to_decks.insert(key, Decks::new(default_deck));
         info!(
             "Adding new default deck for {:?}. New decks size is {}",
             key,
@@ -273,6 +274,19 @@ impl Default for Deck {
 impl Deck {
     pub fn new(icon: char, name: String) -> Self {
         let mut columns = Columns::default();
+        columns.new_column_picker();
+        Self {
+            icon,
+            name,
+            columns,
+        }
+    }
+
+    pub fn new_with_notifications(icon: char, name: String, pubkey: Pubkey) -> Self {
+        let mut columns = Columns::default();
+        columns.add_column(Column::new(vec![Route::Timeline(
+            TimelineKind::Notifications(pubkey),
+        )]));
         columns.new_column_picker();
         Self {
             icon,

--- a/crates/notedeck_columns/src/decks.rs
+++ b/crates/notedeck_columns/src/decks.rs
@@ -284,10 +284,10 @@ impl Deck {
 
     pub fn new_with_notifications(icon: char, name: String, pubkey: Pubkey) -> Self {
         let mut columns = Columns::default();
+        columns.new_column_picker();
         columns.add_column(Column::new(vec![Route::Timeline(
             TimelineKind::Notifications(pubkey),
         )]));
-        columns.new_column_picker();
         Self {
             icon,
             name,


### PR DESCRIPTION
Default deck for a new user looks like this after the change:

![image](https://github.com/user-attachments/assets/1af32d4c-87cf-4194-b27f-958efc6e1177)

I did notice this panic / crash though if I try to click the "add new column" button:

```
thread 'main' panicked at crates/notedeck_columns/src/app.rs:600:23:
Added more `Strip` cells than were pre-allocated (3 pre-allocated)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I get the same on `master` though so I don't think it's related.

Relates to https://github.com/damus-io/notedeck/issues/599