### PR TITLE
notedeck: The feed is now updated manually only when user need it

### DIFF
--- a/crates/notedeck_chrome/src/notedeck.rs
+++ b/crates/notedeck_chrome/src/notedeck.rs
@@ -138,6 +138,7 @@ pub fn main() {
 #[cfg(test)]
 mod tests {
     use super::{Damus, Notedeck};
+    use notedeck_columns::timeline::TimelineKind;
     use std::path::{Path, PathBuf};
 
     fn create_tmp_dir() -> PathBuf {
@@ -157,11 +158,11 @@ mod tests {
         let datapath = create_tmp_dir();
         let dbpath = create_tmp_dir();
         let args: Vec<String> = [
-            "--testrunner",
-            "--datapath",
-            &datapath.to_str().unwrap(),
-            "--dbpath",
-            &dbpath.to_str().unwrap(),
+            "notedeck",
+            "--datadir",
+            datapath.to_str().unwrap(),
+            "--db",
+            dbpath.to_str().unwrap(),
         ]
         .iter()
         .map(|s| s.to_string())
@@ -232,8 +233,11 @@ mod tests {
             .unwrap();
 
         assert_eq!(app.timeline_cache.timelines.len(), 2);
-        assert!(app.timeline_cache.timelines.get(&tl1).is_some());
-        assert!(app.timeline_cache.timelines.get(&tl2).is_some());
+        assert!(app.timeline_cache.timelines.contains_key(tl1));
+        assert!(app.timeline_cache.timelines.contains_key(tl2));
+        let mut keys: Vec<TimelineKind> = app.timeline_cache.timelines.keys().cloned().collect();
+        keys.sort();
+        assert_eq!(keys, vec![tl1.clone(), tl2.clone()]);
 
         rmrf(tmpdir);
     }

--- a/crates/notedeck_columns/src/accounts/route.rs
+++ b/crates/notedeck_columns/src/accounts/route.rs
@@ -65,7 +65,7 @@ mod tests {
         let data_str = "accounts:show";
         let data = &data_str.split(":").collect::<Vec<&str>>();
         let mut token_writer = TokenWriter::default();
-        let mut parser = TokenParser::new(&data);
+        let mut parser = TokenParser::new(data);
         let parsed = AccountsRoute::parse_from_tokens(&mut parser).unwrap();
         let expected = AccountsRoute::Accounts;
         parsed.serialize_tokens(&mut token_writer);

--- a/crates/notedeck_columns/src/app.rs
+++ b/crates/notedeck_columns/src/app.rs
@@ -140,16 +140,16 @@ fn try_process_event(
         if is_ready {
             let txn = Transaction::new(app_ctx.ndb).expect("txn");
             // only thread timelines are reversed
-            let reversed = false;
+            //let reversed = false; // No longer needed here
 
-            if let Err(err) = timeline.poll_notes_into_view(
+            if let Err(err) = timeline.poll_notes_into_pending(
                 app_ctx.ndb,
                 &txn,
                 app_ctx.unknown_ids,
                 app_ctx.note_cache,
-                reversed,
+                //reversed, // Removed
             ) {
-                error!("poll_notes_into_view: {err}");
+                error!("poll_notes_into_pending: {err}");
             }
         } else {
             // TODO: show loading?

--- a/crates/notedeck_columns/src/route.rs
+++ b/crates/notedeck_columns/src/route.rs
@@ -538,7 +538,7 @@ mod tests {
         let data_str = format!("thread:{}", note_id_hex);
         let data = &data_str.split(":").collect::<Vec<&str>>();
         let mut token_writer = TokenWriter::default();
-        let mut parser = TokenParser::new(&data);
+        let mut parser = TokenParser::new(data);
         let parsed = Route::parse(&mut parser, &Pubkey::new(*note_id.bytes())).unwrap();
         let expected = Route::Thread(ThreadSelection::from_root_id(RootNoteIdBuf::new_unsafe(
             *note_id.bytes(),

--- a/crates/notedeck_columns/src/search.rs
+++ b/crates/notedeck_columns/src/search.rs
@@ -3,7 +3,7 @@ use nostrdb::{Filter, FilterBuilder};
 use rmpv::Value;
 use tokenator::{ParseError, TokenParser, TokenSerializable, TokenWriter};
 
-#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+#[derive(Debug, Eq, PartialEq, Clone, Hash, PartialOrd, Ord)]
 pub struct SearchQuery {
     author: Option<Pubkey>,
     pub search: String,

--- a/crates/notedeck_columns/src/timeline/kind.rs
+++ b/crates/notedeck_columns/src/timeline/kind.rs
@@ -14,14 +14,14 @@ use std::{borrow::Cow, fmt::Display};
 use tokenator::{ParseError, TokenParser, TokenSerializable, TokenWriter};
 use tracing::{error, warn};
 
-#[derive(Clone, Hash, Copy, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
 pub enum PubkeySource {
     Explicit(Pubkey),
     #[default]
     DeckAuthor,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Hash, Eq, PartialOrd, Ord)]
 pub enum ListKind {
     Contact(Pubkey),
 }
@@ -195,7 +195,7 @@ impl Eq for ThreadSelection {}
 ///   - filter
 ///   - ... etc
 ///
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum TimelineKind {
     List(ListKind),
 
@@ -220,7 +220,7 @@ const NOTIFS_TOKEN_DEPRECATED: &str = "notifs";
 const NOTIFS_TOKEN: &str = "notifications";
 
 /// Hardcoded algo timelines
-#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AlgoTimeline {
     /// LastPerPubkey: a special nostr query that fetches the last N
     /// notes for each pubkey on the list

--- a/crates/notedeck_columns/src/timeline/mod.rs
+++ b/crates/notedeck_columns/src/timeline/mod.rs
@@ -14,6 +14,7 @@ use egui_virtual_list::VirtualList;
 use enostr::{PoolRelay, Pubkey, RelayPool};
 use nostrdb::{Filter, Ndb, Note, NoteKey, Transaction};
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::rc::Rc;
 
 use tracing::{debug, error, info, warn};
@@ -196,6 +197,8 @@ pub struct Timeline {
     pub filter: FilterStates,
     pub views: Vec<TimelineTab>,
     pub selected_view: usize,
+    /// Notes polled from the database but not yet shown in the UI.
+    pub pending_notes: Vec<NoteRef>,
 
     pub subscription: Option<MultiSubscriber>,
 }
@@ -255,16 +258,13 @@ impl Timeline {
     }
 
     pub fn new(kind: TimelineKind, filter_state: FilterState, views: Vec<TimelineTab>) -> Self {
-        let filter = FilterStates::new(filter_state);
-        let subscription: Option<MultiSubscriber> = None;
-        let selected_view = 0;
-
-        Timeline {
+        Self {
             kind,
-            filter,
+            filter: FilterStates::new(filter_state),
             views,
-            subscription,
-            selected_view,
+            selected_view: 0,
+            pending_notes: Vec::new(),
+            subscription: None,
         }
     }
 
@@ -389,17 +389,18 @@ impl Timeline {
         Ok(())
     }
 
-    pub fn poll_notes_into_view(
+    /// Adds newly polled notes to the `pending_notes` list.
+    /// Returns true if new notes were added.
+    pub fn poll_notes_into_pending(
         &mut self,
         ndb: &Ndb,
         txn: &Transaction,
         unknown_ids: &mut UnknownIds,
         note_cache: &mut NoteCache,
-        reversed: bool,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         if !self.kind.should_subscribe_locally() {
             // don't need to poll for timelines that don't have local subscriptions
-            return Ok(());
+            return Ok(false);
         }
 
         let sub = self
@@ -410,12 +411,107 @@ impl Timeline {
 
         let new_note_ids = ndb.poll_for_notes(sub, 500);
         if new_note_ids.is_empty() {
-            return Ok(());
+            return Ok(false);
         } else {
             debug!("{} new notes! {:?}", new_note_ids.len(), new_note_ids);
         }
 
-        self.insert(&new_note_ids, ndb, txn, unknown_ids, note_cache, reversed)
+        // Fetch NoteRefs for the new NoteKeys and add to pending_notes
+        let mut new_refs: Vec<NoteRef> = Vec::with_capacity(new_note_ids.len());
+        for key in new_note_ids {
+            let note = match ndb.get_note_by_key(txn, key) {
+                Ok(note) => note,
+                Err(_) => {
+                    error!(
+                        "hit race condition in poll_notes_into_pending: note {:?} not found",
+                        key
+                    );
+                    continue;
+                }
+            };
+
+            // Ensure that unknown ids are captured (needed for profile info etc.)
+            UnknownIds::update_from_note(txn, ndb, unknown_ids, note_cache, &note);
+
+            let created_at = note.created_at();
+            new_refs.push(NoteRef { key, created_at });
+        }
+
+        // Add to pending, ensuring no duplicates and maintaining order (newest first)
+        // We assume poll_for_notes returns newest first.
+        let mut existing_pending_keys: HashSet<_> =
+            self.pending_notes.iter().map(|nr| nr.key).collect();
+        let mut added = false;
+        for new_ref in new_refs.into_iter().rev() {
+            // Iterate reversed to prepend correctly
+            if existing_pending_keys.insert(new_ref.key) {
+                self.pending_notes.insert(0, new_ref); // Prepend to keep newest first
+                added = true;
+            }
+        }
+
+        Ok(added)
+    }
+
+    /// Applies the notes currently in `pending_notes` to the visible timeline views.
+    pub fn apply_pending_notes(
+        &mut self,
+        ndb: &Ndb,
+        txn: &Transaction,
+        unknown_ids: &mut UnknownIds,
+        note_cache: &mut NoteCache,
+    ) -> Result<()> {
+        if self.pending_notes.is_empty() {
+            return Ok(());
+        }
+
+        let notes_to_apply = std::mem::take(&mut self.pending_notes);
+        let reversed = false; // Apply reversed logic if needed
+
+        // Fetch full notes for applying filters (slightly inefficient but necessary for Notes filter)
+        let mut fetched_notes: Vec<(Note, NoteRef)> = Vec::with_capacity(notes_to_apply.len());
+        for key_ref in &notes_to_apply {
+            let note = match ndb.get_note_by_key(txn, key_ref.key) {
+                Ok(note) => note,
+                Err(_) => {
+                    // Note might have been deleted between polling and applying
+                    error!(
+                        "Failed to fetch note {:?} while applying pending notes",
+                        key_ref.key
+                    );
+                    continue;
+                }
+            };
+            // Re-check unknown IDs just in case?
+            UnknownIds::update_from_note(txn, ndb, unknown_ids, note_cache, &note);
+            fetched_notes.push((note, *key_ref));
+        }
+
+        for view in &mut self.views {
+            match view.filter {
+                ViewFilter::NotesAndReplies => {
+                    // For this view, we just need the NoteRefs
+                    let refs_to_insert: Vec<NoteRef> = notes_to_apply.to_vec();
+                    if !refs_to_insert.is_empty() {
+                        view.insert(&refs_to_insert, reversed);
+                    }
+                }
+                ViewFilter::Notes => {
+                    let mut filtered_refs = Vec::with_capacity(fetched_notes.len());
+                    for (note, nr) in &fetched_notes {
+                        let cached_note = note_cache.cached_note_or_insert(nr.key, note);
+                        if ViewFilter::filter_notes(cached_note, note) {
+                            filtered_refs.push(*nr);
+                        }
+                    }
+                    if !filtered_refs.is_empty() {
+                        view.insert(&filtered_refs, reversed);
+                    }
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/notedeck_columns/src/timeline/route.rs
+++ b/crates/notedeck_columns/src/timeline/route.rs
@@ -36,7 +36,6 @@ pub fn render_timeline_route(
                 note_context,
                 note_options,
                 &accounts.get_selected_account().map(|a| (&a.key).into()),
-                jobs,
             )
             .ui(ui);
 
@@ -65,7 +64,6 @@ pub fn render_timeline_route(
                     note_context,
                     note_options,
                     &accounts.get_selected_account().map(|a| (&a.key).into()),
-                    jobs,
                 )
                 .ui(ui);
 

--- a/crates/notedeck_columns/src/ui/add_column.rs
+++ b/crates/notedeck_columns/src/ui/add_column.rs
@@ -808,7 +808,7 @@ mod tests {
             let data_str = "column:algo_selection:last_per_pubkey";
             let data = &data_str.split(":").collect::<Vec<&str>>();
             let mut token_writer = TokenWriter::default();
-            let mut parser = TokenParser::new(&data);
+            let mut parser = TokenParser::new(data);
             let parsed = AddColumnRoute::parse_from_tokens(&mut parser).unwrap();
             let expected = AddColumnRoute::Algo(AddAlgoRoute::LastPerPubkey);
             parsed.serialize_tokens(&mut token_writer);

--- a/crates/notedeck_columns/src/ui/thread.rs
+++ b/crates/notedeck_columns/src/ui/thread.rs
@@ -1,14 +1,12 @@
-use egui::InnerResponse;
-use egui_virtual_list::VirtualList;
-use enostr::KeypairUnowned;
-use nostrdb::{Note, Transaction};
-use notedeck::note::root_note_id_from_selected_id;
-use notedeck::{MuteFun, NoteAction, NoteContext};
-use notedeck_ui::jobs::JobsCache;
-use notedeck_ui::note::NoteResponse;
-use notedeck_ui::{NoteOptions, NoteView};
+use enostr::{KeypairUnowned, NoteId};
+use nostrdb::Transaction;
+use notedeck::{note::NoteAction, MuteFun, NoteContext};
+use notedeck_ui::{jobs::JobsCache, NoteOptions};
 
-use crate::timeline::thread::{NoteSeenFlags, ParentState, Threads};
+use crate::{
+    timeline::{thread::Threads, TimelineTab, ViewFilter},
+    ui::timeline::TimelineTabView,
+};
 
 pub struct ThreadView<'a, 'd> {
     threads: &'a mut Threads,
@@ -56,362 +54,46 @@ impl<'a, 'd> ThreadView<'a, 'd> {
     pub fn ui(&mut self, ui: &mut egui::Ui) -> Option<NoteAction> {
         let txn = Transaction::new(self.note_context.ndb).expect("txn");
 
-        let mut scroll_area = egui::ScrollArea::vertical()
+        let note_id = NoteId::new(*self.selected_note_id);
+
+        if let Ok(note) = self.note_context.ndb.get_note_by_id(&txn, note_id.bytes()) {
+            self.threads.update(
+                &note,
+                self.note_context.note_cache,
+                self.note_context.ndb,
+                &txn,
+                self.note_context.unknown_ids,
+                self.col,
+            );
+        }
+
+        egui::ScrollArea::vertical()
             .id_salt(self.id_source)
             .animated(false)
             .auto_shrink([false, false])
-            .scroll_bar_visibility(egui::scroll_area::ScrollBarVisibility::AlwaysVisible);
-
-        let offset_id = self
-            .id_source
-            .with(("scroll_offset", self.selected_note_id));
-
-        if let Some(offset) = ui.data(|i| i.get_temp::<f32>(offset_id)) {
-            scroll_area = scroll_area.vertical_scroll_offset(offset);
-        }
-
-        let output = scroll_area.show(ui, |ui| self.notes(ui, &txn));
-
-        ui.data_mut(|d| d.insert_temp(offset_id, output.state.offset.y));
-
-        output.inner
-    }
-
-    fn notes(&mut self, ui: &mut egui::Ui, txn: &Transaction) -> Option<NoteAction> {
-        let Ok(cur_note) = self
-            .note_context
-            .ndb
-            .get_note_by_id(txn, self.selected_note_id)
-        else {
-            let id = *self.selected_note_id;
-            tracing::error!("ndb: Did not find note {}", enostr::NoteId::new(id).hex());
-            return None;
-        };
-
-        self.threads.update(
-            &cur_note,
-            self.note_context.note_cache,
-            self.note_context.ndb,
-            txn,
-            self.note_context.unknown_ids,
-            self.col,
-        );
-
-        let cur_node = self.threads.threads.get(&self.selected_note_id).unwrap();
-
-        let full_chain = cur_node.have_all_ancestors;
-        let mut note_builder = ThreadNoteBuilder::new(cur_note);
-
-        let mut parent_state = cur_node.prev.clone();
-        while let ParentState::Parent(id) = parent_state {
-            if let Ok(note) = self.note_context.ndb.get_note_by_id(txn, id.bytes()) {
-                note_builder.add_chain(note);
-                if let Some(res) = self.threads.threads.get(&id.bytes()) {
-                    parent_state = res.prev.clone();
-                    continue;
+            .scroll_bar_visibility(egui::scroll_area::ScrollBarVisibility::AlwaysVisible)
+            .show(ui, |ui| {
+                if let Some(thread_node) = self.threads.threads.get(&note_id) {
+                    let notes: Vec<notedeck::NoteRef> =
+                        thread_node.replies.iter().copied().collect();
+                    let mut tab = TimelineTab::new(ViewFilter::NotesAndReplies);
+                    tab.notes = notes;
+                    TimelineTabView::new(
+                        &tab,
+                        true, // reversed for threads
+                        self.note_options,
+                        &txn,
+                        self.is_muted,
+                        self.note_context,
+                        self.cur_acc,
+                        self.jobs,
+                    )
+                    .show(ui)
+                } else {
+                    ui.label("Loading thread timeline...");
+                    None
                 }
-            }
-            parent_state = ParentState::Unknown;
-        }
-
-        for note_ref in &cur_node.replies {
-            if let Ok(note) = self.note_context.ndb.get_note_by_key(txn, note_ref.key) {
-                note_builder.add_reply(note);
-            }
-        }
-
-        let list = &mut self
-            .threads
-            .threads
-            .get_mut(&self.selected_note_id)
-            .unwrap()
-            .list;
-
-        let notes = note_builder.into_notes(&mut self.threads.seen_flags);
-
-        if !full_chain {
-            // TODO(kernelkind): insert UI denoting we don't have the full chain yet
-            ui.colored_label(ui.visuals().error_fg_color, "LOADING NOTES");
-        }
-
-        let zapping_acc = self
-            .cur_acc
-            .as_ref()
-            .filter(|_| self.note_context.current_account_has_wallet)
-            .or(self.cur_acc.as_ref());
-
-        show_notes(
-            ui,
-            list,
-            &notes,
-            self.note_context,
-            zapping_acc,
-            self.note_options,
-            self.jobs,
-            txn,
-            self.is_muted,
-        )
+            })
+            .inner
     }
 }
-
-#[allow(clippy::too_many_arguments)]
-fn show_notes(
-    ui: &mut egui::Ui,
-    list: &mut VirtualList,
-    thread_notes: &ThreadNotes,
-    note_context: &mut NoteContext<'_>,
-    zapping_acc: Option<&KeypairUnowned<'_>>,
-    flags: NoteOptions,
-    jobs: &mut JobsCache,
-    txn: &Transaction,
-    is_muted: &MuteFun,
-) -> Option<NoteAction> {
-    let mut action = None;
-
-    ui.spacing_mut().item_spacing.y = 0.0;
-    ui.spacing_mut().item_spacing.x = 4.0;
-
-    let selected_note_index = thread_notes.selected_index;
-    let notes = &thread_notes.notes;
-
-    list.ui_custom_layout(ui, notes.len(), |ui, cur_index| {
-        let note = &notes[cur_index];
-
-        // should we mute the thread? we might not have it!
-        let muted = root_note_id_from_selected_id(
-            note_context.ndb,
-            note_context.note_cache,
-            txn,
-            note.note.id(),
-        )
-        .ok()
-        .is_some_and(|root_id| is_muted(&note.note, root_id.bytes()));
-
-        if muted {
-            return 1;
-        }
-
-        let resp = note.show(note_context, zapping_acc, flags, jobs, ui);
-
-        action = if cur_index == selected_note_index {
-            resp.action.and_then(strip_note_action)
-        } else {
-            resp.action
-        }
-        .or(action.take());
-
-        1
-    });
-
-    action
-}
-
-fn strip_note_action(action: NoteAction) -> Option<NoteAction> {
-    if matches!(
-        action,
-        NoteAction::Note {
-            note_id: _,
-            preview: false,
-        }
-    ) {
-        return None;
-    }
-
-    Some(action)
-}
-
-struct ThreadNoteBuilder<'a> {
-    chain: Vec<Note<'a>>,
-    selected: Note<'a>,
-    replies: Vec<Note<'a>>,
-}
-
-impl<'a> ThreadNoteBuilder<'a> {
-    pub fn new(selected: Note<'a>) -> Self {
-        Self {
-            chain: Vec::new(),
-            selected,
-            replies: Vec::new(),
-        }
-    }
-
-    pub fn add_chain(&mut self, note: Note<'a>) {
-        self.chain.push(note);
-    }
-
-    pub fn add_reply(&mut self, note: Note<'a>) {
-        self.replies.push(note);
-    }
-
-    pub fn into_notes(mut self, seen_flags: &mut NoteSeenFlags) -> ThreadNotes<'a> {
-        let mut notes = Vec::new();
-
-        let selected_is_root = self.chain.is_empty();
-        let mut cur_is_root = true;
-        while let Some(note) = self.chain.pop() {
-            notes.push(ThreadNote {
-                unread_and_have_replies: *seen_flags.get(note.id()).unwrap_or(&false),
-                note,
-                note_type: ThreadNoteType::Chain { root: cur_is_root },
-            });
-            cur_is_root = false;
-        }
-
-        let selected_index = notes.len();
-        notes.push(ThreadNote {
-            note: self.selected,
-            note_type: ThreadNoteType::Selected {
-                root: selected_is_root,
-            },
-            unread_and_have_replies: false,
-        });
-
-        for reply in self.replies {
-            notes.push(ThreadNote {
-                unread_and_have_replies: *seen_flags.get(reply.id()).unwrap_or(&false),
-                note: reply,
-                note_type: ThreadNoteType::Reply,
-            });
-        }
-
-        ThreadNotes {
-            notes,
-            selected_index,
-        }
-    }
-}
-
-enum ThreadNoteType {
-    Chain { root: bool },
-    Selected { root: bool },
-    Reply,
-}
-
-struct ThreadNotes<'a> {
-    notes: Vec<ThreadNote<'a>>,
-    selected_index: usize,
-}
-
-struct ThreadNote<'a> {
-    pub note: Note<'a>,
-    note_type: ThreadNoteType,
-    pub unread_and_have_replies: bool,
-}
-
-impl<'a> ThreadNote<'a> {
-    fn options(&self, mut cur_options: NoteOptions) -> NoteOptions {
-        match self.note_type {
-            ThreadNoteType::Chain { root: _ } => cur_options,
-            ThreadNoteType::Selected { root: _ } => {
-                cur_options.set_wide(true);
-                cur_options.set_selectable_text(true);
-                cur_options
-            }
-            ThreadNoteType::Reply => cur_options,
-        }
-    }
-
-    fn show(
-        &self,
-        note_context: &'a mut NoteContext<'_>,
-        zapping_acc: Option<&'a KeypairUnowned<'a>>,
-        flags: NoteOptions,
-        jobs: &'a mut JobsCache,
-        ui: &mut egui::Ui,
-    ) -> NoteResponse {
-        let inner = notedeck_ui::padding(8.0, ui, |ui| {
-            NoteView::new(
-                note_context,
-                zapping_acc,
-                &self.note,
-                self.options(flags),
-                jobs,
-            )
-            .unread_indicator(self.unread_and_have_replies)
-            .show(ui)
-        });
-
-        match self.note_type {
-            ThreadNoteType::Chain { root } => add_chain_adornment(ui, &inner, root),
-            ThreadNoteType::Selected { root } => add_selected_adornment(ui, &inner, root),
-            ThreadNoteType::Reply => notedeck_ui::hline(ui),
-        }
-
-        inner.inner
-    }
-}
-
-fn add_chain_adornment(ui: &mut egui::Ui, note_resp: &InnerResponse<NoteResponse>, root: bool) {
-    let Some(pfp_rect) = note_resp.inner.pfp_rect else {
-        return;
-    };
-
-    let note_rect = note_resp.response.rect;
-
-    let painter = ui.painter_at(note_rect);
-
-    if !root {
-        paint_line_above_pfp(ui, &painter, &pfp_rect, &note_rect);
-    }
-
-    // painting line below pfp:
-    let top_pt = {
-        let mut top = pfp_rect.center();
-        top.y = pfp_rect.bottom();
-        top
-    };
-
-    let bottom_pt = {
-        let mut bottom = top_pt;
-        bottom.y = note_rect.bottom();
-        bottom
-    };
-
-    painter.line_segment([top_pt, bottom_pt], LINE_STROKE(ui));
-
-    let hline_min_x = top_pt.x + 6.0;
-    notedeck_ui::hline_with_width(
-        ui,
-        egui::Rangef::new(hline_min_x, ui.available_rect_before_wrap().right()),
-    );
-}
-
-fn add_selected_adornment(ui: &mut egui::Ui, note_resp: &InnerResponse<NoteResponse>, root: bool) {
-    let Some(pfp_rect) = note_resp.inner.pfp_rect else {
-        return;
-    };
-    let note_rect = note_resp.response.rect;
-    let painter = ui.painter_at(note_rect);
-
-    if !root {
-        paint_line_above_pfp(ui, &painter, &pfp_rect, &note_rect);
-    }
-    notedeck_ui::hline(ui);
-}
-
-fn paint_line_above_pfp(
-    ui: &egui::Ui,
-    painter: &egui::Painter,
-    pfp_rect: &egui::Rect,
-    note_rect: &egui::Rect,
-) {
-    let bottom_pt = {
-        let mut center = pfp_rect.center();
-        center.y = pfp_rect.top();
-        center
-    };
-
-    let top_pt = {
-        let mut top = bottom_pt;
-        top.y = note_rect.top();
-        top
-    };
-
-    painter.line_segment([bottom_pt, top_pt], LINE_STROKE(ui));
-}
-
-const LINE_STROKE: fn(&egui::Ui) -> egui::Stroke = |ui: &egui::Ui| {
-    let mut stroke = ui.style().visuals.widgets.noninteractive.bg_stroke;
-    stroke.width = 2.0;
-    stroke
-};


### PR DESCRIPTION
Small ux improvement. Now the feed don't get updated each time new notes come like before.

 Insteal a counter appear in the top of the feed. And when user want to see new note he then click.
I want to mimick the behavior of twitter, as on Universe  feed  get update often and it's almost impossible to read a note. 