### PR TITLE
windows: don't show terminal window

### DIFF
--- a/crates/notedeck_chrome/src/notedeck.rs
+++ b/crates/notedeck_chrome/src/notedeck.rs
@@ -1,4 +1,4 @@
-//#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 // hide console window on Windows in release
 
 use notedeck::{DataPath, DataPathType, Notedeck};


### PR DESCRIPTION
Looks like this got accidentally commented out in an android build