### PR TITLE
Update README.md with deepwiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,6 @@ This project is licensed under the GPL - see license information in individual c
 - William Casarin <jb55@jb55.com>
 - kernelkind <kernelkind@gmail.com>
 - And [contributors](https://github.com/damus-io/notedeck/graphs/contributors)
+
+## Deepwiki
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/damus-io/notedeck)


### PR DESCRIPTION
Added deepwiki badge that allows for automatic indexing of notedeck, and automatic docs creation.

See https://deepwiki.com/damus-io/notedeck/1-overview