### PR TITLE
Follow/Unfollow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3204,8 +3204,8 @@ dependencies = [
 
 [[package]]
 name = "nostrdb"
-version = "0.6.1"
-source = "git+https://github.com/damus-io/nostrdb-rs?rev=3e87e504090b8cc153474e584a1ecd4618441099#3e87e504090b8cc153474e584a1ecd4618441099"
+version = "0.7.0"
+source = "git+https://github.com/damus-io/nostrdb-rs?rev=15ae7f88cf9aa2d1e58dd622dbcccffb77fe51eb#15ae7f88cf9aa2d1e58dd622dbcccffb77fe51eb"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ log = "0.4.17"
 nostr = { version = "0.37.0", default-features = false, features = ["std", "nip49"] }
 nwc = "0.39.0"
 mio = { version = "1.0.3", features = ["os-poll", "net"] }
-nostrdb = { git = "https://github.com/damus-io/nostrdb-rs", rev = "3e87e504090b8cc153474e584a1ecd4618441099" }
+nostrdb = { git = "https://github.com/damus-io/nostrdb-rs", rev = "15ae7f88cf9aa2d1e58dd622dbcccffb77fe51eb" }
 #nostrdb = "0.6.1"
 notedeck = { path = "crates/notedeck" }
 notedeck_chrome = { path = "crates/notedeck_chrome" }

--- a/crates/notedeck/src/account/accounts.rs
+++ b/crates/notedeck/src/account/accounts.rs
@@ -313,6 +313,10 @@ impl Accounts {
             create_wakeup(ctx),
         );
     }
+
+    pub fn get_subs(&self) -> &AccountSubs {
+        &self.subs
+    }
 }
 
 enum AccType<'a> {
@@ -421,14 +425,14 @@ pub struct AddAccountResponse {
     pub unk_id_action: SingleUnkIdAction,
 }
 
-pub(super) struct AccountSubs {
+pub struct AccountSubs {
     relay: UnifiedSubscription,
     mute: UnifiedSubscription,
-    contacts: UnifiedSubscription,
+    pub contacts: UnifiedSubscription,
 }
 
 impl AccountSubs {
-    pub fn new(
+    pub(super) fn new(
         ndb: &mut Ndb,
         pool: &mut RelayPool,
         relay_defaults: &RelayDefaults,
@@ -448,7 +452,7 @@ impl AccountSubs {
         }
     }
 
-    pub fn swap_to(
+    pub(super) fn swap_to(
         &mut self,
         ndb: &mut Ndb,
         pool: &mut RelayPool,

--- a/crates/notedeck/src/account/accounts.rs
+++ b/crates/notedeck/src/account/accounts.rs
@@ -41,10 +41,7 @@ impl Accounts {
     ) -> Self {
         let (mut cache, unknown_id) = AccountCache::new(UserAccount::new(
             Keypair::only_pubkey(fallback),
-            AccountData {
-                relay: AccountRelayData::new(ndb, txn, fallback.bytes()),
-                muted: AccountMutedData::new(ndb, txn, fallback.bytes()),
-            },
+            AccountData::new(ndb, txn, fallback.bytes()),
         ));
 
         unknown_id.process_action(unknown_ids, ndb, txn);
@@ -131,10 +128,7 @@ impl Accounts {
             acc.key = kp.clone();
             AccType::Acc(&*acc)
         } else {
-            let new_account_data = AccountData {
-                relay: AccountRelayData::new(ndb, txn, kp.pubkey.bytes()),
-                muted: AccountMutedData::new(ndb, txn, kp.pubkey.bytes()),
-            };
+            let new_account_data = AccountData::new(ndb, txn, kp.pubkey.bytes());
             AccType::Entry(
                 self.cache
                     .add(UserAccount::new(kp.clone(), new_account_data)),
@@ -356,10 +350,7 @@ fn get_acc_from_storage(
     user_account_serializable: UserAccountSerializable,
 ) -> Option<UserAccount> {
     let keypair = user_account_serializable.key;
-    let new_account_data = AccountData {
-        relay: AccountRelayData::new(ndb, txn, keypair.pubkey.bytes()),
-        muted: AccountMutedData::new(ndb, txn, keypair.pubkey.bytes()),
-    };
+    let new_account_data = AccountData::new(ndb, txn, keypair.pubkey.bytes());
 
     let mut wallet = None;
     if let Some(wallet_s) = user_account_serializable.wallet {
@@ -385,6 +376,13 @@ pub struct AccountData {
 }
 
 impl AccountData {
+    pub fn new(ndb: &Ndb, txn: &Transaction, pubkey: &[u8; 32]) -> Self {
+        Self {
+            relay: AccountRelayData::new(ndb, txn, pubkey),
+            muted: AccountMutedData::new(ndb, txn, pubkey),
+        }
+    }
+
     pub(super) fn poll_for_updates(
         &mut self,
         ndb: &Ndb,

--- a/crates/notedeck/src/account/accounts.rs
+++ b/crates/notedeck/src/account/accounts.rs
@@ -255,6 +255,13 @@ impl Accounts {
             ),
             relay_url,
         );
+        pool.send_to(
+            &ClientMessage::req(
+                self.subs.contacts.remote.clone(),
+                vec![data.contacts.filter.clone()],
+            ),
+            relay_url,
+        );
     }
 
     pub fn update(&mut self, ndb: &mut Ndb, pool: &mut RelayPool, ctx: &egui::Context) {

--- a/crates/notedeck/src/account/accounts.rs
+++ b/crates/notedeck/src/account/accounts.rs
@@ -1,7 +1,7 @@
 use uuid::Uuid;
 
 use crate::account::cache::AccountCache;
-use crate::account::contacts::Contacts;
+use crate::account::contacts::{ContactState, Contacts, UnreceivedState};
 use crate::account::mute::AccountMutedData;
 use crate::account::relay::{
     modify_advertised_relays, update_relay_configuration, AccountRelayData, RelayAction,
@@ -316,6 +316,28 @@ impl Accounts {
 
     pub fn get_subs(&self) -> &AccountSubs {
         &self.subs
+    }
+
+    pub fn handle_eose_tally(&mut self, pool: &RelayPool, eose_relay: &str) {
+        let ContactState::Unreceived(unknown_state) =
+            &mut self.get_selected_account_mut().data.contacts.state
+        else {
+            return;
+        };
+
+        let UnreceivedState::TallyEose(eose_tally) = unknown_state else {
+            return;
+        };
+
+        eose_tally.eose_from.insert(eose_relay.to_owned());
+        tracing::info!(
+            "Inserted {} in EOSE tally. have eose's from {} of {} relays",
+            eose_relay,
+            eose_tally.eose_from.len(),
+            pool.urls().len()
+        );
+
+        unknown_state.process(pool);
     }
 }
 

--- a/crates/notedeck/src/account/accounts.rs
+++ b/crates/notedeck/src/account/accounts.rs
@@ -1,6 +1,7 @@
 use uuid::Uuid;
 
 use crate::account::cache::AccountCache;
+use crate::account::contacts::Contacts;
 use crate::account::mute::AccountMutedData;
 use crate::account::relay::{
     modify_advertised_relays, update_relay_configuration, AccountRelayData, RelayAction,
@@ -373,6 +374,7 @@ fn get_acc_from_storage(
 pub struct AccountData {
     pub(crate) relay: AccountRelayData,
     pub(crate) muted: AccountMutedData,
+    pub contacts: Contacts,
 }
 
 impl AccountData {
@@ -380,6 +382,7 @@ impl AccountData {
         Self {
             relay: AccountRelayData::new(ndb, txn, pubkey),
             muted: AccountMutedData::new(ndb, txn, pubkey),
+            contacts: Contacts::new(ndb, txn, pubkey),
         }
     }
 
@@ -395,6 +398,8 @@ impl AccountData {
         }
 
         self.muted.poll_for_updates(ndb, &txn, subs.mute.local);
+        self.contacts
+            .poll_for_updates(ndb, &txn, subs.contacts.local);
 
         resp
     }
@@ -412,6 +417,7 @@ pub struct AddAccountResponse {
 pub(super) struct AccountSubs {
     relay: UnifiedSubscription,
     mute: UnifiedSubscription,
+    contacts: UnifiedSubscription,
 }
 
 impl AccountSubs {
@@ -425,9 +431,14 @@ impl AccountSubs {
     ) -> Self {
         let relay = subscribe(ndb, pool, &data.relay.filter);
         let mute = subscribe(ndb, pool, &data.muted.filter);
+        let contacts = subscribe(ndb, pool, &data.contacts.filter);
         update_relay_configuration(pool, relay_defaults, pk, &data.relay, wakeup);
 
-        Self { relay, mute }
+        Self {
+            relay,
+            mute,
+            contacts,
+        }
     }
 
     pub fn swap_to(
@@ -441,6 +452,7 @@ impl AccountSubs {
     ) {
         unsubscribe(ndb, pool, &self.relay);
         unsubscribe(ndb, pool, &self.mute);
+        unsubscribe(ndb, pool, &self.contacts);
 
         *self = AccountSubs::new(ndb, pool, relay_defaults, pk, new_selection_data, wakeup);
     }

--- a/crates/notedeck/src/account/contacts.rs
+++ b/crates/notedeck/src/account/contacts.rs
@@ -1,0 +1,188 @@
+use std::collections::{BTreeSet, HashSet};
+
+use enostr::{Pubkey, RelayPool};
+use nostrdb::{Filter, Ndb, Note, NoteKey, Subscription, Transaction};
+
+pub struct Contacts {
+    pub filter: Filter,
+    pub(super) state: ContactState,
+}
+
+pub enum ContactState {
+    Unreceived(UnreceivedState),
+    Received {
+        contacts: HashSet<Pubkey>,
+        note_key: NoteKey,
+    },
+}
+
+pub enum UnreceivedState {
+    TallyEose(EoseTally),
+    NoContacts,
+}
+
+#[derive(Default)]
+pub struct EoseTally {
+    pub(super) eose_from: BTreeSet<String>,
+}
+
+const EOSE_CONSENSUS_PERCENT: f32 = 0.6;
+
+impl EoseTally {
+    pub(super) fn reached_consensus(&mut self, pool: &RelayPool) -> bool {
+        let num_pool_urls = pool.urls().len();
+
+        let count_in_both = pool.urls().intersection(&self.eose_from).count();
+
+        let percent_eose = count_in_both as f32 / num_pool_urls as f32;
+
+        if percent_eose >= EOSE_CONSENSUS_PERCENT {
+            tracing::info!(
+                "Contacts: Got EOSEs from {}% of relays, which is geq than the minimum {}%.",
+                percent_eose * 100.0,
+                EOSE_CONSENSUS_PERCENT * 100.0,
+            );
+            return true;
+        }
+
+        false
+    }
+}
+
+impl UnreceivedState {
+    pub fn process(&mut self, pool: &RelayPool) {
+        let UnreceivedState::TallyEose(eose_tally) = self else {
+            return;
+        };
+
+        if eose_tally.reached_consensus(pool) {
+            *self = UnreceivedState::NoContacts;
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Debug, Clone, Copy)]
+pub enum IsFollowing {
+    /// We don't have the contact list, so we don't know
+    Unknown,
+
+    /// We are follow
+    Yes,
+
+    No,
+}
+
+impl Contacts {
+    pub fn new(ndb: &Ndb, txn: &Transaction, pubkey: &[u8; 32]) -> Self {
+        let filter = Filter::new().authors([pubkey]).kinds([3]).limit(1).build();
+
+        let binding = ndb
+            .query(txn, &[filter.clone()], 1)
+            .expect("query user relays results");
+
+        let res = binding.first();
+
+        let state = match res {
+            Some(res) => ContactState::Received {
+                contacts: get_contacts_owned(&res.note),
+                note_key: res.note_key,
+            },
+            None => ContactState::Unreceived(UnreceivedState::TallyEose(EoseTally::default())),
+        };
+
+        Self { filter, state }
+    }
+
+    pub fn is_following(&self, other: &Pubkey) -> IsFollowing {
+        match &self.state {
+            ContactState::Unreceived(unknown_state) => match unknown_state {
+                UnreceivedState::TallyEose(_) => IsFollowing::Unknown,
+                UnreceivedState::NoContacts => IsFollowing::No,
+            },
+            ContactState::Received {
+                contacts,
+                note_key: _,
+            } => {
+                if contacts.contains(other) {
+                    IsFollowing::Yes
+                } else {
+                    IsFollowing::No
+                }
+            }
+        }
+    }
+
+    pub(super) fn poll_for_updates(&mut self, ndb: &Ndb, txn: &Transaction, sub: Subscription) {
+        let nks = ndb.poll_for_notes(sub, 1);
+
+        let Some(key) = nks.first() else {
+            return;
+        };
+
+        let note = match ndb.get_note_by_key(txn, *key) {
+            Ok(note) => note,
+            Err(e) => {
+                tracing::error!("Could not find note at key {:?}: {e}", key);
+                return;
+            }
+        };
+
+        match &mut self.state {
+            ContactState::Unreceived(_) => {
+                self.state = ContactState::Received {
+                    contacts: get_contacts_owned(&note),
+                    note_key: *key,
+                };
+            }
+            ContactState::Received { contacts, note_key } => {
+                update_contacts(contacts, &note);
+                *note_key = *key;
+            }
+        }
+    }
+
+    pub fn get_state(&self) -> &ContactState {
+        &self.state
+    }
+}
+
+fn get_contacts<'a>(note: &Note<'a>) -> HashSet<&'a [u8; 32]> {
+    let mut contacts = HashSet::with_capacity(note.tags().count().into());
+
+    for tag in note.tags() {
+        if tag.count() < 2 {
+            continue;
+        }
+
+        let Some("p") = tag.get_str(0) else {
+            continue;
+        };
+
+        let Some(cur_id) = tag.get_id(1) else {
+            continue;
+        };
+
+        contacts.insert(cur_id);
+    }
+
+    contacts
+}
+
+fn get_contacts_owned(note: &Note<'_>) -> HashSet<Pubkey> {
+    get_contacts(note)
+        .iter()
+        .map(|p| Pubkey::new(**p))
+        .collect()
+}
+
+fn update_contacts(cur: &mut HashSet<Pubkey>, new: &Note<'_>) {
+    let new_contacts = get_contacts(new);
+
+    cur.retain(|pk| new_contacts.contains(pk.bytes()));
+
+    new_contacts.iter().for_each(|c| {
+        if !cur.contains(*c) {
+            cur.insert(Pubkey::new(**c));
+        }
+    });
+}

--- a/crates/notedeck/src/account/mod.rs
+++ b/crates/notedeck/src/account/mod.rs
@@ -1,5 +1,6 @@
 pub mod accounts;
 pub mod cache;
+pub mod contacts;
 pub mod mute;
 pub mod relay;
 

--- a/crates/notedeck/src/account/relay.rs
+++ b/crates/notedeck/src/account/relay.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use enostr::{Keypair, Pubkey, RelayPool};
-use nostrdb::{Filter, Ndb, NoteBuilder, NoteKey, Transaction};
+use nostrdb::{Filter, Ndb, NoteBuilder, NoteKey, Subscription, Transaction};
 use tracing::{debug, error, info};
 use url::Url;
 
@@ -106,6 +106,20 @@ impl AccountRelayData {
         let note = builder.sign(seckey).build().expect("note build");
         pool.send(&enostr::ClientMessage::event(&note).expect("note client message"));
     }
+
+    pub fn poll_for_updates(&mut self, ndb: &Ndb, txn: &Transaction, sub: Subscription) -> bool {
+        let nks = ndb.poll_for_notes(sub, 1);
+
+        if nks.is_empty() {
+            return false;
+        }
+
+        let relays = AccountRelayData::harvest_nip65_relays(ndb, txn, &nks);
+        debug!("updated relays {:?}", relays);
+        self.advertised = relays.into_iter().collect();
+
+        true
+    }
 }
 
 pub(crate) struct RelayDefaults {
@@ -142,7 +156,7 @@ pub(super) fn update_relay_configuration(
     pool: &mut RelayPool,
     relay_defaults: &RelayDefaults,
     pk: &Pubkey,
-    data: &AccountData,
+    data: &AccountRelayData,
     wakeup: impl Fn() + Send + Sync + Clone + 'static,
 ) {
     debug!(
@@ -155,8 +169,8 @@ pub(super) fn update_relay_configuration(
 
     // Compose the desired relay lists from the selected account
     if desired_relays.is_empty() {
-        desired_relays.extend(data.relay.local.iter().cloned());
-        desired_relays.extend(data.relay.advertised.iter().cloned());
+        desired_relays.extend(data.local.iter().cloned());
+        desired_relays.extend(data.advertised.iter().cloned());
     }
 
     // If no relays are specified at this point use the bootstrap list

--- a/crates/notedeck/src/lib.rs
+++ b/crates/notedeck/src/lib.rs
@@ -34,6 +34,7 @@ mod wallet;
 mod zaps;
 
 pub use account::accounts::{AccountData, Accounts};
+pub use account::contacts::{ContactState, IsFollowing, UnreceivedState};
 pub use account::relay::RelayAction;
 pub use account::FALLBACK_PUBKEY;
 pub use app::{App, AppAction, Notedeck};

--- a/crates/notedeck/src/lib.rs
+++ b/crates/notedeck/src/lib.rs
@@ -33,7 +33,7 @@ mod user_account;
 mod wallet;
 mod zaps;
 
-pub use account::accounts::{AccountData, Accounts};
+pub use account::accounts::{AccountData, AccountSubs, Accounts};
 pub use account::contacts::{ContactState, IsFollowing, UnreceivedState};
 pub use account::relay::RelayAction;
 pub use account::FALLBACK_PUBKEY;

--- a/crates/notedeck/src/user_account.rs
+++ b/crates/notedeck/src/user_account.rs
@@ -1,9 +1,9 @@
-use enostr::{Keypair, KeypairUnowned};
+use enostr::{Keypair, KeypairUnowned, Pubkey};
 use tokenator::{ParseError, TokenParser, TokenSerializable};
 
 use crate::{
     wallet::{WalletSerializable, ZapWallet},
-    AccountData,
+    AccountData, IsFollowing,
 };
 
 pub struct UserAccount {
@@ -31,6 +31,10 @@ impl UserAccount {
     pub fn with_wallet(mut self, wallet: ZapWallet) -> Self {
         self.wallet = Some(wallet);
         self
+    }
+
+    pub fn is_following(&self, pk: &Pubkey) -> IsFollowing {
+        self.data.contacts.is_following(pk)
     }
 }
 

--- a/crates/notedeck_columns/src/app.rs
+++ b/crates/notedeck_columns/src/app.rs
@@ -8,13 +8,15 @@ use crate::{
     storage,
     subscriptions::{SubKind, Subscriptions},
     support::Support,
-    timeline::{self, thread::Threads, TimelineCache},
+    timeline::{
+        self, fetch_contact_list, kind::ListKind, thread::Threads, TimelineCache, TimelineKind,
+    },
     ui::{self, DesktopSidePanel},
     view_state::ViewState,
     Result,
 };
 
-use notedeck::{Accounts, AppAction, AppContext, DataPath, DataPathType, FilterState, UnknownIds};
+use notedeck::{Accounts, AppAction, AppContext, DataPath, DataPathType, UnknownIds};
 use notedeck_ui::{jobs::JobsCache, NoteOptions};
 
 use enostr::{ClientMessage, PoolRelay, Pubkey, RelayEvent, RelayMessage, RelayPool};
@@ -114,13 +116,21 @@ fn try_process_event(
                     .accounts
                     .send_initial_filters(app_ctx.pool, &ev.relay);
 
+                let data = app_ctx.accounts.get_subs();
+                damus.subscriptions.subs.insert(
+                    data.contacts.remote.clone(),
+                    SubKind::FetchingContactList(TimelineKind::List(ListKind::Contact(
+                        *app_ctx.accounts.selected_account_pubkey(),
+                    ))),
+                );
+
                 timeline::send_initial_timeline_filters(
-                    app_ctx.ndb,
                     damus.since_optimize,
                     &mut damus.timeline_cache,
                     &mut damus.subscriptions,
                     app_ctx.pool,
                     &ev.relay,
+                    app_ctx.accounts,
                 );
             }
             // TODO: handle reconnects
@@ -246,44 +256,13 @@ fn handle_eose(
         }
 
         SubKind::FetchingContactList(timeline_uid) => {
-            let timeline = if let Some(tl) = timeline_cache.timelines.get_mut(timeline_uid) {
-                tl
-            } else {
-                error!(
-                    "timeline uid:{} not found for FetchingContactList",
-                    timeline_uid
-                );
+            ctx.accounts.handle_eose_tally(ctx.pool, relay_url);
+
+            let Some(timeline) = timeline_cache.timelines.get_mut(timeline_uid) else {
                 return Ok(());
             };
 
-            let filter_state = timeline.filter.get_mut(relay_url);
-
-            // If this request was fetching a contact list, our filter
-            // state should be "FetchingRemote". We look at the local
-            // subscription for that filter state and get the subscription id
-            let local_sub = if let FilterState::FetchingRemote(unisub) = filter_state {
-                unisub.local
-            } else {
-                // TODO: we could have multiple contact list results, we need
-                // to check to see if this one is newer and use that instead
-                warn!(
-                    "Expected timeline to have FetchingRemote state but was {:?}",
-                    timeline.filter
-                );
-                return Ok(());
-            };
-
-            info!(
-                "got contact list from {}, updating filter_state to got_remote",
-                relay_url
-            );
-
-            // We take the subscription id and pass it to the new state of
-            // "GotRemote". This will let future frames know that it can try
-            // to look for the contact list in nostrdb.
-            timeline
-                .filter
-                .set_relay_state(relay_url.to_string(), FilterState::got_remote(local_sub));
+            fetch_contact_list(relay_url, timeline, ctx.accounts);
         }
     }
 
@@ -694,7 +673,13 @@ fn timelines_view(
     let mut save_cols = false;
     if let Some(action) = side_panel_action {
         save_cols = save_cols
-            || action.process(&mut app.timeline_cache, &mut app.decks_cache, ctx, ui.ctx());
+            || action.process(
+                &mut app.timeline_cache,
+                &mut app.decks_cache,
+                &mut app.subscriptions,
+                ctx,
+                ui.ctx(),
+            );
     }
 
     let mut app_action: Option<AppAction> = None;

--- a/crates/notedeck_columns/src/nav.rs
+++ b/crates/notedeck_columns/src/nav.rs
@@ -404,6 +404,7 @@ fn process_render_nav_action(
             &mut app.view_state.pubkey_to_profile_state,
             ctx.ndb,
             ctx.pool,
+            ctx.accounts,
         ),
         RenderNavAction::WalletAction(wallet_action) => {
             wallet_action.process(ctx.accounts, ctx.global_wallet)

--- a/crates/notedeck_columns/src/nav.rs
+++ b/crates/notedeck_columns/src/nav.rs
@@ -7,9 +7,11 @@ use crate::{
     profile::{ProfileAction, SaveProfileChanges},
     profile_state::ProfileState,
     route::{Route, Router, SingletonRouter},
+    subscriptions::{SubKind, Subscriptions},
     timeline::{
+        kind::ListKind,
         route::{render_thread_route, render_timeline_route},
-        TimelineCache,
+        TimelineCache, TimelineKind,
     },
     ui::{
         self,
@@ -72,6 +74,7 @@ impl SwitchingAction {
         &self,
         timeline_cache: &mut TimelineCache,
         decks_cache: &mut DecksCache,
+        subs: &mut Subscriptions,
         ctx: &mut AppContext<'_>,
         ui_ctx: &egui::Context,
     ) -> bool {
@@ -84,6 +87,16 @@ impl SwitchingAction {
                         ctx.pool,
                         ui_ctx,
                     );
+
+                    let new_subs = ctx.accounts.get_subs();
+
+                    subs.subs.insert(
+                        new_subs.contacts.remote.clone(),
+                        SubKind::FetchingContactList(TimelineKind::List(ListKind::Contact(
+                            *ctx.accounts.selected_account_pubkey(),
+                        ))),
+                    );
+
                     // pop nav after switch
                     get_active_columns_mut(ctx.accounts, decks_cache)
                         .column_mut(switch_action.source_column)
@@ -378,6 +391,7 @@ fn process_render_nav_action(
             if switching_action.process(
                 &mut app.timeline_cache,
                 &mut app.decks_cache,
+                &mut app.subscriptions,
                 ctx,
                 ui.ctx(),
             ) {

--- a/crates/notedeck_columns/src/profile.rs
+++ b/crates/notedeck_columns/src/profile.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
 use enostr::{FullKeypair, Pubkey, RelayPool};
-use nostrdb::{Ndb, Note, NoteBuildOptions, NoteBuilder};
+use nostrdb::{Ndb, Note, NoteBuildOptions, NoteBuilder, Transaction};
 
+use notedeck::{Accounts, ContactState};
 use tracing::info;
 
 use crate::{nav::RouterAction, profile_state::ProfileState, route::Route};
@@ -64,6 +65,24 @@ impl ProfileAction {
             }
         }
     }
+
+    fn send_follow_user_event(
+        ndb: &Ndb,
+        pool: &mut RelayPool,
+        accounts: &Accounts,
+        target_key: &Pubkey,
+    ) {
+        send_kind_3_event(ndb, pool, accounts, FollowAction::Follow(target_key));
+    }
+
+    fn send_unfollow_user_event(
+        ndb: &Ndb,
+        pool: &mut RelayPool,
+        accounts: &Accounts,
+        target_key: &Pubkey,
+    ) {
+        send_kind_3_event(ndb, pool, accounts, FollowAction::Unfollow(target_key));
+    }
 }
 
 pub fn builder_from_note<F>(note: Note<'_>, skip_tag: Option<F>) -> NoteBuilder<'_>
@@ -94,4 +113,94 @@ where
     }
 
     builder
+}
+
+enum FollowAction<'a> {
+    Follow(&'a Pubkey),
+    Unfollow(&'a Pubkey),
+}
+
+fn send_kind_3_event(ndb: &Ndb, pool: &mut RelayPool, accounts: &Accounts, action: FollowAction) {
+    let Some(secretkey) = accounts.get_selected_account().keypair().secret_key else {
+        return;
+    };
+
+    let txn = Transaction::new(ndb).expect("txn");
+    let builder = match accounts.get_selected_account().data.contacts.get_state() {
+        ContactState::Unreceived(unknown_state) => match unknown_state {
+            notedeck::UnreceivedState::TallyEose(_) => {
+                return;
+            }
+            notedeck::UnreceivedState::NoContacts => match action {
+                FollowAction::Follow(pubkey) => NoteBuilder::new()
+                    .content("")
+                    .kind(3)
+                    .options(NoteBuildOptions::default())
+                    .start_tag()
+                    .tag_str("p")
+                    .tag_str(&pubkey.hex()),
+                FollowAction::Unfollow(_) => {
+                    return;
+                }
+            },
+        },
+        ContactState::Received {
+            contacts: _,
+            note_key,
+        } => {
+            let contact_note = match ndb.get_note_by_key(&txn, *note_key).ok() {
+                Some(n) => n,
+                None => {
+                    tracing::error!("Somehow we are in state ContactState::Received but the contact note key doesn't exist");
+                    return;
+                }
+            };
+
+            if contact_note.kind() != 3 {
+                tracing::error!("Something very wrong just occured. The key for the supposed contact note yielded a note which was not a contact...");
+                return;
+            }
+
+            match action {
+                FollowAction::Follow(pubkey) => {
+                    builder_from_note(contact_note, None::<fn(&nostrdb::Tag<'_>) -> bool>)
+                        .start_tag()
+                        .tag_str("p")
+                        .tag_str(&pubkey.hex())
+                }
+                FollowAction::Unfollow(pubkey) => builder_from_note(
+                    contact_note,
+                    Some(|tag: &nostrdb::Tag<'_>| {
+                        if tag.count() < 2 {
+                            return false;
+                        }
+
+                        let Some("p") = tag.get_str(0) else {
+                            return false;
+                        };
+
+                        let Some(cur_val) = tag.get_id(1) else {
+                            return false;
+                        };
+
+                        cur_val == pubkey.bytes()
+                    }),
+                ),
+            }
+        }
+    };
+
+    let note = builder
+        .sign(&secretkey.to_secret_bytes())
+        .build()
+        .expect("build note");
+
+    let raw_msg = format!("[\"EVENT\",{}]", note.json().unwrap());
+
+    let _ = ndb.process_event_with(
+        raw_msg.as_str(),
+        nostrdb::IngestMetadata::new().client(true),
+    );
+    info!("sending {}", raw_msg);
+    pool.send(&enostr::ClientMessage::raw(raw_msg));
 }

--- a/crates/notedeck_columns/src/timeline/mod.rs
+++ b/crates/notedeck_columns/src/timeline/mod.rs
@@ -7,7 +7,8 @@ use crate::{
 };
 
 use notedeck::{
-    filter, CachedNote, FilterError, FilterState, FilterStates, NoteCache, NoteRef, UnknownIds,
+    filter, Accounts, CachedNote, FilterError, FilterState, FilterStates, NoteCache, NoteRef,
+    UnknownIds,
 };
 
 use egui_virtual_list::VirtualList;
@@ -474,6 +475,7 @@ pub fn setup_new_timeline(
     pool: &mut RelayPool,
     note_cache: &mut NoteCache,
     since_optimize: bool,
+    accounts: &Accounts,
 ) {
     // if we're ready, setup local subs
     if is_timeline_ready(ndb, pool, note_cache, timeline) {
@@ -483,7 +485,7 @@ pub fn setup_new_timeline(
     }
 
     for relay in &mut pool.relays {
-        send_initial_timeline_filter(ndb, since_optimize, subs, relay, timeline);
+        send_initial_timeline_filter(since_optimize, subs, relay, timeline, accounts);
     }
 }
 
@@ -492,29 +494,29 @@ pub fn setup_new_timeline(
 /// situations where you are adding a new timeline, use
 /// setup_new_timeline.
 pub fn send_initial_timeline_filters(
-    ndb: &Ndb,
     since_optimize: bool,
     timeline_cache: &mut TimelineCache,
     subs: &mut Subscriptions,
     pool: &mut RelayPool,
     relay_id: &str,
+    accounts: &Accounts,
 ) -> Option<()> {
     info!("Sending initial filters to {}", relay_id);
     let relay = &mut pool.relays.iter_mut().find(|r| r.url() == relay_id)?;
 
     for (_kind, timeline) in timeline_cache.timelines.iter_mut() {
-        send_initial_timeline_filter(ndb, since_optimize, subs, relay, timeline);
+        send_initial_timeline_filter(since_optimize, subs, relay, timeline, accounts);
     }
 
     Some(())
 }
 
 pub fn send_initial_timeline_filter(
-    ndb: &Ndb,
     can_since_optimize: bool,
     subs: &mut Subscriptions,
     relay: &mut PoolRelay,
     timeline: &mut Timeline,
+    accounts: &Accounts,
 ) {
     let filter_state = timeline.filter.get_mut(relay.url());
 
@@ -572,34 +574,30 @@ pub fn send_initial_timeline_filter(
         }
 
         // we need some data first
-        FilterState::NeedsRemote(filter) => {
-            fetch_contact_list(filter.to_owned(), ndb, subs, relay, timeline)
-        }
+        FilterState::NeedsRemote(_filter) => fetch_contact_list(relay.url(), timeline, accounts),
     }
 }
 
-fn fetch_contact_list(
-    filter: Vec<Filter>,
-    ndb: &Ndb,
-    subs: &mut Subscriptions,
-    relay: &mut PoolRelay,
-    timeline: &mut Timeline,
-) {
-    let sub_kind = SubKind::FetchingContactList(timeline.kind.clone());
-    let sub_id = subscriptions::new_sub_id();
-    let local_sub = ndb.subscribe(&filter).expect("sub");
+pub fn fetch_contact_list(relay_url: &str, timeline: &mut Timeline, accounts: &Accounts) {
+    let account_subs = accounts.get_subs();
+    let local = account_subs.contacts.local;
 
-    timeline.filter.set_relay_state(
-        relay.url().to_string(),
-        FilterState::fetching_remote(sub_id.clone(), local_sub),
-    );
+    let filter_state = match accounts.get_selected_account().data.contacts.get_state() {
+        notedeck::ContactState::Unreceived(unk) => match unk {
+            notedeck::UnreceivedState::TallyEose(_) => {
+                FilterState::fetching_remote(account_subs.contacts.remote.clone(), local)
+            }
+            notedeck::UnreceivedState::NoContacts => FilterState::GotRemote(local),
+        },
+        notedeck::ContactState::Received {
+            contacts: _,
+            note_key: _,
+        } => FilterState::GotRemote(local),
+    };
 
-    subs.subs.insert(sub_id.clone(), sub_kind);
-
-    info!("fetching contact list from {}", relay.url());
-    if let Err(err) = relay.subscribe(sub_id, filter) {
-        error!("error subscribing: {err}");
-    }
+    timeline
+        .filter
+        .set_relay_state(relay_url.to_owned(), filter_state);
 }
 
 fn setup_initial_timeline(

--- a/crates/notedeck_columns/src/timeline/route.rs
+++ b/crates/notedeck_columns/src/timeline/route.rs
@@ -116,7 +116,7 @@ pub fn render_profile_route(
     note_context: &mut NoteContext,
     jobs: &mut JobsCache,
 ) -> Option<RenderNavAction> {
-    let action = ProfileView::new(
+    let profile_view = ProfileView::new(
         pubkey,
         accounts,
         col,
@@ -128,7 +128,7 @@ pub fn render_profile_route(
     )
     .ui(ui);
 
-    if let Some(action) = action {
+    if let Some(action) = profile_view {
         match action {
             ui::profile::ProfileViewAction::EditProfile => accounts
                 .get_full(pubkey)
@@ -136,6 +136,12 @@ pub fn render_profile_route(
             ui::profile::ProfileViewAction::Note(note_action) => {
                 Some(RenderNavAction::NoteAction(note_action))
             }
+            ui::profile::ProfileViewAction::Follow(target_key) => Some(
+                RenderNavAction::ProfileAction(ProfileAction::Follow(target_key)),
+            ),
+            ui::profile::ProfileViewAction::Unfollow(target_key) => Some(
+                RenderNavAction::ProfileAction(ProfileAction::Unfollow(target_key)),
+            ),
         }
     } else {
         None

--- a/crates/notedeck_columns/src/ui/add_column.rs
+++ b/crates/notedeck_columns/src/ui/add_column.rs
@@ -622,6 +622,7 @@ pub fn render_add_column_routes(
                     ctx.pool,
                     ctx.note_cache,
                     app.since_optimize,
+                    ctx.accounts,
                 );
 
                 app.columns_mut(ctx.accounts)
@@ -663,6 +664,7 @@ pub fn render_add_column_routes(
                             ctx.pool,
                             ctx.note_cache,
                             app.since_optimize,
+                            ctx.accounts,
                         );
 
                         app.columns_mut(ctx.accounts)

--- a/crates/notedeck_columns/src/ui/note/custom_zap.rs
+++ b/crates/notedeck_columns/src/ui/note/custom_zap.rs
@@ -9,9 +9,10 @@ use nostrdb::{Ndb, ProfileRecord, Transaction};
 use notedeck::{
     fonts::get_font_size, get_profile_url, name::get_display_name, Images, NotedeckTextStyle,
 };
-use notedeck_ui::{app_images, colors, profile::display_name_widget, AnimationHelper, ProfilePic};
-
-use crate::ui::widgets::styled_button_toggleable;
+use notedeck_ui::{
+    app_images, colors, profile::display_name_widget, widgets::styled_button_toggleable,
+    AnimationHelper, ProfilePic,
+};
 
 pub struct CustomZapView<'a> {
     images: &'a mut Images,

--- a/crates/notedeck_columns/src/ui/profile/mod.rs
+++ b/crates/notedeck_columns/src/ui/profile/mod.rs
@@ -4,6 +4,7 @@ pub use edit::EditProfileView;
 use egui::{vec2, Color32, CornerRadius, Layout, Rect, RichText, ScrollArea, Sense, Stroke};
 use enostr::Pubkey;
 use nostrdb::{ProfileRecord, Transaction};
+use notedeck_ui::profile::follow_button;
 use tracing::error;
 
 use crate::{
@@ -11,8 +12,8 @@ use crate::{
     ui::timeline::{tabs_ui, TimelineTabView},
 };
 use notedeck::{
-    name::get_display_name, profile::get_profile_url, Accounts, MuteFun, NoteAction, NoteContext,
-    NotedeckTextStyle,
+    name::get_display_name, profile::get_profile_url, Accounts, IsFollowing, MuteFun, NoteAction,
+    NoteContext, NotedeckTextStyle,
 };
 use notedeck_ui::{
     app_images,
@@ -81,8 +82,8 @@ impl<'a, 'd> ProfileView<'a, 'd> {
                 .ndb
                 .get_profile_by_pubkey(&txn, self.pubkey.bytes())
             {
-                if self.profile_body(ui, profile) {
-                    action = Some(ProfileViewAction::EditProfile);
+                if let Some(profile_view_action) = self.profile_body(ui, profile) {
+                    action = Some(profile_view_action);
                 }
             }
             let profile_timeline = self
@@ -133,8 +134,12 @@ impl<'a, 'd> ProfileView<'a, 'd> {
         output.inner
     }
 
-    fn profile_body(&mut self, ui: &mut egui::Ui, profile: ProfileRecord<'_>) -> bool {
-        let mut action = false;
+    fn profile_body(
+        &mut self,
+        ui: &mut egui::Ui,
+        profile: ProfileRecord<'_>,
+    ) -> Option<ProfileViewAction> {
+        let mut action = None;
         ui.vertical(|ui| {
             banner(
                 ui,
@@ -171,13 +176,49 @@ impl<'a, 'd> ProfileView<'a, 'd> {
                         ui.ctx().copy_text(to_copy)
                     }
 
-                    if self.accounts.contains_full_kp(self.pubkey) {
-                        ui.with_layout(Layout::right_to_left(egui::Align::Max), |ui| {
-                            if ui.add(edit_profile_button()).clicked() {
-                                action = true;
+                    ui.with_layout(Layout::right_to_left(egui::Align::RIGHT), |ui| {
+                        ui.add_space(24.0);
+
+                        let target_key = self.pubkey;
+                        let selected = self.accounts.get_selected_account();
+
+                        let profile_type = if selected.key.secret_key.is_none() {
+                            ProfileType::ReadOnly
+                        } else if &selected.key.pubkey == self.pubkey {
+                            ProfileType::MyProfile
+                        } else {
+                            ProfileType::Followable(selected.is_following(target_key))
+                        };
+
+                        match profile_type {
+                            ProfileType::MyProfile => {
+                                if ui.add(edit_profile_button()).clicked() {
+                                    action = Some(ProfileViewAction::EditProfile);
+                                }
                             }
-                        });
-                    }
+                            ProfileType::Followable(is_following) => {
+                                let follow_button = ui.add(follow_button(is_following));
+
+                                if follow_button.clicked() {
+                                    action = match is_following {
+                                        IsFollowing::Unknown => {
+                                            // don't do anything, we don't have contact list
+                                            None
+                                        }
+
+                                        IsFollowing::Yes => {
+                                            Some(ProfileViewAction::Unfollow(target_key.to_owned()))
+                                        }
+
+                                        IsFollowing::No => {
+                                            Some(ProfileViewAction::Follow(target_key.to_owned()))
+                                        }
+                                    };
+                                }
+                            }
+                            ProfileType::ReadOnly => {}
+                        }
+                    });
                 });
 
                 ui.add_space(18.0);
@@ -215,6 +256,12 @@ impl<'a, 'd> ProfileView<'a, 'd> {
 
         action
     }
+}
+
+enum ProfileType {
+    MyProfile,
+    ReadOnly,
+    Followable(IsFollowing),
 }
 
 fn handle_link(ui: &mut egui::Ui, website_url: &str) {

--- a/crates/notedeck_columns/src/ui/profile/mod.rs
+++ b/crates/notedeck_columns/src/ui/profile/mod.rs
@@ -35,6 +35,8 @@ pub struct ProfileView<'a, 'd> {
 pub enum ProfileViewAction {
     EditProfile,
     Note(NoteAction),
+    Unfollow(Pubkey),
+    Follow(Pubkey),
 }
 
 impl<'a, 'd> ProfileView<'a, 'd> {

--- a/crates/notedeck_columns/src/ui/widgets.rs
+++ b/crates/notedeck_columns/src/ui/widgets.rs
@@ -1,49 +1,7 @@
-use egui::{Button, Widget};
-use notedeck::NotedeckTextStyle;
+use egui::Widget;
+use notedeck_ui::widgets::styled_button_toggleable;
 
 /// Sized and styled to match the figma design
 pub fn styled_button(text: &str, fill_color: egui::Color32) -> impl Widget + '_ {
     styled_button_toggleable(text, fill_color, true)
-}
-
-pub fn styled_button_toggleable(
-    text: &str,
-    fill_color: egui::Color32,
-    enabled: bool,
-) -> impl Widget + '_ {
-    move |ui: &mut egui::Ui| -> egui::Response {
-        let painter = ui.painter();
-        let text_color = if ui.visuals().dark_mode {
-            egui::Color32::WHITE
-        } else {
-            egui::Color32::BLACK
-        };
-
-        let galley = painter.layout(
-            text.to_owned(),
-            NotedeckTextStyle::Body.get_font_id(ui.ctx()),
-            text_color,
-            ui.available_width(),
-        );
-
-        let size = galley.rect.expand2(egui::vec2(16.0, 8.0)).size();
-        let mut button = Button::new(galley).corner_radius(8.0);
-
-        if !enabled {
-            button = button
-                .sense(egui::Sense::focusable_noninteractive())
-                .fill(ui.visuals().noninteractive().bg_fill)
-                .stroke(ui.visuals().noninteractive().bg_stroke);
-        } else {
-            button = button.fill(fill_color);
-        }
-
-        let mut resp = ui.add_sized(size, button);
-
-        if !enabled {
-            resp = resp.on_hover_cursor(egui::CursorIcon::NotAllowed);
-        }
-
-        resp
-    }
 }

--- a/crates/notedeck_ui/src/profile/mod.rs
+++ b/crates/notedeck_ui/src/profile/mod.rs
@@ -8,9 +8,9 @@ pub use picture::ProfilePic;
 pub use preview::ProfilePreview;
 
 use egui::{load::TexturePoll, Label, RichText};
-use notedeck::{NostrName, NotedeckTextStyle};
+use notedeck::{IsFollowing, NostrName, NotedeckTextStyle};
 
-use crate::app_images;
+use crate::{app_images, colors, widgets::styled_button_toggleable};
 
 pub fn display_name_widget<'a>(
     name: &'a NostrName<'a>,
@@ -114,4 +114,17 @@ pub fn banner(ui: &mut egui::Ui, banner_url: Option<&str>, height: f32) -> egui:
             })
             .unwrap_or_else(|| ui.label(""))
     })
+}
+
+pub fn follow_button(following: IsFollowing) -> impl egui::Widget + 'static {
+    move |ui: &mut egui::Ui| -> egui::Response {
+        let (bg_color, text) = match following {
+            IsFollowing::Unknown => (ui.visuals().noninteractive().bg_fill, "Unknown"),
+            IsFollowing::Yes => (ui.visuals().widgets.inactive.bg_fill, "Unfollow"),
+            IsFollowing::No => (colors::PINK, "Follow"),
+        };
+
+        let enabled = following != IsFollowing::Unknown;
+        ui.add(styled_button_toggleable(text, bg_color, enabled))
+    }
 }

--- a/crates/notedeck_ui/src/widgets.rs
+++ b/crates/notedeck_ui/src/widgets.rs
@@ -1,5 +1,6 @@
 use crate::anim::{AnimationHelper, ICON_EXPANSION_MULTIPLE};
 use egui::{emath::GuiRounding, Pos2, Stroke};
+use notedeck::NotedeckTextStyle;
 
 pub fn x_button(rect: egui::Rect) -> impl egui::Widget {
     move |ui: &mut egui::Ui| -> egui::Response {
@@ -31,5 +32,48 @@ pub fn x_button(rect: egui::Rect) -> impl egui::Widget {
         painter.line_segment([ne_edge, sw_edge], Stroke::new(line_width, fill_color));
 
         helper.take_animation_response()
+    }
+}
+
+/// Button styled in the Notedeck theme
+pub fn styled_button_toggleable(
+    text: &str,
+    fill_color: egui::Color32,
+    enabled: bool,
+) -> impl egui::Widget + '_ {
+    move |ui: &mut egui::Ui| -> egui::Response {
+        let painter = ui.painter();
+        let text_color = if ui.visuals().dark_mode {
+            egui::Color32::WHITE
+        } else {
+            egui::Color32::BLACK
+        };
+
+        let galley = painter.layout(
+            text.to_owned(),
+            NotedeckTextStyle::Button.get_font_id(ui.ctx()),
+            text_color,
+            ui.available_width(),
+        );
+
+        let size = galley.rect.expand2(egui::vec2(16.0, 8.0)).size();
+        let mut button = egui::Button::new(galley).corner_radius(8.0);
+
+        if !enabled {
+            button = button
+                .sense(egui::Sense::focusable_noninteractive())
+                .fill(ui.visuals().noninteractive().bg_fill)
+                .stroke(ui.visuals().noninteractive().bg_stroke);
+        } else {
+            button = button.fill(fill_color);
+        }
+
+        let mut resp = ui.add_sized(size, button);
+
+        if !enabled {
+            resp = resp.on_hover_cursor(egui::CursorIcon::NotAllowed);
+        }
+
+        resp
     }
 }


### PR DESCRIPTION
adds functionality to follow/unfollow via profile view

there is a consensus mechanism to determine whether a user has never made a contact list before. This is because sometimes relays are unresponsive so we check if >= 60% of them have returned an EOSE and ndb still has no results then we reach the `UnreceivedState::NoContacts` state.

Also, timelines which need the contacts subscription use the same one in `AccountSubs`. The state changes for `FilterStates` should occur as before