### PR TITLE
Unify contact sub

### DIFF
--- a/crates/notedeck/src/filter.rs
+++ b/crates/notedeck/src/filter.rs
@@ -92,7 +92,7 @@ impl FilterStates {
 /// [`FilterState`] tracks this.
 #[derive(Debug, Clone)]
 pub enum FilterState {
-    NeedsRemote(Vec<Filter>),
+    NeedsRemote,
     FetchingRemote(FetchingRemoteType),
     GotRemote(GotRemoteType),
     Ready(Vec<Filter>),
@@ -139,8 +139,8 @@ impl FilterState {
     /// for home timelines where we don't have a contact list yet. We
     /// need to fetch the contact list before we have the right timeline
     /// filter.
-    pub fn needs_remote(filter: Vec<Filter>) -> Self {
-        Self::NeedsRemote(filter)
+    pub fn needs_remote() -> Self {
+        Self::NeedsRemote
     }
 
     /// We got the remote data. Local data should be available to build

--- a/crates/notedeck_columns/src/timeline/mod.rs
+++ b/crates/notedeck_columns/src/timeline/mod.rs
@@ -574,7 +574,7 @@ pub fn send_initial_timeline_filter(
         }
 
         // we need some data first
-        FilterState::NeedsRemote(_) => fetch_contact_list(subs, relay, timeline, accounts),
+        FilterState::NeedsRemote => fetch_contact_list(subs, relay, timeline, accounts),
     }
 }
 

--- a/crates/notedeck_columns/src/ui/add_column.rs
+++ b/crates/notedeck_columns/src/ui/add_column.rs
@@ -623,6 +623,7 @@ pub fn render_add_column_routes(
                     ctx.pool,
                     ctx.note_cache,
                     app.since_optimize,
+                    ctx.accounts,
                 );
 
                 app.columns_mut(ctx.accounts)
@@ -664,6 +665,7 @@ pub fn render_add_column_routes(
                             ctx.pool,
                             ctx.note_cache,
                             app.since_optimize,
+                            ctx.accounts,
                         );
 
                         app.columns_mut(ctx.accounts)


### PR DESCRIPTION
use the `AccountSubs` remote contact sub for timelines instead of having one for accounts and one for every timeline which needed it