### PR TITLE
feat(chrome): add hover text and pointer cursor sidebar elements

### DIFF
--- a/crates/notedeck_columns/src/ui/post.rs
+++ b/crates/notedeck_columns/src/ui/post.rs
@@ -45,11 +45,13 @@ pub fn compose_note_button(dark_mode: bool) -> impl Widget {
             [west_edge, east_edge],
             Stroke::new(use_line_width, icon_color),
         );
-        painter.circle_filled(north_edge, use_edge_circle_radius, Color32::WHITE);
-        painter.circle_filled(south_edge, use_edge_circle_radius, Color32::WHITE);
-        painter.circle_filled(west_edge, use_edge_circle_radius, Color32::WHITE);
-        painter.circle_filled(east_edge, use_edge_circle_radius, Color32::WHITE);
+        painter.circle_filled(north_edge, use_edge_circle_radius, icon_color);
+        painter.circle_filled(south_edge, use_edge_circle_radius, icon_color);
+        painter.circle_filled(west_edge, use_edge_circle_radius, icon_color);
+        painter.circle_filled(east_edge, use_edge_circle_radius, icon_color);
 
-        helper.take_animation_response()
+        helper
+            .take_animation_response()
+            .on_hover_text("Compose new note")
     }
 }

--- a/crates/notedeck_columns/src/ui/side_panel.rs
+++ b/crates/notedeck_columns/src/ui/side_panel.rs
@@ -1,4 +1,7 @@
-use egui::{vec2, InnerResponse, Layout, Margin, RichText, ScrollArea, Separator, Stroke, Widget};
+use egui::{
+    vec2, CursorIcon, InnerResponse, Layout, Margin, RichText, ScrollArea, Separator, Stroke,
+    Widget,
+};
 use tracing::{error, info};
 
 use crate::{
@@ -312,7 +315,10 @@ fn add_column_button() -> impl Widget {
                 .shrink((max_size - cur_img_size) / 2.0),
         );
 
-        helper.take_animation_response()
+        helper
+            .take_animation_response()
+            .on_hover_cursor(CursorIcon::PointingHand)
+            .on_hover_text("Add new column")
     }
 }
 
@@ -354,7 +360,10 @@ pub fn search_button() -> impl Widget {
             circle_stroke,
         );
 
-        helper.take_animation_response()
+        helper
+            .take_animation_response()
+            .on_hover_cursor(CursorIcon::PointingHand)
+            .on_hover_text("Open search")
     }
 }
 
@@ -377,7 +386,10 @@ fn add_deck_button() -> impl Widget {
                 .shrink((max_size - cur_img_size) / 2.0),
         );
 
-        helper.take_animation_response()
+        helper
+            .take_animation_response()
+            .on_hover_cursor(CursorIcon::PointingHand)
+            .on_hover_text("Add new deck")
     }
 }
 
@@ -406,7 +418,8 @@ fn show_decks<'a>(
                 40.0,
                 highlight,
             ))
-            .on_hover_text_at_pointer(&deck.name);
+            .on_hover_text_at_pointer(&deck.name)
+            .on_hover_cursor(CursorIcon::PointingHand);
         if deck_icon_resp.clicked() || deck_icon_resp.secondary_clicked() {
             clicked_index = Some(index);
         }


### PR DESCRIPTION
old:
<img width="270" height="176" alt="imagen" src="https://github.com/user-attachments/assets/b1b87a83-6824-4fd8-ac61-9a87691322be" />

new:
<img width="258" height="207" alt="imagen" src="https://github.com/user-attachments/assets/ee02d278-6879-46a7-a504-b732db9d8f15" />
