### PR TITLE
feat(profile-view): split profile info entries when is_narrow

### DIFF
--- a/crates/notedeck_columns/src/app.rs
+++ b/crates/notedeck_columns/src/app.rs
@@ -180,6 +180,10 @@ fn unknown_id_send(unknown_ids: &mut UnknownIds, pool: &mut RelayPool) {
 fn update_damus(damus: &mut Damus, app_ctx: &mut AppContext<'_>, ctx: &egui::Context) {
     app_ctx.img_cache.urls.cache.handle_io();
 
+    if damus.columns(app_ctx.accounts).columns().is_empty() {
+        damus.columns_mut(app_ctx.accounts).new_column_picker();
+    }
+
     match damus.state {
         DamusState::Initializing => {
             damus.state = DamusState::Initialized;

--- a/crates/notedeck_columns/src/ui/profile/mod.rs
+++ b/crates/notedeck_columns/src/ui/profile/mod.rs
@@ -12,8 +12,8 @@ use crate::{
     ui::timeline::{tabs_ui, TimelineTabView},
 };
 use notedeck::{
-    name::get_display_name, profile::get_profile_url, ui::is_narrow, Accounts, IsFollowing,
-    MuteFun, NoteAction, NoteContext, NotedeckTextStyle,
+    name::get_display_name, profile::get_profile_url, Accounts, IsFollowing, MuteFun, NoteAction,
+    NoteContext, NotedeckTextStyle,
 };
 use notedeck_ui::{
     app_images,
@@ -246,7 +246,7 @@ impl<'a, 'd> ProfileView<'a, 'd> {
                     }
 
                     if let Some(lud16) = lud16 {
-                        if is_narrow(ui.ctx()) && website_url.is_some() {
+                        if website_url.is_some() {
                             ui.end_row();
                         }
                         ui.horizontal(|ui| {

--- a/crates/notedeck_columns/src/ui/profile/mod.rs
+++ b/crates/notedeck_columns/src/ui/profile/mod.rs
@@ -304,11 +304,13 @@ fn copy_key_widget(pfp_rect: &egui::Rect) -> impl egui::Widget + '_ {
             pfp_rect.center_bottom(),
             egui::vec2(48.0, 28.0),
         ));
-        let resp = ui.interact(
-            copy_key_rect,
-            ui.id().with("custom_painter"),
-            Sense::click(),
-        );
+        let resp = ui
+            .interact(
+                copy_key_rect,
+                ui.id().with("custom_painter"),
+                Sense::click(),
+            )
+            .on_hover_text("Copy npub to clipboard");
 
         let copy_key_rounding = CornerRadius::same(100);
         let fill_color = if resp.hovered() {

--- a/crates/notedeck_ui/src/profile/mod.rs
+++ b/crates/notedeck_ui/src/profile/mod.rs
@@ -8,7 +8,7 @@ pub use picture::ProfilePic;
 pub use preview::ProfilePreview;
 
 use egui::{load::TexturePoll, Label, RichText};
-use notedeck::{IsFollowing, NostrName, NotedeckTextStyle};
+use notedeck::{ui::is_narrow, IsFollowing, NostrName, NotedeckTextStyle};
 
 use crate::{app_images, colors, widgets::styled_button_toggleable};
 
@@ -39,12 +39,18 @@ pub fn display_name_widget<'a>(
                     )
                 });
 
-                let nip05_resp = name.nip05.map(|nip05| {
-                    ui.add(app_images::verified_image());
+                if is_narrow(ui.ctx()) {
+                    ui.end_row();
+                }
 
-                    ui.add(Label::new(
-                        RichText::new(nip05).size(16.0).color(crate::colors::TEAL),
-                    ))
+                let nip05_resp = name.nip05.map(|nip05| {
+                    ui.horizontal(|ui| {
+                        ui.add(app_images::verified_image());
+
+                        ui.label(RichText::new(nip05).size(16.0).color(crate::colors::TEAL))
+                            .on_hover_text(nip05)
+                    })
+                    .inner
                 });
 
                 (username_resp, nip05_resp)

--- a/crates/notedeck_ui/src/profile/mod.rs
+++ b/crates/notedeck_ui/src/profile/mod.rs
@@ -8,7 +8,7 @@ pub use picture::ProfilePic;
 pub use preview::ProfilePreview;
 
 use egui::{load::TexturePoll, Label, RichText};
-use notedeck::{ui::is_narrow, IsFollowing, NostrName, NotedeckTextStyle};
+use notedeck::{IsFollowing, NostrName, NotedeckTextStyle};
 
 use crate::{app_images, colors, widgets::styled_button_toggleable};
 
@@ -39,7 +39,7 @@ pub fn display_name_widget<'a>(
                     )
                 });
 
-                if is_narrow(ui.ctx()) {
+                if name.username.is_some() && name.nip05.is_some() {
                     ui.end_row();
                 }
 
@@ -74,12 +74,7 @@ pub fn display_name_widget<'a>(
     }
 }
 
-pub fn about_section_widget<'a, 'b>(
-    profile: Option<&'b ProfileRecord<'a>>,
-) -> impl egui::Widget + 'b
-where
-    'b: 'a,
-{
+pub fn about_section_widget<'a>(profile: Option<&'a ProfileRecord<'a>>) -> impl egui::Widget + 'a {
     move |ui: &mut egui::Ui| {
         if let Some(about) = profile
             .map(|p| p.record().profile())


### PR DESCRIPTION
Closes #925 & #926

<img width="420" height="796" alt="imagen" src="https://github.com/user-attachments/assets/1a94b3aa-6b02-45b5-91ec-ce8dd9f1c9c1" />

<img width="362" height="740" alt="imagen" src="https://github.com/user-attachments/assets/f015fce0-854b-4c55-a5cc-c81b464f0689" />
