### PR TITLE
introduce HybridFilter

### DIFF
--- a/crates/notedeck/src/contacts.rs
+++ b/crates/notedeck/src/contacts.rs
@@ -1,0 +1,24 @@
+use crate::{
+    filter::{self, HybridFilter},
+    Error,
+};
+use nostrdb::{Filter, Note};
+
+pub fn contacts_filter(pk: &[u8; 32]) -> Filter {
+    Filter::new().authors([pk]).kinds([3]).limit(1).build()
+}
+
+/// Contact filters have an additional kind0 in the remote filter so it can fetch profiles as well
+/// we don't need this in the local filter since we only care about the kind1 results
+pub fn hybrid_contacts_filter(
+    note: &Note,
+    add_pk: Option<&[u8; 32]>,
+    with_hashtags: bool,
+) -> Result<HybridFilter, Error> {
+    let local = filter::filter_from_tags(&note, add_pk, with_hashtags)?
+        .into_filter([1], filter::default_limit());
+    let remote = filter::filter_from_tags(&note, add_pk, with_hashtags)?
+        .into_filter([1, 0], filter::default_remote_limit());
+
+    Ok(HybridFilter::split(local, remote))
+}

--- a/crates/notedeck/src/lib.rs
+++ b/crates/notedeck/src/lib.rs
@@ -2,6 +2,7 @@ pub mod abbrev;
 mod account;
 mod app;
 mod args;
+pub mod contacts;
 mod context;
 pub mod debouncer;
 mod error;

--- a/crates/notedeck_columns/src/timeline/cache.rs
+++ b/crates/notedeck_columns/src/timeline/cache.rs
@@ -129,7 +129,7 @@ impl TimelineCache {
         }
 
         let notes = if let FilterState::Ready(filters) = id.filters(txn, ndb) {
-            if let Ok(results) = ndb.query(txn, &filters, 1000) {
+            if let Ok(results) = ndb.query(txn, filters.local(), 1000) {
                 results
                     .into_iter()
                     .map(NoteRef::from_query_result)
@@ -171,7 +171,7 @@ impl TimelineCache {
                 // The timeline cache is stale, let's update it
                 let notes = find_new_notes(
                     timeline.all_or_any_notes(),
-                    timeline.subscription.get_filter()?,
+                    timeline.subscription.get_filter()?.local(),
                     txn,
                     ndb,
                 );

--- a/crates/notedeck_columns/src/timeline/kind.rs
+++ b/crates/notedeck_columns/src/timeline/kind.rs
@@ -4,10 +4,10 @@ use crate::timeline::{Timeline, TimelineTab};
 use enostr::{Filter, NoteId, Pubkey};
 use nostrdb::{Ndb, Transaction};
 use notedeck::{
+    contacts::{contacts_filter, hybrid_contacts_filter},
     filter::{self, default_limit},
     FilterError, FilterState, NoteCache, RootIdError, RootNoteIdBuf,
 };
-use notedeck_ui::contacts::contacts_filter;
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
 use std::{borrow::Cow, fmt::Display};
@@ -651,7 +651,7 @@ fn contact_filter_state(txn: &Transaction, ndb: &Ndb, pk: &Pubkey) -> FilterStat
         FilterState::needs_remote()
     } else {
         let with_hashtags = false;
-        match filter::filter_from_tags(&results[0].note, Some(pk.bytes()), with_hashtags) {
+        match hybrid_contacts_filter(&results[0].note, Some(pk.bytes()), with_hashtags) {
             Err(notedeck::Error::Filter(FilterError::EmptyContactList)) => {
                 FilterState::needs_remote()
             }
@@ -659,7 +659,7 @@ fn contact_filter_state(txn: &Transaction, ndb: &Ndb, pk: &Pubkey) -> FilterStat
                 error!("Error getting contact filter state: {err}");
                 FilterState::Broken(FilterError::EmptyContactList)
             }
-            Ok(filter) => FilterState::ready(filter.into_follow_filter()),
+            Ok(filter) => FilterState::ready_hybrid(filter),
         }
     }
 }

--- a/crates/notedeck_columns/src/timeline/mod.rs
+++ b/crates/notedeck_columns/src/timeline/mod.rs
@@ -7,8 +7,10 @@ use crate::{
 };
 
 use notedeck::{
-    filter, Accounts, CachedNote, ContactState, FilterError, FilterState, FilterStates, NoteCache,
-    NoteRef, UnknownIds,
+    contacts::hybrid_contacts_filter,
+    filter::{self, HybridFilter},
+    Accounts, CachedNote, ContactState, FilterError, FilterState, FilterStates, NoteCache, NoteRef,
+    UnknownIds,
 };
 
 use egui_virtual_list::VirtualList;
@@ -205,12 +207,12 @@ impl Timeline {
     /// Create a timeline from a contact list
     pub fn contact_list(contact_list: &Note, pubkey: &[u8; 32]) -> Result<Self> {
         let with_hashtags = false;
-        let filter = filter::filter_from_tags(contact_list, Some(pubkey), with_hashtags)?
-            .into_follow_filter();
+        let add_pk = Some(pubkey);
+        let filter = hybrid_contacts_filter(contact_list, add_pk, with_hashtags)?;
 
         Ok(Timeline::new(
             TimelineKind::contact_list(Pubkey::new(*pubkey)),
-            FilterState::ready(filter),
+            FilterState::ready_hybrid(filter),
             TimelineTab::full_tabs(),
         ))
     }
@@ -346,7 +348,10 @@ impl Timeline {
             let note = if let Ok(note) = ndb.get_note_by_key(txn, *key) {
                 note
             } else {
-                error!("hit race condition in poll_notes_into_view: https://github.com/damus-io/nostrdb/issues/35 note {:?} was not added to timeline", key);
+                error!(
+                    "hit race condition in poll_notes_into_view: https://github.com/damus-io/nostrdb/issues/35 note {:?} was not added to timeline",
+                    key
+                );
                 continue;
             };
 
@@ -537,7 +542,7 @@ pub fn send_initial_timeline_filter(
 
         FilterState::Ready(filter) => {
             let filter = filter.to_owned();
-            let new_filters: Vec<Filter> = filter.into_iter().map(|f| {
+            let new_filters: Vec<Filter> = filter.remote().to_owned().into_iter().map(|f| {
                 // limit the size of remote filters
                 let default_limit = filter::default_remote_limit();
                 let mut lim = f.limit().unwrap_or(default_limit);
@@ -606,12 +611,12 @@ pub fn fetch_contact_list(
     subs.subs.insert(sub.remote.clone(), sub_kind);
 }
 
-fn setup_initial_timeline(
+fn setup_initial_timeline<'a>(
     ndb: &Ndb,
     txn: &Transaction,
     timeline: &mut Timeline,
     note_cache: &mut NoteCache,
-    filters: &[Filter],
+    filters: &HybridFilter,
 ) -> Result<()> {
     // some timelines are one-shot and a refreshed, like last_per_pubkey algo feed
     if timeline.kind.should_subscribe_locally() {
@@ -624,12 +629,12 @@ fn setup_initial_timeline(
     );
 
     let mut lim = 0i32;
-    for filter in filters {
+    for filter in filters.local() {
         lim += filter.limit().unwrap_or(1) as i32;
     }
 
     let notes: Vec<NoteRef> = ndb
-        .query(txn, filters, lim)?
+        .query(txn, filters.local(), lim)?
         .into_iter()
         .map(NoteRef::from_query_result)
         .collect();
@@ -728,7 +733,8 @@ pub fn is_timeline_ready(
         let txn = Transaction::new(ndb).expect("txn");
         let note = ndb.get_note_by_key(&txn, note_key).expect("note");
         let add_pk = timeline.kind.pubkey().map(|pk| pk.bytes());
-        filter::filter_from_tags(&note, add_pk, with_hashtags).map(|f| f.into_follow_filter())
+
+        hybrid_contacts_filter(&note, add_pk, with_hashtags).map_err(Into::into)
     };
 
     // TODO: into_follow_filter is hardcoded to contact lists, let's generalize
@@ -755,7 +761,7 @@ pub fn is_timeline_ready(
             setup_initial_timeline(ndb, &txn, timeline, note_cache, &filter).expect("setup init");
             timeline
                 .filter
-                .set_relay_state(relay_id, FilterState::ready(filter.clone()));
+                .set_relay_state(relay_id, FilterState::ready_hybrid(filter.clone()));
 
             //let ck = &timeline.kind;
             //let subid = damus.gen_subid(&SubKind::Column(ck.clone()));

--- a/crates/notedeck_ui/src/contacts.rs
+++ b/crates/notedeck_ui/src/contacts.rs
@@ -1,5 +1,0 @@
-use nostrdb::Filter;
-
-pub fn contacts_filter(pk: &[u8; 32]) -> Filter {
-    Filter::new().authors([pk]).kinds([3]).limit(1).build()
-}

--- a/crates/notedeck_ui/src/lib.rs
+++ b/crates/notedeck_ui/src/lib.rs
@@ -3,7 +3,6 @@ pub mod app_images;
 pub mod blur;
 pub mod colors;
 pub mod constants;
-pub mod contacts;
 pub mod context_menu;
 pub mod gif;
 pub mod icons;


### PR DESCRIPTION
This introduces a new filter construct called HybridFilter. This allows filters to have different remote filter than local ones. For example, adding kind0 to the remote for keeping profiles up to date on your timeline, but only subscribing to kind1 locally.

Only home/contact filters use this feature for now.

- Fixes: https://github.com/damus-io/notedeck/issues/995