### PR TITLE
Fix wrapping issue in reply timelines

### DIFF
--- a/crates/notedeck_ui/src/note/mod.rs
+++ b/crates/notedeck_ui/src/note/mod.rs
@@ -498,7 +498,8 @@ impl<'a, 'd> NoteView<'a, 'd> {
                     profile,
                     self.show_unread_indicator,
                 );
-                ui.horizontal(|ui| 's: {
+
+                ui.horizontal_wrapped(|ui| 's: {
                     ui.spacing_mut().item_spacing.x = if is_narrow(ui.ctx()) { 1.0 } else { 2.0 };
 
                     let note_reply = self


### PR DESCRIPTION
    ui: wrap reply description
    
    This is similar to our fix in:
    
    - Fixes: ee85b754dd86 ("Fix text wrapping issues")
    
    Where removing the ui.horizontal call fixes subsequent main wrap layout
    issues. It's still not clear to me where wrap state is getting mutated
    where it would affect subsequent ui calls...
    
    Fixes: https://github.com/damus-io/notedeck/issues/892
    Changelog-Fixed: Fixed wrapping issues in Notes & Replies timeslines
    Signed-off-by: William Casarin <jb55@jb55.com>