### PR TITLE
feat(columns): hold ctrl or command to see remove options

### DIFF
--- a/crates/notedeck_columns/src/column.rs
+++ b/crates/notedeck_columns/src/column.rs
@@ -226,6 +226,51 @@ impl Columns {
         self.selected += 1;
     }
 
+    pub fn delete_all_columns(&mut self) -> Vec<TimelineKind> {
+        let cols: &mut Vec<Column> = self.columns_mut();
+        let num_cols = cols.len();
+
+        let mut kinds_to_pop: Vec<TimelineKind> = vec![];
+        for i in (0..num_cols).rev() {
+            kinds_to_pop.append(self.delete_column(i).as_mut());
+        }
+        self.selected = 0;
+        if self.columns.is_empty() {
+            self.new_column_picker();
+        }
+        kinds_to_pop
+    }
+
+    pub fn delete_other(&mut self, index: usize) -> Vec<TimelineKind> {
+        let cols = self.columns_mut();
+        let num_cols = cols.len();
+
+        let mut kinds_to_pop: Vec<TimelineKind> = vec![];
+        'col_loop: for i in (0..num_cols).rev() {
+            if i == index {
+                continue 'col_loop;
+            }
+            kinds_to_pop.append(self.delete_column(i).as_mut());
+        }
+        self.selected = 0;
+        kinds_to_pop
+    }
+
+    pub fn delete_dir(&mut self, index: usize, left: bool) -> Vec<TimelineKind> {
+        let cols = self.columns_mut();
+        let num_cols = cols.len();
+
+        let mut kinds_to_pop: Vec<TimelineKind> = vec![];
+        let cols = if left { 0..index } else { index + 1..num_cols };
+        for i in cols.rev() {
+            if i < num_cols {
+                kinds_to_pop.append(self.delete_column(i).as_mut());
+            }
+        }
+        self.selected = 0;
+        kinds_to_pop
+    }
+
     #[must_use = "you must call timeline_cache.pop() for each returned value"]
     pub fn delete_column(&mut self, index: usize) -> Vec<TimelineKind> {
         let mut kinds_to_pop: Vec<TimelineKind> = vec![];

--- a/crates/notedeck_columns/src/ui/column/mod.rs
+++ b/crates/notedeck_columns/src/ui/column/mod.rs
@@ -1,3 +1,4 @@
 mod header;
 
 pub use header::NavTitle;
+pub use header::RemoveColumnType;


### PR DESCRIPTION
<img width="452" height="164" alt="imagen" src="https://github.com/user-attachments/assets/657e8448-a84f-4034-8111-21272706b1f7" />

Advanced Remove Options:
Hold Ctrl (Win/Linux) or ⌘ (macOS) + click:
- All – remove all
- Other – keep this, remove others
- Left/Right – directional removal