### PR TITLE
Thread scroll fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,7 +1554,7 @@ dependencies = [
 [[package]]
 name = "egui_nav"
 version = "0.2.0"
-source = "git+https://github.com/damus-io/egui-nav?rev=3c67eb6298edbff36d46546897cfac33df4f04db#3c67eb6298edbff36d46546897cfac33df4f04db"
+source = "git+https://github.com/kernelkind/egui-nav?rev=de6e2d51892478fdd516df166f866e64dedbae07#de6e2d51892478fdd516df166f866e64dedbae07"
 dependencies = [
  "egui",
  "egui_extras",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ egui = { version = "0.31.1", features = ["serde"] }
 egui-wgpu = "0.31.1"
 egui_extras = { version = "0.31.1", features = ["all_loaders"] }
 egui-winit = { version = "0.31.1", features = ["android-game-activity", "clipboard"] }
-egui_nav = { git = "https://github.com/damus-io/egui-nav", rev = "3c67eb6298edbff36d46546897cfac33df4f04db" }
+egui_nav = { git = "https://github.com/kernelkind/egui-nav", rev = "de6e2d51892478fdd516df166f866e64dedbae07" }
 egui_tabs = { git = "https://github.com/damus-io/egui-tabs", rev = "6eb91740577b374a8a6658c09c9a4181299734d0" }
 #egui_virtual_list = "0.6.0"
 egui_virtual_list = { git = "https://github.com/jb55/hello_egui", rev = "a66b6794f5e707a2f4109633770e02b02fb722e1" }

--- a/crates/notedeck/src/media/gif.rs
+++ b/crates/notedeck/src/media/gif.rs
@@ -22,7 +22,7 @@ pub fn ensure_latest_texture_from_cache(
 }
 
 pub fn ensure_latest_texture(
-    ui: &egui::Ui,
+    _ui: &egui::Ui,
     url: &str,
     gifs: &mut GifStateMap,
     img: &mut TexturedImage,
@@ -108,7 +108,7 @@ pub fn ensure_latest_texture(
                 gifs.insert(url.to_owned(), new_state);
             }
 
-            if let Some(req) = request_next_repaint {
+            if let Some(_req) = request_next_repaint {
                 // TODO(jb55): make a continuous gif rendering setting
                 // 24fps for gif is fine
                 /*

--- a/crates/notedeck/src/note/action.rs
+++ b/crates/notedeck/src/note/action.rs
@@ -24,7 +24,11 @@ pub enum NoteAction {
     Profile(Pubkey),
 
     /// User has clicked a note link
-    Note { note_id: NoteId, preview: bool },
+    Note {
+        note_id: NoteId,
+        preview: bool,
+        scroll_offset: f32,
+    },
 
     /// User has selected some context option
     Context(ContextSelection),
@@ -44,6 +48,7 @@ impl NoteAction {
         NoteAction::Note {
             note_id: id,
             preview: false,
+            scroll_offset: 0.0,
         }
     }
 }

--- a/crates/notedeck_columns/src/actionbar.rs
+++ b/crates/notedeck_columns/src/actionbar.rs
@@ -81,7 +81,11 @@ fn execute_note_action(
                 .open(ndb, note_cache, txn, pool, &kind)
                 .map(NotesOpenResult::Timeline);
         }
-        NoteAction::Note { note_id, preview } => 'ex: {
+        NoteAction::Note {
+            note_id,
+            preview,
+            scroll_offset,
+        } => 'ex: {
             let Ok(thread_selection) = ThreadSelection::from_note_id(ndb, note_cache, txn, note_id)
             else {
                 tracing::error!("No thread selection for {}?", hex::encode(note_id.bytes()));

--- a/crates/notedeck_columns/src/actionbar.rs
+++ b/crates/notedeck_columns/src/actionbar.rs
@@ -93,7 +93,15 @@ fn execute_note_action(
             };
 
             timeline_res = threads
-                .open(ndb, txn, pool, &thread_selection, preview, col)
+                .open(
+                    ndb,
+                    txn,
+                    pool,
+                    &thread_selection,
+                    preview,
+                    col,
+                    scroll_offset,
+                )
                 .map(NotesOpenResult::Thread);
 
             let route = Route::Thread(thread_selection);

--- a/crates/notedeck_columns/src/timeline/thread.rs
+++ b/crates/notedeck_columns/src/timeline/thread.rs
@@ -154,6 +154,7 @@ pub struct Threads {
 impl Threads {
     /// Opening a thread.
     /// Similar to [[super::cache::TimelineCache::open]]
+    #[allow(clippy::too_many_arguments)]
     pub fn open(
         &mut self,
         ndb: &mut Ndb,
@@ -162,6 +163,7 @@ impl Threads {
         thread: &ThreadSelection,
         new_scope: bool,
         col: usize,
+        scroll_offset: f32,
     ) -> Option<NewThreadNotes> {
         tracing::info!("Opening thread: {:?}", thread);
         let local_sub_filter = if let Some(selected) = &thread.selected_note {
@@ -191,7 +193,7 @@ impl Threads {
             RawEntryMut::Vacant(entry) => {
                 let id = NoteId::new(*selected_note_id);
 
-                let node = ThreadNode::new(ParentState::Unknown);
+                let node = ThreadNode::new(ParentState::Unknown).with_offset(scroll_offset);
                 entry.insert(id, node);
 
                 &local_sub_filter

--- a/crates/notedeck_columns/src/timeline/thread.rs
+++ b/crates/notedeck_columns/src/timeline/thread.rs
@@ -23,6 +23,7 @@ pub struct ThreadNode {
     pub prev: ParentState,
     pub have_all_ancestors: bool,
     pub list: VirtualList,
+    pub set_scroll_offset: Option<f32>,
 }
 
 #[derive(Clone)]
@@ -132,7 +133,13 @@ impl ThreadNode {
             prev: parent,
             have_all_ancestors: false,
             list: VirtualList::new(),
+            set_scroll_offset: None,
         }
+    }
+
+    pub fn with_offset(mut self, offset: f32) -> Self {
+        self.set_scroll_offset = Some(offset);
+        self
     }
 }
 

--- a/crates/notedeck_columns/src/ui/thread.rs
+++ b/crates/notedeck_columns/src/ui/thread.rs
@@ -195,6 +195,7 @@ fn strip_note_action(action: NoteAction) -> Option<NoteAction> {
         NoteAction::Note {
             note_id: _,
             preview: false,
+            scroll_offset: _,
         }
     ) {
         return None;

--- a/crates/notedeck_ui/src/note/contents.rs
+++ b/crates/notedeck_ui/src/note/contents.rs
@@ -363,6 +363,7 @@ fn render_undecorated_note_contents<'a>(
                 NoteAction::Note { note_id, .. } => NoteAction::Note {
                     note_id,
                     preview: true,
+                    scroll_offset: 0.0,
                 },
                 other => other,
             })


### PR DESCRIPTION
in a thread, scroll offset now 'resumes' from where it left off on the last route. When going back to the previous route, it uses the offset previously used for that route