### PR TITLE
zaps: cache `payRequest`s

### DIFF
--- a/crates/notedeck/src/error.rs
+++ b/crates/notedeck/src/error.rs
@@ -33,14 +33,25 @@ pub enum ZapError {
     #[error("invalid lud16")]
     InvalidLud16(String),
     #[error("invalid endpoint response")]
-    EndpointError(String),
+    EndpointError(EndpointError),
     #[error("bech encoding/decoding error")]
     Bech(String),
     #[error("serialization/deserialization problem")]
     Serialization(String),
     #[error("nwc error")]
     NWC(String),
+    #[error("ndb error")]
+    Ndb(String),
 }
+
+impl ZapError {
+    pub fn endpoint_error(error: String) -> ZapError {
+        ZapError::EndpointError(EndpointError(error))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EndpointError(pub String);
 
 impl From<String> for Error {
     fn from(s: String) -> Self {

--- a/crates/notedeck/src/zaps/cache.rs
+++ b/crates/notedeck/src/zaps/cache.rs
@@ -4,7 +4,11 @@ use nwc::nostr::nips::nip47::PayInvoiceResponse;
 use poll_promise::Promise;
 use tokio::task::JoinError;
 
-use crate::{get_wallet_for, Accounts, GlobalWallet, ZapError};
+use crate::{
+    get_wallet_for,
+    zaps::{get_users_zap_address, ZapAddress},
+    Accounts, GlobalWallet, ZapError,
+};
 
 use super::{
     networking::{fetch_invoice_lnurl, fetch_invoice_lud16, FetchedInvoice, FetchingInvoice},
@@ -137,24 +141,6 @@ fn send_note_zap(
         }
     };
     Some(promise)
-}
-
-enum ZapAddress {
-    Lud16(String),
-    Lud06(String),
-}
-
-fn get_users_zap_address(txn: &Transaction, ndb: &Ndb, receiver: &Pubkey) -> Option<ZapAddress> {
-    let profile = ndb
-        .get_profile_by_pubkey(txn, receiver.bytes())
-        .ok()?
-        .record()
-        .profile()?;
-
-    profile
-        .lud06()
-        .map(|l| ZapAddress::Lud06(l.to_string()))
-        .or(profile.lud16().map(|l| ZapAddress::Lud16(l.to_string())))
 }
 
 fn try_get_promise_response(

--- a/crates/notedeck/src/zaps/cache.rs
+++ b/crates/notedeck/src/zaps/cache.rs
@@ -126,7 +126,7 @@ fn send_note_zap(
     nsec: &[u8; 32],
     relays: Vec<String>,
 ) -> Option<FetchingInvoice> {
-    let address = get_users_zap_endpoint(txn, ndb, &note_target.zap_recipient)?;
+    let address = get_users_zap_address(txn, ndb, &note_target.zap_recipient)?;
 
     let promise = match address {
         ZapAddress::Lud16(s) => {
@@ -144,7 +144,7 @@ enum ZapAddress {
     Lud06(String),
 }
 
-fn get_users_zap_endpoint(txn: &Transaction, ndb: &Ndb, receiver: &Pubkey) -> Option<ZapAddress> {
+fn get_users_zap_address(txn: &Transaction, ndb: &Ndb, receiver: &Pubkey) -> Option<ZapAddress> {
     let profile = ndb
         .get_profile_by_pubkey(txn, receiver.bytes())
         .ok()?

--- a/crates/notedeck/src/zaps/mod.rs
+++ b/crates/notedeck/src/zaps/mod.rs
@@ -11,3 +11,27 @@ pub use default_zap::{
     get_current_default_msats, DefaultZapError, DefaultZapMsats, PendingDefaultZapState,
     UserZapMsats,
 };
+use enostr::Pubkey;
+use nostrdb::{Ndb, Transaction};
+
+pub enum ZapAddress {
+    Lud16(String),
+    Lud06(String),
+}
+
+pub fn get_users_zap_address(
+    txn: &Transaction,
+    ndb: &Ndb,
+    receiver: &Pubkey,
+) -> Option<ZapAddress> {
+    let profile = ndb
+        .get_profile_by_pubkey(txn, receiver.bytes())
+        .ok()?
+        .record()
+        .profile()?;
+
+    profile
+        .lud06()
+        .map(|l| ZapAddress::Lud06(l.to_string()))
+        .or(profile.lud16().map(|l| ZapAddress::Lud16(l.to_string())))
+}

--- a/crates/notedeck/src/zaps/mod.rs
+++ b/crates/notedeck/src/zaps/mod.rs
@@ -14,6 +14,8 @@ pub use default_zap::{
 use enostr::Pubkey;
 use nostrdb::{Ndb, Transaction};
 
+use crate::ZapError;
+
 pub enum ZapAddress {
     Lud16(String),
     Lud06(String),
@@ -23,15 +25,25 @@ pub fn get_users_zap_address(
     txn: &Transaction,
     ndb: &Ndb,
     receiver: &Pubkey,
-) -> Option<ZapAddress> {
-    let profile = ndb
+) -> Result<ZapAddress, ZapError> {
+    let Some(profile) = ndb
         .get_profile_by_pubkey(txn, receiver.bytes())
-        .ok()?
+        .map_err(|e| ZapError::Ndb(e.to_string()))?
         .record()
-        .profile()?;
+        .profile()
+    else {
+        return Err(ZapError::Ndb(format!("No profile for {receiver}")));
+    };
 
-    profile
+    let Some(address) = profile
         .lud06()
         .map(|l| ZapAddress::Lud06(l.to_string()))
         .or(profile.lud16().map(|l| ZapAddress::Lud16(l.to_string())))
+    else {
+        return Err(ZapError::Ndb(format!(
+            "profile for {receiver} doesn't have lud06 or lud16"
+        )));
+    };
+
+    Ok(address)
 }

--- a/crates/notedeck/src/zaps/networking.rs
+++ b/crates/notedeck/src/zaps/networking.rs
@@ -13,7 +13,7 @@ pub struct FetchedInvoice {
 
 pub type FetchingInvoice = Promise<Result<Result<FetchedInvoice, ZapError>, JoinError>>;
 
-async fn fetch_pay_req_async(url: &Url) -> Result<LNUrlPayRequest, ZapError> {
+async fn fetch_pay_req_async(url: &Url) -> Result<LNUrlPayResponseRaw, ZapError> {
     let (sender, promise) = Promise::new();
 
     let on_done = move |response: Result<ehttp::Response, String>| {
@@ -36,7 +36,7 @@ async fn fetch_pay_req_async(url: &Url) -> Result<LNUrlPayRequest, ZapError> {
     tokio::task::block_in_place(|| promise.block_and_take())
 }
 
-async fn fetch_pay_req_from_lud16(lud16: &str) -> Result<LNUrlPayRequest, ZapError> {
+async fn fetch_pay_req_from_lud16(lud16: &str) -> Result<LNUrlPayResponseRaw, ZapError> {
     let url = match generate_endpoint_url(lud16) {
         Ok(url) => url,
         Err(e) => return Err(e),
@@ -100,7 +100,7 @@ fn make_kind_9734<'a>(
 }
 
 #[derive(Debug, Deserialize)]
-pub struct LNUrlPayRequest {
+pub struct LNUrlPayResponseRaw {
     #[allow(dead_code)]
     #[serde(rename = "allowsNostr")]
     allow_nostr: bool,
@@ -184,7 +184,7 @@ fn convert_lnurl_to_endpoint_url(lnurl: &str) -> Result<Url, ZapError> {
         .map_err(|e| ZapError::EndpointError(format!("endpoint url from lnurl is invalid: {e}")))
 }
 
-async fn fetch_pay_req_from_lnurl_async(lnurl: &str) -> Result<LNUrlPayRequest, ZapError> {
+async fn fetch_pay_req_from_lnurl_async(lnurl: &str) -> Result<LNUrlPayResponseRaw, ZapError> {
     let url = match convert_lnurl_to_endpoint_url(lnurl) {
         Ok(u) => u,
         Err(e) => return Err(e),
@@ -195,7 +195,7 @@ async fn fetch_pay_req_from_lnurl_async(lnurl: &str) -> Result<LNUrlPayRequest, 
 
 async fn fetch_invoice_lnurl_async(
     lnurl: &str,
-    pay_req: &LNUrlPayRequest,
+    pay_req: &LNUrlPayResponseRaw,
     msats: u64,
     sender_nsec: &[u8; 32],
     relays: Vec<String>,

--- a/crates/notedeck/src/zaps/networking.rs
+++ b/crates/notedeck/src/zaps/networking.rs
@@ -17,9 +17,9 @@ async fn fetch_pay_req_async(url: &Url) -> Result<LNUrlPayResponseRaw, ZapError>
     let (sender, promise) = Promise::new();
 
     let on_done = move |response: Result<ehttp::Response, String>| {
-        let handle = response.map_err(ZapError::EndpointError).and_then(|resp| {
+        let handle = response.map_err(ZapError::endpoint_error).and_then(|resp| {
             if !resp.ok {
-                return Err(ZapError::EndpointError(format!(
+                return Err(ZapError::endpoint_error(format!(
                     "bad http response: {}",
                     resp.status_text
                 )));
@@ -181,7 +181,7 @@ fn convert_lnurl_to_endpoint_url(lnurl: &str) -> Result<Url, ZapError> {
         String::from_utf8(data).map_err(|e| ZapError::Bech(format!("string conversion: {e}")))?;
 
     Url::parse(&url_str)
-        .map_err(|e| ZapError::EndpointError(format!("endpoint url from lnurl is invalid: {e}")))
+        .map_err(|e| ZapError::endpoint_error(format!("endpoint url from lnurl is invalid: {e}")))
 }
 
 async fn fetch_pay_req_from_lnurl_async(lnurl: &str) -> Result<LNUrlPayResponseRaw, ZapError> {
@@ -204,8 +204,9 @@ async fn fetch_invoice_lnurl_async(
     //let recipient = Pubkey::from_hex(&pay_req.nostr_pubkey)
     //.map_err(|e| ZapError::EndpointError(format!("invalid pubkey hex from endpoint: {e}")))?;
 
-    let mut base_url = Url::parse(&pay_req.callback_url)
-        .map_err(|e| ZapError::EndpointError(format!("invalid callback url from endpoint: {e}")))?;
+    let mut base_url = Url::parse(&pay_req.callback_url).map_err(|e| {
+        ZapError::endpoint_error(format!("invalid callback url from endpoint: {e}"))
+    })?;
 
     let (query, noteid) = {
         let comment: &str = "";
@@ -240,9 +241,9 @@ async fn fetch_invoice(req: &Url) -> Result<LNInvoice, ZapError> {
     let request = ehttp::Request::get(req);
     let (sender, promise) = Promise::new();
     let on_done = move |response: Result<ehttp::Response, String>| {
-        let handle = response.map_err(ZapError::EndpointError).and_then(|resp| {
+        let handle = response.map_err(ZapError::endpoint_error).and_then(|resp| {
             if !resp.ok {
-                return Err(ZapError::EndpointError(format!(
+                return Err(ZapError::endpoint_error(format!(
                     "invalid http response: {}",
                     resp.status_text
                 )));
@@ -290,7 +291,7 @@ fn generate_endpoint_url(lud16: &str) -> Result<Url, ZapError> {
         if use_http { "" } else { "s" }
     );
 
-    Url::parse(&url_str).map_err(|e| ZapError::EndpointError(e.to_string()))
+    Url::parse(&url_str).map_err(|e| ZapError::endpoint_error(e.to_string()))
 }
 
 #[cfg(test)]

--- a/crates/notedeck/src/zaps/networking.rs
+++ b/crates/notedeck/src/zaps/networking.rs
@@ -401,6 +401,10 @@ mod tests {
         });
 
         assert!(maybe_invoice.is_ok());
+        let inner = maybe_invoice.unwrap();
+        assert!(inner.is_ok());
+        let inner = inner.unwrap().invoice;
+        assert!(inner.is_ok());
 
         assert!(maybe_invoice.unwrap().unwrap().invoice.starts_with("lnbc"));
     }

--- a/crates/notedeck_ui/src/note/mod.rs
+++ b/crates/notedeck_ui/src/note/mod.rs
@@ -841,6 +841,8 @@ fn render_note_actionbar(
     note_key: NoteKey,
     i18n: &mut Localization,
 ) -> Option<NoteAction> {
+    let mut action = None;
+
     ui.set_min_height(26.0);
     ui.spacing_mut().item_spacing.x = 24.0;
 
@@ -852,11 +854,11 @@ fn render_note_actionbar(
 
     let to_noteid = |id: &[u8; 32]| NoteId::new(*id);
     if reply_resp.clicked() {
-        return Some(NoteAction::Reply(to_noteid(note_id)));
+        action = Some(NoteAction::Reply(to_noteid(note_id)));
     }
 
     if quote_resp.clicked() {
-        return Some(NoteAction::Quote(to_noteid(note_id)));
+        action = Some(NoteAction::Quote(to_noteid(note_id)));
     }
 
     let Zapper { zaps, cur_acc } = zapper?;
@@ -874,7 +876,7 @@ fn render_note_actionbar(
     };
 
     if zap_state.is_err() {
-        return Some(NoteAction::Zap(ZapAction::ClearError(target)));
+        action = Some(NoteAction::Zap(ZapAction::ClearError(target.clone())));
     }
 
     let zap_resp = {
@@ -891,17 +893,17 @@ fn render_note_actionbar(
     .on_hover_cursor(egui::CursorIcon::PointingHand);
 
     if zap_resp.secondary_clicked() {
-        return Some(NoteAction::Zap(ZapAction::CustomizeAmount(target)));
+        action = Some(NoteAction::Zap(ZapAction::CustomizeAmount(target.clone())));
     }
 
-    if !zap_resp.clicked() {
-        return None;
+    if zap_resp.clicked() {
+        action = Some(NoteAction::Zap(ZapAction::Send(ZapTargetAmount {
+            target,
+            specified_msats: None,
+        })))
     }
 
-    Some(NoteAction::Zap(ZapAction::Send(ZapTargetAmount {
-        target,
-        specified_msats: None,
-    })))
+    action
 }
 
 #[profiling::function]


### PR DESCRIPTION
- The payRequest response from ln providers weren't cached, now they are
- fixed UI regression: if the zap fails, an X will appear in place of zap button, and hovering will show the error message
- some nip57 requirements weren't accounted for, now they are

the caching is in preparation for #1037 