### PR TITLE
fix: image shimmer bug

### DIFF
--- a/crates/notedeck/src/imgcache.rs
+++ b/crates/notedeck/src/imgcache.rs
@@ -89,7 +89,7 @@ impl TexturesCache {
 
         entry.replace_entry_with(|_, v| {
             let TextureStateInternal::Loading(textured) = v else {
-                return None;
+                return Some(v);
             };
 
             Some(TextureStateInternal::Loaded(textured))


### PR DESCRIPTION
if the same image on two separate columns unblur at the same time, it caused them both to continually cycle between blurred and unblurred

https://github.com/user-attachments/assets/cdb22159-dc18-4b66-bf61-ca3ca3338d0a

