### PR TITLE
fix: WalletView don't request keyboard focus if narrow

### DIFF
--- a/crates/notedeck_columns/src/ui/wallet.rs
+++ b/crates/notedeck_columns/src/ui/wallet.rs
@@ -402,7 +402,9 @@ fn show_default_zap(
                         notedeck_ui::include_input(ui, &r);
                     }
 
-                    ui.memory_mut(|m| m.request_focus(id));
+                    if !notedeck::ui::is_narrow(ui.ctx()) { // TODO: this should really be checking if we are using a virtual keyboard instead of narrow
+                        ui.memory_mut(|m| m.request_focus(id));
+                    }
 
                     ui.label(tr!(i18n, "sats", "Unit label for satoshis (Bitcoin unit) for configuring default zap amount in wallet settings."));
 


### PR DESCRIPTION
on android it kept popping up the keyboard even when i close it