### PR TITLE
Thread improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "egui_virtual_list"
 version = "0.7.0"
-source = "git+https://github.com/jb55/hello_egui?rev=a66b6794f5e707a2f4109633770e02b02fb722e1#a66b6794f5e707a2f4109633770e02b02fb722e1"
+source = "git+https://github.com/kernelkind/hello_egui?rev=542e6747703cf648bb462ec55f0f885fd37cf0b0#542e6747703cf648bb462ec55f0f885fd37cf0b0"
 dependencies = [
  "egui",
  "web-time 1.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ egui-winit = { version = "0.31.1", features = ["android-game-activity", "clipboa
 egui_nav = { git = "https://github.com/damus-io/egui-nav", rev = "8767df4bc8d12a90fbcee7493d9c9604fe30f1a2" }
 egui_tabs = { git = "https://github.com/damus-io/egui-tabs", rev = "6eb91740577b374a8a6658c09c9a4181299734d0" }
 #egui_virtual_list = "0.6.0"
-egui_virtual_list = { git = "https://github.com/jb55/hello_egui", rev = "a66b6794f5e707a2f4109633770e02b02fb722e1" }
+egui_virtual_list = { git = "https://github.com/kernelkind/hello_egui", rev = "542e6747703cf648bb462ec55f0f885fd37cf0b0" }
 ehttp = "0.5.0"
 enostr = { path = "crates/enostr" } 
 ewebsock = { version = "0.2.0", features = ["tls"] }

--- a/crates/notedeck/src/note/action.rs
+++ b/crates/notedeck/src/note/action.rs
@@ -24,11 +24,7 @@ pub enum NoteAction {
     Profile(Pubkey),
 
     /// User has clicked a note link
-    Note {
-        note_id: NoteId,
-        preview: bool,
-        scroll_offset: f32,
-    },
+    Note { note_id: NoteId, preview: bool },
 
     /// User has selected some context option
     Context(ContextSelection),
@@ -48,7 +44,6 @@ impl NoteAction {
         NoteAction::Note {
             note_id: id,
             preview: false,
-            scroll_offset: 0.0,
         }
     }
 }

--- a/crates/notedeck/src/note/action.rs
+++ b/crates/notedeck/src/note/action.rs
@@ -26,6 +26,11 @@ pub enum NoteAction {
     /// User has clicked a note link
     Note { note_id: NoteId, preview: bool },
 
+    ThreadAutoUnfold {
+        note_id: NoteId,
+        scroll_to: Option<NoteId>,
+    },
+
     /// User has selected some context option
     Context(ContextSelection),
 

--- a/crates/notedeck_columns/src/actionbar.rs
+++ b/crates/notedeck_columns/src/actionbar.rs
@@ -83,11 +83,7 @@ fn execute_note_action(
                 .open(ndb, note_cache, txn, pool, &kind)
                 .map(NotesOpenResult::Timeline);
         }
-        NoteAction::Note {
-            note_id,
-            preview,
-            scroll_offset,
-        } => 'ex: {
+        NoteAction::Note { note_id, preview } => 'ex: {
             let Ok(thread_selection) = ThreadSelection::from_note_id(ndb, note_cache, txn, note_id)
             else {
                 tracing::error!("No thread selection for {}?", hex::encode(note_id.bytes()));
@@ -95,15 +91,7 @@ fn execute_note_action(
             };
 
             timeline_res = threads
-                .open(
-                    ndb,
-                    txn,
-                    pool,
-                    &thread_selection,
-                    preview,
-                    col,
-                    scroll_offset,
-                )
+                .open(ndb, txn, pool, &thread_selection, preview, col)
                 .map(NotesOpenResult::Thread);
 
             let route = Route::Thread(thread_selection);

--- a/crates/notedeck_columns/src/actionbar.rs
+++ b/crates/notedeck_columns/src/actionbar.rs
@@ -91,7 +91,15 @@ fn execute_note_action(
             };
 
             timeline_res = threads
-                .open(ndb, txn, pool, &thread_selection, preview, col)
+                .open(
+                    ndb,
+                    txn,
+                    pool,
+                    &thread_selection,
+                    Some(note_id),
+                    preview,
+                    col,
+                )
                 .map(NotesOpenResult::Thread);
 
             let route = Route::Thread(thread_selection);

--- a/crates/notedeck_columns/src/nav.rs
+++ b/crates/notedeck_columns/src/nav.rs
@@ -368,6 +368,7 @@ pub enum RouterAction {
     /// information about the pfp since we only use it for toggling the
     /// chrome atm
     PfpClicked,
+    RouteInstantly(Route),
     RouteTo(Route, RouterType),
     CloseSheetThenRoute(Route),
     Overlay {
@@ -437,6 +438,10 @@ impl RouterAction {
             RouterAction::CloseSheetThenRoute(route) => {
                 sheet_router.go_back();
                 sheet_router.after_action = Some(route);
+                None
+            }
+            RouterAction::RouteInstantly(route) => {
+                stack_router.route_instantly(route);
                 None
             }
         }

--- a/crates/notedeck_columns/src/route.rs
+++ b/crates/notedeck_columns/src/route.rs
@@ -433,6 +433,14 @@ impl<R: Clone> Router<R> {
         self.routes.push(route);
     }
 
+    pub fn route_instantly(&mut self, route: R) {
+        if self.routes.pop().is_none() {
+            return;
+        }
+
+        self.routes.push(route);
+    }
+
     /// Go back, start the returning process
     pub fn go_back(&mut self) -> Option<R> {
         if self.returning || self.routes.len() == 1 {

--- a/crates/notedeck_columns/src/timeline/thread.rs
+++ b/crates/notedeck_columns/src/timeline/thread.rs
@@ -33,11 +33,13 @@ pub enum ParentState {
 
 impl ThreadNode {
     pub fn new(parent: ParentState) -> Self {
+        let mut list = VirtualList::new();
+        list.hide_on_resize(None);
         Self {
             replies: SingleNoteUnits::new(true),
             prev: parent,
             have_all_ancestors: false,
-            list: VirtualList::new(),
+            list,
         }
     }
 }

--- a/crates/notedeck_columns/src/timeline/thread.rs
+++ b/crates/notedeck_columns/src/timeline/thread.rs
@@ -22,7 +22,6 @@ pub struct ThreadNode {
     pub prev: ParentState,
     pub have_all_ancestors: bool,
     pub list: VirtualList,
-    pub set_scroll_offset: Option<f32>,
 }
 
 #[derive(Clone)]
@@ -39,13 +38,7 @@ impl ThreadNode {
             prev: parent,
             have_all_ancestors: false,
             list: VirtualList::new(),
-            set_scroll_offset: None,
         }
-    }
-
-    pub fn with_offset(mut self, offset: f32) -> Self {
-        self.set_scroll_offset = Some(offset);
-        self
     }
 }
 
@@ -69,7 +62,6 @@ impl Threads {
         thread: &ThreadSelection,
         new_scope: bool,
         col: usize,
-        scroll_offset: f32,
     ) -> Option<NewThreadNotes> {
         tracing::info!("Opening thread: {:?}", thread);
         let local_sub_filter = if let Some(selected) = &thread.selected_note {
@@ -99,7 +91,7 @@ impl Threads {
             RawEntryMut::Vacant(entry) => {
                 let id = NoteId::new(*selected_note_id);
 
-                let node = ThreadNode::new(ParentState::Unknown).with_offset(scroll_offset);
+                let node = ThreadNode::new(ParentState::Unknown);
                 entry.insert(id, node);
 
                 &local_sub_filter

--- a/crates/notedeck_columns/src/timeline/thread.rs
+++ b/crates/notedeck_columns/src/timeline/thread.rs
@@ -80,7 +80,6 @@ impl Threads {
             self.scroll_to = Some(ScrollToNote::new(scroll_to));
         }
 
-        tracing::info!("Opening thread: {:?}", thread);
         let local_sub_filter = if let Some(selected) = &thread.selected_note {
             vec![direct_replies_filter_non_root(
                 selected.bytes(),

--- a/crates/notedeck_columns/src/timeline/thread.rs
+++ b/crates/notedeck_columns/src/timeline/thread.rs
@@ -442,4 +442,12 @@ impl SingleNoteUnits {
     pub fn contains_key(&self, k: &NoteKey) -> bool {
         self.units.contains_key(&UnitKey::Single(*k))
     }
+
+    pub fn len(&self) -> usize {
+        self.units.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.units.is_empty()
+    }
 }

--- a/crates/notedeck_columns/src/ui/thread.rs
+++ b/crates/notedeck_columns/src/ui/thread.rs
@@ -47,31 +47,16 @@ impl<'a, 'd> ThreadView<'a, 'd> {
         let txn = Transaction::new(self.note_context.ndb).expect("txn");
 
         let scroll_id = ThreadView::scroll_id(self.selected_note_id, self.col);
-        let mut scroll_area = egui::ScrollArea::vertical()
+        let scroll_area = egui::ScrollArea::vertical()
             .id_salt(scroll_id)
             .animated(false)
             .auto_shrink([false, false])
             .scroll_bar_visibility(egui::scroll_area::ScrollBarVisibility::AlwaysVisible);
 
-        if let Some(thread) = self.threads.threads.get_mut(&self.selected_note_id) {
-            if let Some(new_offset) = thread.set_scroll_offset.take() {
-                scroll_area = scroll_area.vertical_scroll_offset(new_offset);
-            }
-        }
-
         let output = scroll_area.show(ui, |ui| self.notes(ui, &txn));
 
         let out_id = output.id;
-        let mut resp = output.inner;
-
-        if let Some(NoteAction::Note {
-            note_id: _,
-            preview: _,
-            scroll_offset,
-        }) = &mut resp
-        {
-            *scroll_offset = output.state.offset.y;
-        }
+        let resp = output.inner;
 
         BodyResponse::output(resp).scroll_raw(out_id)
     }
@@ -206,7 +191,6 @@ fn strip_note_action(action: NoteAction) -> Option<NoteAction> {
         NoteAction::Note {
             note_id: _,
             preview: false,
-            scroll_offset: _,
         }
     ) {
         return None;

--- a/crates/notedeck_ui/src/note/contents.rs
+++ b/crates/notedeck_ui/src/note/contents.rs
@@ -361,7 +361,6 @@ fn render_undecorated_note_contents<'a>(
                 NoteAction::Note { note_id, .. } => NoteAction::Note {
                     note_id,
                     preview: true,
-                    scroll_offset: 0.0,
                 },
                 other => other,
             })


### PR DESCRIPTION
- make scroll position go to the correct offset after navigating to a thread
- make scroll position go to the correct offset after all ancestors are loaded
- auto unfold thread if there is only one reply, while retaining original scroll offset