### PR TITLE
WIP mp4 playback Linux: add gstreamer backend for mp4 playback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atomic_refcell"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2191,6 +2197,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "gio-sys"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd743ba4714d671ad6b6234e8ab2a13b42304d0e13ab7eba1dcdd78a7d6d4ef"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,6 +2218,51 @@ dependencies = [
  "khronos_api",
  "log",
  "xml-rs",
+]
+
+[[package]]
+name = "glib"
+version = "0.19.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39650279f135469465018daae0ba53357942a5212137515777d5fdca74984a44"
+dependencies = [
+ "bitflags 2.9.1",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "memchr",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.19.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4429b0277a14ae9751350ad9b658b1be0abb5b54faa5bcdf6e74a3372582fad7"
+dependencies = [
+ "heck",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2dc18d3a82b0006d470b13304fbbb3e0a9bd4884cf985a60a7ed733ac2c4a5"
+dependencies = [
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -2298,6 +2362,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gobject-sys"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e697e252d6e0416fd1d9e169bda51c0f1c926026c39ca21fbe8b1bb5c3b8b9e"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "gpu-alloc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2334,6 +2409,129 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "gstreamer"
+version = "0.22.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d14f5b75598fa79c864803786b4b242adddbf2b86cbc378df9b7b8a1c5cf53"
+dependencies = [
+ "cfg-if",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "glib",
+ "gstreamer-sys",
+ "itertools 0.13.0",
+ "libc",
+ "muldiv",
+ "num-integer",
+ "num-rational",
+ "once_cell",
+ "option-operations",
+ "paste",
+ "pin-project-lite",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "gstreamer-app"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1363313eb1931d66ac0b82c9b477fdd066af9dc118ea844966f85b6d99f261fd"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "glib",
+ "gstreamer",
+ "gstreamer-app-sys",
+ "gstreamer-base",
+ "libc",
+]
+
+[[package]]
+name = "gstreamer-app-sys"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed667453517b47754b9f9d28c096074e5d565f1cc48c6fa2483b1ea10d7688d3"
+dependencies = [
+ "glib-sys",
+ "gstreamer-base-sys",
+ "gstreamer-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gstreamer-base"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39d55668b23fc69f1843daa42b43d289c00fe38e9586c5453b134783d2dd75a3"
+dependencies = [
+ "atomic_refcell",
+ "cfg-if",
+ "glib",
+ "gstreamer",
+ "gstreamer-base-sys",
+ "libc",
+]
+
+[[package]]
+name = "gstreamer-base-sys"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5448abb00c197e3ad306710293bf757303cbeab4036b5ccad21c7642b8bf00c9"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "gstreamer-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gstreamer-sys"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71f147e7c6bc9313d5569eb15da61f6f64026ec69791922749de230583a07286"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gstreamer-video"
+version = "0.22.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7256dfa16eff9b1ddcae1a906c1a14bb96898523a512755587803433de6774ab"
+dependencies = [
+ "cfg-if",
+ "futures-channel",
+ "glib",
+ "gstreamer",
+ "gstreamer-base",
+ "gstreamer-video-sys",
+ "libc",
+ "once_cell",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "gstreamer-video-sys"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ec210495f94cabaa45d08003081b550095c2d4ab12d5320f64856a91f3f01c"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "gstreamer-base-sys",
+ "gstreamer-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -2758,13 +2956,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2849,6 +3048,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -3305,6 +3513,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "muldiv"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
+
+[[package]]
 name = "naga"
 version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3316,7 +3530,7 @@ dependencies = [
  "cfg_aliases",
  "codespan-reporting",
  "hexf-parse",
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "log",
  "rustc-hash 1.1.0",
  "spirv",
@@ -3556,7 +3770,7 @@ dependencies = [
  "hashbrown 0.15.4",
  "hex",
  "image",
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "jni 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lightning-invoice",
  "md5",
@@ -3564,6 +3778,7 @@ dependencies = [
  "ndk-context",
  "nostr 0.37.0",
  "nostrdb",
+ "notedeck_media_gst",
  "nwc",
  "once_cell",
  "poll-promise",
@@ -3661,7 +3876,7 @@ dependencies = [
  "hex",
  "human_format",
  "image",
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "jni 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndk-context",
  "nostrdb",
@@ -3719,6 +3934,20 @@ dependencies = [
  "sha2",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "notedeck_media_gst"
+version = "0.7.1"
+dependencies = [
+ "crossbeam-channel",
+ "glib",
+ "gstreamer",
+ "gstreamer-app",
+ "gstreamer-video",
+ "once_cell",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -4194,6 +4423,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "option-operations"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c26d27bb1aeab65138e4bf7666045169d1717febcc9ff870166be8348b223d0"
+dependencies = [
+ "paste",
+]
+
+[[package]]
 name = "orbclient"
 version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4505,11 +4743,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.7",
 ]
 
 [[package]]
@@ -4571,7 +4809,7 @@ source = "git+https://github.com/jb55/puffin?rev=c6a6242adaf90b6292c0f462d2acd34
 dependencies = [
  "egui",
  "egui_extras",
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "natord",
  "once_cell",
  "parking_lot",
@@ -5433,18 +5671,28 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5457,7 +5705,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "itoa",
  "memchr",
  "ryu",
@@ -5506,7 +5754,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -6103,36 +6351,66 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.3",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.27"
+name = "toml_datetime"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
 dependencies = [
- "indexmap 2.9.0",
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap 2.11.4",
  "serde",
  "serde_spanned",
- "toml_datetime",
- "winnow",
+ "toml_datetime 0.6.3",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+dependencies = [
+ "indexmap 2.11.4",
+ "toml_datetime 0.7.3",
+ "toml_parser",
+ "winnow 0.7.13",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+dependencies = [
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -6283,7 +6561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "319c70195101a93f56db4c74733e272d720768e13471f400c78406a326b172b0"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6932,7 +7210,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cfg_aliases",
  "document-features",
- "indexmap 2.9.0",
+ "indexmap 2.11.4",
  "log",
  "naga",
  "once_cell",
@@ -7657,9 +7935,18 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
@@ -7805,7 +8092,7 @@ dependencies = [
  "tracing",
  "uds_windows",
  "windows-sys 0.59.0",
- "winnow",
+ "winnow 0.7.13",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -7834,7 +8121,7 @@ checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
 dependencies = [
  "serde",
  "static_assertions",
- "winnow",
+ "winnow 0.7.13",
  "zvariant",
 ]
 
@@ -7952,7 +8239,7 @@ dependencies = [
  "enumflags2",
  "serde",
  "url",
- "winnow",
+ "winnow 0.7.13",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -7981,5 +8268,5 @@ dependencies = [
  "serde",
  "static_assertions",
  "syn 2.0.104",
- "winnow",
+ "winnow 0.7.13",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/notedeck_notebook",
     "crates/notedeck_ui",
     "crates/notedeck_clndash",
+    "crates/notedeck_media_gst",
 
     "crates/enostr", "crates/tokenator", "crates/notedeck_dave", "crates/notedeck_ui", "crates/notedeck_clndash",
 ]

--- a/crates/notedeck/Cargo.toml
+++ b/crates/notedeck/Cargo.toml
@@ -53,6 +53,7 @@ chrono = { workspace = true }
 indexmap = {workspace = true}
 rand = {workspace = true}
 crossbeam-channel = "0.5"
+notedeck_media_gst = { path = "../notedeck_media_gst" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/notedeck/src/context.rs
+++ b/crates/notedeck/src/context.rs
@@ -1,7 +1,7 @@
 use crate::{
     account::accounts::Accounts, frame_history::FrameHistory, i18n::Localization,
     wallet::GlobalWallet, zaps::Zaps, Args, DataPath, Images, JobPool, NoteCache, SettingsHandler,
-    UnknownIds,
+    UnknownIds, VideoManager,
 };
 use egui_winit::clipboard::Clipboard;
 
@@ -29,6 +29,7 @@ pub struct AppContext<'a> {
     pub frame_history: &'a mut FrameHistory,
     pub job_pool: &'a mut JobPool,
     pub i18n: &'a mut Localization,
+    pub video: &'a mut VideoManager,
 
     #[cfg(target_os = "android")]
     pub android: AndroidApp,

--- a/crates/notedeck/src/lib.rs
+++ b/crates/notedeck/src/lib.rs
@@ -65,7 +65,8 @@ pub use jobs::{
 };
 pub use media::{
     compute_blurhash, update_imeta_blurhashes, ImageMetadata, ImageType, MediaAction,
-    ObfuscationType, PixelDimensions, PointDimensions, RenderableMedia,
+    ObfuscationType, PixelDimensions, PointDimensions, RenderableMedia, RenderableMediaKind,
+    VideoCodec, VideoMedia,
 };
 pub use muted::{MuteFun, Muted};
 pub use name::NostrName;
@@ -104,4 +105,7 @@ pub use zaps::{
 pub use enostr;
 pub use nostrdb;
 
+pub use notedeck_media_gst::{
+    VideoEvent, VideoFrame, VideoHandle, VideoManager, VideoManagerConfig, VideoState, VideoStatus,
+};
 pub use zaps::Zaps;

--- a/crates/notedeck/src/media/mod.rs
+++ b/crates/notedeck/src/media/mod.rs
@@ -12,7 +12,7 @@ pub use blur::{
 };
 use egui::{ColorImage, TextureHandle};
 pub use images::ImageType;
-pub use renderable::RenderableMedia;
+pub use renderable::{RenderableMedia, RenderableMediaKind, VideoCodec, VideoMedia};
 
 #[derive(Copy, Clone, Debug)]
 pub enum AnimationMode {

--- a/crates/notedeck/src/media/renderable.rs
+++ b/crates/notedeck/src/media/renderable.rs
@@ -1,9 +1,46 @@
 use super::ObfuscationType;
 use crate::MediaCacheType;
 
-/// Media that is prepared for rendering. Use [`Images::get_renderable_media`] to get these
+/// Supported media variants that can be embedded inside Notedeck.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RenderableMediaKind {
+    Image(MediaCacheType),
+    Video(VideoMedia),
+}
+
+/// Metadata describing a video asset. This will expand as we add duration,
+/// dimensions, poster frames, etc.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VideoMedia {
+    pub codec: VideoCodec,
+}
+
+impl VideoMedia {
+    pub const fn mp4() -> Self {
+        Self {
+            codec: VideoCodec::Mp4,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VideoCodec {
+    Mp4,
+}
+
+impl RenderableMediaKind {
+    pub const fn as_cache_type(&self) -> Option<MediaCacheType> {
+        match self {
+            Self::Image(cache_type) => Some(*cache_type),
+            Self::Video(_) => None,
+        }
+    }
+}
+
+/// Media that is prepared for rendering. Use [`Images::get_renderable_media`] to get these.
+#[derive(Clone)]
 pub struct RenderableMedia {
     pub url: String,
-    pub media_type: MediaCacheType,
+    pub kind: RenderableMediaKind,
     pub obfuscation_type: ObfuscationType,
 }

--- a/crates/notedeck/src/note/mod.rs
+++ b/crates/notedeck/src/note/mod.rs
@@ -9,7 +9,7 @@ use crate::GlobalWallet;
 use crate::JobPool;
 use crate::Localization;
 use crate::UnknownIds;
-use crate::{notecache::NoteCache, zaps::Zaps, Images};
+use crate::{notecache::NoteCache, zaps::Zaps, Images, VideoManager};
 use enostr::{NoteId, RelayPool};
 use nostrdb::{Ndb, Note, NoteKey, QueryResult, Transaction};
 use std::borrow::Borrow;
@@ -29,6 +29,7 @@ pub struct NoteContext<'d> {
     pub pool: &'d mut RelayPool,
     pub job_pool: &'d mut JobPool,
     pub unknown_ids: &'d mut UnknownIds,
+    pub video: &'d mut VideoManager,
     pub clipboard: &'d mut egui_winit::clipboard::Clipboard,
 }
 

--- a/crates/notedeck_clndash/src/ui.rs
+++ b/crates/notedeck_clndash/src/ui.rs
@@ -51,6 +51,7 @@ pub fn note_hover_ui(
             pool: ctx.pool,
             job_pool: ctx.job_pool,
             unknown_ids: ctx.unknown_ids,
+            video: ctx.video,
             clipboard: ctx.clipboard,
             i18n: ctx.i18n,
             global_wallet: ctx.global_wallet,

--- a/crates/notedeck_columns/src/accounts/mod.rs
+++ b/crates/notedeck_columns/src/accounts/mod.rs
@@ -109,6 +109,7 @@ pub fn render_accounts_route(
             app_ctx.i18n,
             app_ctx.job_pool,
             jobs,
+            app_ctx.video,
         )
         .ui(ui)
         .map_output(|r| match r {

--- a/crates/notedeck_columns/src/app.rs
+++ b/crates/notedeck_columns/src/app.rs
@@ -22,6 +22,7 @@ use nostrdb::Transaction;
 use notedeck::{
     tr, ui::is_narrow, Accounts, AppAction, AppContext, AppResponse, DataPath, DataPathType,
     FilterState, Images, JobsCache, Localization, NotedeckOptions, SettingsHandler, UnknownIds,
+    VideoManager,
 };
 use notedeck_ui::{
     media::{MediaViewer, MediaViewerFlags, MediaViewerState},
@@ -389,7 +390,12 @@ fn render_damus(damus: &mut Damus, app_ctx: &mut AppContext<'_>, ui: &mut egui::
         render_damus_desktop(damus, app_ctx, ui)
     };
 
-    fullscreen_media_viewer_ui(ui, &mut damus.view_state.media_viewer, app_ctx.img_cache);
+    fullscreen_media_viewer_ui(
+        ui,
+        &mut damus.view_state.media_viewer,
+        app_ctx.img_cache,
+        app_ctx.video,
+    );
 
     // We use this for keeping timestamps and things up to date
     //ui.ctx().request_repaint_after(Duration::from_secs(5));
@@ -404,6 +410,7 @@ fn fullscreen_media_viewer_ui(
     ui: &mut egui::Ui,
     state: &mut MediaViewerState,
     img_cache: &mut Images,
+    video: &mut VideoManager,
 ) {
     if !state.should_show(ui) {
         if state.scene_rect.is_some() {
@@ -415,7 +422,9 @@ fn fullscreen_media_viewer_ui(
         return;
     }
 
-    let resp = MediaViewer::new(state).fullscreen(true).ui(img_cache, ui);
+    let resp = MediaViewer::new(state)
+        .fullscreen(true)
+        .ui(img_cache, video, ui);
 
     if resp.clicked() || ui.input(|i| i.key_pressed(egui::Key::Escape)) {
         fullscreen_media_close(state);

--- a/crates/notedeck_columns/src/nav.rs
+++ b/crates/notedeck_columns/src/nav.rs
@@ -565,6 +565,7 @@ fn render_nav_body(
         pool: ctx.pool,
         job_pool: ctx.job_pool,
         unknown_ids: ctx.unknown_ids,
+        video: ctx.video,
         clipboard: ctx.clipboard,
         i18n: ctx.i18n,
         global_wallet: ctx.global_wallet,

--- a/crates/notedeck_columns/src/timeline/thread.rs
+++ b/crates/notedeck_columns/src/timeline/thread.rs
@@ -310,7 +310,7 @@ pub fn selected_has_at_least_n_replies(
         return false;
     };
 
-    res.len() >= n.into()
+    res.len() >= usize::from(n)
 }
 
 fn direct_replies_filter_non_root(

--- a/crates/notedeck_columns/src/ui/note/post.rs
+++ b/crates/notedeck_columns/src/ui/note/post.rs
@@ -523,13 +523,20 @@ impl<'a, 'd> PostView<'a, 'd> {
                 (300, 300)
             };
 
-            let Some(cache_type) =
+            let Some(kind) =
                 supported_mime_hosted_at_url(&mut self.note_context.img_cache.urls, &media.url)
             else {
                 self.draft
                     .upload_errors
                     .push("Uploaded media is not supported.".to_owned());
                 error!("Unsupported mime type at url: {}", &media.url);
+                continue;
+            };
+            let Some(cache_type) = kind.as_cache_type() else {
+                self.draft
+                    .upload_errors
+                    .push("Uploaded media type is not yet supported in the composer.".to_owned());
+                error!("Unsupported composer media kind at url: {}", &media.url);
                 continue;
             };
 
@@ -878,6 +885,7 @@ mod preview {
                 pool: app.pool,
                 job_pool: app.job_pool,
                 unknown_ids: app.unknown_ids,
+                video: app.video,
                 clipboard: app.clipboard,
                 i18n: app.i18n,
             };

--- a/crates/notedeck_columns/src/ui/onboarding.rs
+++ b/crates/notedeck_columns/src/ui/onboarding.rs
@@ -2,7 +2,7 @@ use std::mem;
 
 use egui::{Layout, ScrollArea};
 use nostrdb::Ndb;
-use notedeck::{tr, Images, JobPool, JobsCache, Localization};
+use notedeck::{tr, Images, JobPool, JobsCache, Localization, VideoManager};
 use notedeck_ui::{
     colors,
     nip51_set::{Nip51SetUiCache, Nip51SetWidget, Nip51SetWidgetAction, Nip51SetWidgetFlags},
@@ -19,6 +19,7 @@ pub struct FollowPackOnboardingView<'a> {
     loc: &'a mut Localization,
     job_pool: &'a mut JobPool,
     jobs: &'a mut JobsCache,
+    video: &'a mut VideoManager,
 }
 
 pub enum OnboardingResponse {
@@ -40,6 +41,7 @@ impl<'a> FollowPackOnboardingView<'a> {
         loc: &'a mut Localization,
         job_pool: &'a mut JobPool,
         jobs: &'a mut JobsCache,
+        video: &'a mut VideoManager,
     ) -> Self {
         Self {
             onboarding,
@@ -49,6 +51,7 @@ impl<'a> FollowPackOnboardingView<'a> {
             loc,
             job_pool,
             jobs,
+            video,
         }
     }
 
@@ -83,6 +86,7 @@ impl<'a> FollowPackOnboardingView<'a> {
                                 self.images,
                                 self.job_pool,
                                 self.jobs,
+                                self.video,
                             )
                             .with_flags(Nip51SetWidgetFlags::TRUST_IMAGES)
                             .render_at_index(ui, index);

--- a/crates/notedeck_dave/src/ui/dave.rs
+++ b/crates/notedeck_dave/src/ui/dave.rs
@@ -220,6 +220,7 @@ impl<'a> DaveUi<'a> {
             pool: ctx.pool,
             job_pool: ctx.job_pool,
             unknown_ids: ctx.unknown_ids,
+            video: ctx.video,
             clipboard: ctx.clipboard,
             i18n: ctx.i18n,
             global_wallet: ctx.global_wallet,

--- a/crates/notedeck_media_gst/Cargo.toml
+++ b/crates/notedeck_media_gst/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "notedeck_media_gst"
+version = { workspace = true }
+edition = "2021"
+description = "GStreamer-backed media playback plumbing for Notedeck"
+
+[dependencies]
+crossbeam-channel = "0.5"
+glib = "0.19"
+gstreamer = { version = "0.22", features = ["v1_20"] }
+gstreamer-app = { version = "0.22", features = ["v1_20"] }
+gstreamer-video = { version = "0.22", features = ["v1_20"] }
+once_cell = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }

--- a/crates/notedeck_media_gst/src/lib.rs
+++ b/crates/notedeck_media_gst/src/lib.rs
@@ -1,0 +1,760 @@
+//! GStreamer-backed video playback manager for Notedeck.
+//!
+//! This module brokers communication between the egui UI thread and a
+//! background GStreamer worker. The UI requests players for HTTP(S) MP4 URLs,
+//! and the backend handles progressive download, hardware-accelerated decode,
+//! and surface extraction into CPU RGBA frames suitable for upload to wgpu.
+
+use std::cmp::min;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, Sender};
+use gstreamer as gst;
+use gstreamer::prelude::*;
+use gstreamer_app as gst_app;
+use gstreamer_video as gst_video;
+use once_cell::sync::Lazy;
+use tracing::{debug, error, trace, warn};
+use url::Url;
+
+static GST_INIT: Lazy<Result<(), gst::glib::Error>> = Lazy::new(gst::init);
+
+/// Unique identifier for a video session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VideoId(u64);
+
+impl VideoId {
+    fn next(counter: &mut u64) -> Self {
+        let id = *counter;
+        *counter = counter.wrapping_add(1);
+        VideoId(id)
+    }
+
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
+/// RGBA frame extracted from the GStreamer pipeline.
+#[derive(Clone, Debug)]
+pub struct VideoFrame {
+    pub width: u32,
+    pub height: u32,
+    pub pixels: Arc<[u8]>,
+    pub generation: u64,
+    pub timestamp: Option<Duration>,
+}
+
+#[derive(Debug, Clone)]
+pub struct VideoState {
+    pub id: VideoId,
+    pub url: Url,
+    pub created_at: Instant,
+    pub status: VideoStatus,
+    pub poster: Option<Arc<VideoFrame>>,
+    pub current_frame: Option<Arc<VideoFrame>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VideoStatus {
+    Idle,
+    Opening,
+    Paused,
+    Playing,
+    Ended,
+    Failed(String),
+}
+
+#[derive(Debug, Clone)]
+pub enum VideoEvent {
+    StateChanged(VideoState),
+    PosterReady { id: VideoId, frame: Arc<VideoFrame> },
+    FrameReady { id: VideoId, frame: Arc<VideoFrame> },
+}
+
+#[derive(Debug, Clone)]
+pub struct VideoManagerConfig {
+    pub user_agent: String,
+    pub connect_timeout: Duration,
+    pub read_timeout: Duration,
+}
+
+impl Default for VideoManagerConfig {
+    fn default() -> Self {
+        Self {
+            user_agent: "Notedeck/0.0 (video)".to_string(),
+            connect_timeout: Duration::from_secs(10),
+            read_timeout: Duration::from_secs(20),
+        }
+    }
+}
+
+pub struct VideoManager {
+    config: VideoManagerConfig,
+    enabled: bool,
+    counter: u64,
+    players: HashMap<VideoId, VideoState>,
+    url_index: HashMap<String, VideoId>,
+    events: Vec<VideoEvent>,
+    backend: Option<BackendHandle>,
+}
+
+impl Default for VideoManager {
+    fn default() -> Self {
+        Self::new(VideoManagerConfig::default())
+    }
+}
+
+impl VideoManager {
+    pub fn new(config: VideoManagerConfig) -> Self {
+        let enabled = match &*GST_INIT {
+            Ok(_) => true,
+            Err(err) => {
+                error!("Failed to initialize GStreamer: {err}");
+                false
+            }
+        };
+
+        let backend = if enabled {
+            BackendHandle::spawn()
+        } else {
+            None
+        };
+
+        Self {
+            config,
+            enabled,
+            counter: 0,
+            players: HashMap::new(),
+            url_index: HashMap::new(),
+            events: Vec::new(),
+            backend,
+        }
+    }
+
+    pub fn ensure_player_from_str(&mut self, url: &str) -> Result<VideoHandle, url::ParseError> {
+        let parsed = Url::parse(url)?;
+        Ok(self.ensure_player(parsed))
+    }
+
+    pub fn ensure_player(&mut self, url: Url) -> VideoHandle {
+        if let Some(&id) = self.url_index.get(url.as_str()) {
+            return VideoHandle { id };
+        }
+
+        let id = VideoId::next(&mut self.counter);
+
+        let state = VideoState {
+            id,
+            url: url.clone(),
+            created_at: Instant::now(),
+            status: VideoStatus::Opening,
+            poster: None,
+            current_frame: None,
+        };
+
+        self.players.insert(id, state.clone());
+        self.url_index.insert(url.as_str().to_owned(), id);
+
+        self.events.push(VideoEvent::StateChanged(state));
+
+        if let Some(backend) = &self.backend {
+            backend.send(BackendCommand::Create {
+                id,
+                url: url.to_string(),
+                config: self.config.clone(),
+            });
+        } else {
+            self.fail_player(id, "Video backend unavailable".to_string());
+        }
+
+        VideoHandle { id }
+    }
+
+    pub fn create_player(&mut self, url: Url) -> VideoHandle {
+        self.ensure_player(url)
+    }
+
+    pub fn handle_for_str(&self, url: &str) -> Option<VideoHandle> {
+        Url::parse(url)
+            .ok()
+            .and_then(|parsed| self.handle_for_url(&parsed))
+    }
+
+    pub fn handle_for_url(&self, url: &Url) -> Option<VideoHandle> {
+        self.url_index
+            .get(url.as_str())
+            .copied()
+            .map(|id| VideoHandle { id })
+    }
+
+    pub fn play(&mut self, handle: VideoHandle) {
+        self.pump_backend_events();
+        if let Some(state) = self.players.get_mut(&handle.id) {
+            if !matches!(state.status, VideoStatus::Playing) {
+                state.status = VideoStatus::Playing;
+                self.events.push(VideoEvent::StateChanged(state.clone()));
+            }
+        }
+        if let Some(backend) = &self.backend {
+            backend.send(BackendCommand::Play { id: handle.id });
+        }
+    }
+
+    pub fn pause(&mut self, handle: VideoHandle) {
+        self.pump_backend_events();
+        if let Some(state) = self.players.get_mut(&handle.id) {
+            if !matches!(state.status, VideoStatus::Paused) {
+                state.status = VideoStatus::Paused;
+                self.events.push(VideoEvent::StateChanged(state.clone()));
+            }
+        }
+        if let Some(backend) = &self.backend {
+            backend.send(BackendCommand::Pause { id: handle.id });
+        }
+    }
+
+    pub fn drop_player(&mut self, handle: VideoHandle) {
+        self.pump_backend_events();
+
+        if let Some(state) = self.players.remove(&handle.id) {
+            self.events.push(VideoEvent::StateChanged(VideoState {
+                status: VideoStatus::Ended,
+                ..state
+            }));
+        }
+
+        self.url_index.retain(|_, id| *id != handle.id);
+
+        if let Some(backend) = &self.backend {
+            backend.send(BackendCommand::Drop { id: handle.id });
+        }
+    }
+
+    pub fn drain_events(&mut self) -> impl Iterator<Item = VideoEvent> + '_ {
+        self.pump_backend_events();
+        self.events.drain(..)
+    }
+
+    pub fn state(&mut self, handle: VideoHandle) -> Option<VideoState> {
+        self.pump_backend_events();
+        self.players.get(&handle.id).cloned()
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled && self.backend.is_some()
+    }
+
+    fn pump_backend_events(&mut self) {
+        let events: Vec<_> = match &self.backend {
+            Some(backend) => backend.events.try_iter().collect(),
+            None => return,
+        };
+
+        for event in events {
+            match event {
+                BackendEvent::Poster { id, frame } => {
+                    if let Some(state) = self.players.get_mut(&id) {
+                        state.poster = Some(frame.clone());
+                        if state.current_frame.is_none() {
+                            state.current_frame = Some(frame.clone());
+                        }
+                        if matches!(state.status, VideoStatus::Opening | VideoStatus::Idle) {
+                            state.status = VideoStatus::Paused;
+                        }
+                        self.events.push(VideoEvent::PosterReady { id, frame });
+                        self.events.push(VideoEvent::StateChanged(state.clone()));
+                    }
+                }
+                BackendEvent::Frame { id, frame } => {
+                    if let Some(state) = self.players.get_mut(&id) {
+                        state.current_frame = Some(frame.clone());
+                        self.events.push(VideoEvent::FrameReady { id, frame });
+                    }
+                }
+                BackendEvent::State { id, status } => {
+                    if let Some(state) = self.players.get_mut(&id) {
+                        state.status = status.clone();
+                        if matches!(status, VideoStatus::Ended | VideoStatus::Failed(_)) {
+                            // Keep last frame/poster for UI overlays.
+                        }
+                        self.events.push(VideoEvent::StateChanged(state.clone()));
+                    }
+                }
+                BackendEvent::Error { id, message } => {
+                    error!(
+                        video_id = id.as_u64(),
+                        %message,
+                        "video backend reported error"
+                    );
+                    self.fail_player(id, message);
+                }
+            }
+        }
+    }
+
+    fn fail_player(&mut self, id: VideoId, message: String) {
+        if let Some(state) = self.players.get_mut(&id) {
+            state.status = VideoStatus::Failed(message.clone());
+            self.events.push(VideoEvent::StateChanged(state.clone()));
+        }
+    }
+}
+
+impl Drop for VideoManager {
+    fn drop(&mut self) {
+        if let Some(mut backend) = self.backend.take() {
+            backend.send(BackendCommand::Shutdown);
+            if let Some(handle) = backend.join_handle.take() {
+                if let Err(err) = handle.join() {
+                    warn!("Failed to join video backend thread: {err:?}");
+                }
+            }
+        }
+        self.players.clear();
+        self.url_index.clear();
+        self.events.clear();
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VideoHandle {
+    pub id: VideoId,
+}
+
+struct BackendHandle {
+    cmd_tx: Sender<BackendCommand>,
+    events: Receiver<BackendEvent>,
+    join_handle: Option<thread::JoinHandle<()>>,
+}
+
+impl BackendHandle {
+    fn spawn() -> Option<Self> {
+        let (cmd_tx, cmd_rx) = unbounded();
+        let (evt_tx, evt_rx) = unbounded();
+
+        let handle = thread::Builder::new()
+            .name("notedeck-gst-video".into())
+            .spawn(move || backend_main(cmd_rx, evt_tx))
+            .map_err(|err| {
+                error!("Failed to spawn video backend thread: {err}");
+            })
+            .ok()?;
+
+        Some(Self {
+            cmd_tx,
+            events: evt_rx,
+            join_handle: Some(handle),
+        })
+    }
+
+    fn send(&self, command: BackendCommand) {
+        if let Err(err) = self.cmd_tx.send(command) {
+            debug!("Video backend channel closed: {err}");
+        }
+    }
+}
+
+#[derive(Clone)]
+struct BackendPlayer {
+    id: VideoId,
+    playbin: gst::Element,
+    bus: gst::Bus,
+    _appsink: gst_app::AppSink,
+}
+
+enum BackendCommand {
+    Create {
+        id: VideoId,
+        url: String,
+        config: VideoManagerConfig,
+    },
+    Play {
+        id: VideoId,
+    },
+    Pause {
+        id: VideoId,
+    },
+    Drop {
+        id: VideoId,
+    },
+    Shutdown,
+}
+
+enum BackendEvent {
+    Poster { id: VideoId, frame: Arc<VideoFrame> },
+    Frame { id: VideoId, frame: Arc<VideoFrame> },
+    State { id: VideoId, status: VideoStatus },
+    Error { id: VideoId, message: String },
+}
+
+fn backend_main(cmd_rx: Receiver<BackendCommand>, evt_tx: Sender<BackendEvent>) {
+    let mut players: HashMap<VideoId, BackendPlayer> = HashMap::new();
+
+    loop {
+        // Periodically drain bus messages even if no new commands arrive.
+        pump_buses(&players, &evt_tx);
+
+        match cmd_rx.recv_timeout(Duration::from_millis(50)) {
+            Ok(BackendCommand::Create { id, url, config }) => {
+                if players.contains_key(&id) {
+                    continue;
+                }
+
+                match BackendPlayer::new(id, url.clone(), config.clone(), evt_tx.clone()) {
+                    Ok(player) => {
+                        let playbin = player.playbin.clone();
+                        match playbin.set_state(gst::State::Paused) {
+                            Ok(result) => {
+                                trace!(id = id.as_u64(), ?result, "Initialized playbin to paused");
+                            }
+                            Err(err) => {
+                                let message = format!("Failed to pre-roll video pipeline: {err:?}");
+                                let _ = evt_tx.send(BackendEvent::Error { id, message });
+                            }
+                        }
+                        players.insert(id, player.clone());
+                    }
+                    Err(err) => {
+                        let message = format!("Failed to create player: {err}");
+                        let _ = evt_tx.send(BackendEvent::Error { id, message });
+                    }
+                }
+            }
+            Ok(BackendCommand::Play { id }) => {
+                if let Some(player) = players.get(&id) {
+                    set_pipeline_state(&player.playbin, gst::State::Playing, &evt_tx, id);
+                }
+            }
+            Ok(BackendCommand::Pause { id }) => {
+                if let Some(player) = players.get(&id) {
+                    set_pipeline_state(&player.playbin, gst::State::Paused, &evt_tx, id);
+                }
+            }
+            Ok(BackendCommand::Drop { id }) => {
+                if let Some(player) = players.remove(&id) {
+                    let _ = player.playbin.set_state(gst::State::Null);
+                    let _ = evt_tx.send(BackendEvent::State {
+                        id,
+                        status: VideoStatus::Ended,
+                    });
+                }
+            }
+            Ok(BackendCommand::Shutdown) => break,
+            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Disconnected) => break,
+        }
+    }
+
+    // Clean shutdown of players.
+    for (_, player) in players {
+        let _ = player.playbin.set_state(gst::State::Null);
+    }
+}
+
+fn pump_buses(players: &HashMap<VideoId, BackendPlayer>, evt_tx: &Sender<BackendEvent>) {
+    for player in players.values() {
+        while let Some(msg) = player.bus.pop() {
+            handle_bus_message(player, msg, evt_tx);
+        }
+    }
+}
+
+fn handle_bus_message(player: &BackendPlayer, msg: gst::Message, evt_tx: &Sender<BackendEvent>) {
+    use gst::MessageView;
+
+    match msg.view() {
+        MessageView::Error(err) => {
+            let mut debug_msg = err.debug().map(|d| d.to_string()).unwrap_or_default();
+            if debug_msg.len() > 512 {
+                debug_msg.truncate(512);
+                debug_msg.push('…');
+            }
+            let message = if debug_msg.is_empty() {
+                err.error().to_string()
+            } else {
+                format!("{} ({debug_msg})", err.error())
+            };
+            let _ = evt_tx.send(BackendEvent::Error {
+                id: player.id,
+                message,
+            });
+        }
+        MessageView::Eos(_) => {
+            let _ = evt_tx.send(BackendEvent::State {
+                id: player.id,
+                status: VideoStatus::Ended,
+            });
+        }
+        MessageView::StateChanged(state) => {
+            let Some(src) = state.src() else {
+                return;
+            };
+
+            if src.as_ptr() != player.playbin.as_ptr() as *mut gst::ffi::GstObject {
+                return;
+            }
+
+            let status = match state.current() {
+                gst::State::Playing => VideoStatus::Playing,
+                gst::State::Paused | gst::State::Ready => VideoStatus::Paused,
+                gst::State::Null => VideoStatus::Ended,
+                _ => VideoStatus::Opening,
+            };
+
+            let _ = evt_tx.send(BackendEvent::State {
+                id: player.id,
+                status,
+            });
+        }
+        _ => {}
+    }
+}
+
+fn set_pipeline_state(
+    playbin: &gst::Element,
+    state: gst::State,
+    evt_tx: &Sender<BackendEvent>,
+    id: VideoId,
+) {
+    match playbin.set_state(state) {
+        Ok(gst::StateChangeSuccess::Async) | Ok(gst::StateChangeSuccess::Success) => {}
+        Ok(gst::StateChangeSuccess::NoPreroll) => {
+            trace!(id = id.as_u64(), ?state, "pipeline reported NoPreroll");
+        }
+        Err(err) => {
+            let _ = evt_tx.send(BackendEvent::Error {
+                id,
+                message: format!("Failed to change state to {state:?}: {err:?}"),
+            });
+        }
+    }
+}
+
+impl BackendPlayer {
+    fn new(
+        id: VideoId,
+        url: String,
+        config: VideoManagerConfig,
+        evt_tx: Sender<BackendEvent>,
+    ) -> Result<Self, String> {
+        let playbin = gst::ElementFactory::make("playbin")
+            .build()
+            .map_err(|_| "Missing GStreamer element 'playbin'".to_string())?;
+
+        playbin.set_property("uri", url.as_str());
+
+        if playbin.has_property("user-agent", None) {
+            playbin.set_property("user-agent", config.user_agent.as_str());
+        } else {
+            trace!("playbin missing user-agent property; skipping set");
+        }
+
+        let generation = Arc::new(AtomicU64::new(1));
+        let has_poster = Arc::new(AtomicBool::new(false));
+
+        let appsink =
+            Self::configure_video_sink(id, evt_tx.clone(), generation.clone(), has_poster.clone())?;
+
+        playbin.set_property("video-sink", &appsink);
+
+        Self::configure_source(&playbin, &config);
+
+        let bus = playbin
+            .bus()
+            .ok_or_else(|| "playbin missing bus".to_string())?;
+
+        Ok(Self {
+            id,
+            playbin,
+            bus,
+            _appsink: appsink,
+        })
+    }
+
+    fn configure_video_sink(
+        id: VideoId,
+        evt_tx: Sender<BackendEvent>,
+        generation: Arc<AtomicU64>,
+        has_poster: Arc<AtomicBool>,
+    ) -> Result<gst_app::AppSink, String> {
+        let element = gst::ElementFactory::make("appsink")
+            .property("sync", false)
+            .build()
+            .map_err(|_| "Missing GStreamer element 'appsink'".to_string())?;
+
+        let appsink = element
+            .downcast::<gst_app::AppSink>()
+            .map_err(|_| "Failed to downcast appsink".to_string())?;
+
+        let caps = gst::Caps::builder("video/x-raw")
+            .field("format", &"RGBA")
+            .field("pixel-aspect-ratio", &gst::Fraction::new(1, 1))
+            .build();
+        appsink.set_caps(Some(&caps));
+        appsink.set_drop(true);
+        appsink.set_max_buffers(4);
+        appsink.set_qos(true);
+
+        let video_id = id;
+        let callbacks = gst_app::AppSinkCallbacks::builder()
+            .new_sample(move |sink| match sink.pull_sample() {
+                Ok(sample) => {
+                    if let Err(err) = convert_sample_to_frame(
+                        &sample,
+                        video_id,
+                        &generation,
+                        &has_poster,
+                        &evt_tx,
+                    ) {
+                        let _ = evt_tx.send(BackendEvent::Error {
+                            id: video_id,
+                            message: err,
+                        });
+                        return Err(gst::FlowError::Error);
+                    }
+                    Ok(gst::FlowSuccess::Ok)
+                }
+                Err(err) => {
+                    trace!(
+                        id = video_id.as_u64(),
+                        error = %err,
+                        "appsink pull_sample returned BoolError; treating as flushing"
+                    );
+                    Err(gst::FlowError::Flushing)
+                }
+            })
+            .build();
+
+        appsink.set_callbacks(callbacks);
+
+        Ok(appsink)
+    }
+
+    fn configure_source(playbin: &gst::Element, config: &VideoManagerConfig) {
+        let connect_timeout = seconds_clamped(config.connect_timeout);
+        let read_timeout = seconds_clamped(config.read_timeout);
+        let user_agent = config.user_agent.clone();
+
+        let _ = playbin.connect("source-setup", false, move |values| {
+            if let Some(value) = values.get(1) {
+                if let Ok(source_obj) = value.get::<gst::Object>() {
+                    if let Ok(element) = source_obj.downcast::<gst::Element>() {
+                        if element.has_property("user-agent", None) {
+                            element.set_property("user-agent", user_agent.as_str());
+                        }
+                        if element.has_property("timeout", None) {
+                            element.set_property("timeout", connect_timeout);
+                        }
+                        if element.has_property("read-timeout", None) {
+                            element.set_property("read-timeout", read_timeout);
+                        }
+                        if element.has_property("connect-timeout", None) {
+                            element.set_property("connect-timeout", connect_timeout);
+                        }
+                    }
+                }
+            }
+            None
+        });
+    }
+}
+
+fn seconds_clamped(duration: Duration) -> u32 {
+    min(duration.as_secs(), u32::MAX as u64) as u32
+}
+
+fn convert_sample_to_frame(
+    sample: &gst::Sample,
+    id: VideoId,
+    generation: &Arc<AtomicU64>,
+    has_poster: &Arc<AtomicBool>,
+    evt_tx: &Sender<BackendEvent>,
+) -> Result<(), String> {
+    let caps = sample
+        .caps()
+        .ok_or_else(|| "sample missing caps".to_string())?;
+
+    let info = gst_video::VideoInfo::from_caps(caps)
+        .map_err(|err| format!("failed to parse video info: {err}"))?;
+
+    let buffer = sample
+        .buffer()
+        .ok_or_else(|| "sample missing buffer".to_string())?;
+
+    let map = buffer
+        .map_readable()
+        .map_err(|_| "failed to map buffer".to_string())?;
+
+    let data = map.as_slice();
+
+    let width = info.width();
+    let height = info.height();
+
+    let stride = info.stride()[0] as usize;
+    let row_bytes = (width as usize) * 4;
+
+    let mut pixels = vec![0u8; row_bytes * (height as usize)];
+
+    let pixels_len = pixels.len();
+
+    if stride == row_bytes && data.len() >= pixels_len {
+        pixels.copy_from_slice(&data[..pixels_len]);
+    } else {
+        let available = data.len();
+        for y in 0..height as usize {
+            let src_offset = y * stride;
+            let dst_offset = y * row_bytes;
+            if dst_offset + row_bytes > pixels_len {
+                break;
+            }
+            if src_offset + row_bytes > available {
+                break;
+            }
+            pixels[dst_offset..dst_offset + row_bytes]
+                .copy_from_slice(&data[src_offset..src_offset + row_bytes]);
+        }
+    }
+
+    let generation_value = generation.fetch_add(1, Ordering::SeqCst);
+
+    let timestamp = buffer
+        .pts()
+        .or_else(|| buffer.dts())
+        .map(|clock_time| Duration::from_nanos(clock_time.nseconds().into()));
+
+    let frame = Arc::new(VideoFrame {
+        width,
+        height,
+        pixels: pixels.into(),
+        generation: generation_value,
+        timestamp,
+    });
+
+    trace!(
+        video_id = id.as_u64(),
+        generation = generation_value,
+        width,
+        height,
+        pts_ns = frame
+            .timestamp
+            .map(|ts| ts.as_nanos() as u64)
+            .unwrap_or_default(),
+        "converted video frame"
+    );
+
+    if !has_poster.swap(true, Ordering::SeqCst) {
+        let _ = evt_tx.send(BackendEvent::Poster {
+            id,
+            frame: frame.clone(),
+        });
+    }
+
+    let _ = evt_tx.send(BackendEvent::Frame { id, frame });
+
+    Ok(())
+}

--- a/crates/notedeck_ui/src/media/mod.rs
+++ b/crates/notedeck_ui/src/media/mod.rs
@@ -1,3 +1,9 @@
+mod video;
 mod viewer;
 
+pub use video::{
+    draw_error_overlay, draw_pause_overlay, draw_play_overlay, fit_rect_to_aspect,
+    load_state as load_video_texture_state, store_state as store_video_texture_state,
+    VideoTextureState,
+};
 pub use viewer::{MediaViewer, MediaViewerFlags, MediaViewerState};

--- a/crates/notedeck_ui/src/media/video.rs
+++ b/crates/notedeck_ui/src/media/video.rs
@@ -1,0 +1,193 @@
+use egui::{
+    pos2, vec2, Align2, Color32, ColorImage, Context, CornerRadius, FontId, Id, Painter, Rect,
+    Shape, Stroke, TextureHandle, TextureOptions, Ui,
+};
+use notedeck::{VideoFrame, VideoHandle};
+
+#[derive(Clone, Default)]
+pub struct VideoTextureState {
+    pub handle: Option<VideoHandle>,
+    pub poster_generation: u64,
+    pub frame_generation: u64,
+    pub poster_texture: Option<TextureHandle>,
+    pub frame_texture: Option<TextureHandle>,
+}
+
+impl VideoTextureState {
+    pub fn ensure_handle(&mut self, handle: VideoHandle) {
+        if self.handle != Some(handle) {
+            self.handle = Some(handle);
+            self.poster_generation = 0;
+            self.frame_generation = 0;
+            self.poster_texture = None;
+            self.frame_texture = None;
+        }
+    }
+
+    pub fn poster_texture(
+        &mut self,
+        ui: &Ui,
+        handle: VideoHandle,
+        frame: &VideoFrame,
+    ) -> TextureHandle {
+        self.ensure_handle(handle);
+        update_texture(
+            ui,
+            &mut self.poster_texture,
+            &mut self.poster_generation,
+            handle,
+            "poster",
+            frame,
+        )
+    }
+
+    pub fn frame_texture(
+        &mut self,
+        ui: &Ui,
+        handle: VideoHandle,
+        frame: &VideoFrame,
+    ) -> TextureHandle {
+        self.ensure_handle(handle);
+        update_texture(
+            ui,
+            &mut self.frame_texture,
+            &mut self.frame_generation,
+            handle,
+            "frame",
+            frame,
+        )
+    }
+}
+
+fn update_texture(
+    ui: &Ui,
+    slot: &mut Option<TextureHandle>,
+    generation: &mut u64,
+    handle: VideoHandle,
+    suffix: &str,
+    frame: &VideoFrame,
+) -> TextureHandle {
+    if *generation != frame.generation || slot.is_none() {
+        let image = frame_to_image(frame);
+        let name = format!("video:{}:{suffix}", handle.id.as_u64());
+        match slot {
+            Some(existing) => {
+                existing.set(image, TextureOptions::LINEAR);
+            }
+            None => {
+                let texture = ui.ctx().load_texture(name, image, TextureOptions::LINEAR);
+                *slot = Some(texture);
+            }
+        }
+        *generation = frame.generation;
+    }
+
+    slot.as_ref()
+        .expect("texture must exist after update")
+        .clone()
+}
+
+fn frame_to_image(frame: &VideoFrame) -> ColorImage {
+    ColorImage::from_rgba_unmultiplied(
+        [frame.width as usize, frame.height as usize],
+        frame.pixels.as_ref(),
+    )
+}
+
+pub fn load_state(ctx: &Context, id: Id) -> VideoTextureState {
+    ctx.data_mut(|data| {
+        if let Some(existing) = data.get_persisted::<VideoTextureState>(id) {
+            existing.clone()
+        } else {
+            VideoTextureState::default()
+        }
+    })
+}
+
+pub fn store_state(ctx: &Context, id: Id, state: VideoTextureState) {
+    ctx.data_mut(|data| {
+        data.insert_persisted(id, state);
+    });
+}
+
+pub fn fit_rect_to_aspect(rect: Rect, aspect: f32) -> Rect {
+    if aspect <= f32::EPSILON {
+        return rect;
+    }
+
+    let size = rect.size();
+    if size.x <= 0.0 || size.y <= 0.0 {
+        return rect;
+    }
+
+    let current = size.x / size.y;
+    if (current - aspect).abs() < f32::EPSILON {
+        rect
+    } else if current > aspect {
+        let new_width = size.y * aspect;
+        Rect::from_center_size(rect.center(), vec2(new_width, size.y))
+    } else {
+        let new_height = size.x / aspect;
+        Rect::from_center_size(rect.center(), vec2(size.x, new_height))
+    }
+}
+
+pub fn draw_play_overlay(painter: &Painter, rect: Rect) {
+    let radius = rect.size().min_elem() * 0.18;
+    let center = rect.center();
+
+    painter.circle_filled(center, radius, Color32::from_black_alpha(160));
+
+    let points = [
+        pos2(center.x - radius * 0.35, center.y - radius * 0.6),
+        pos2(center.x - radius * 0.35, center.y + radius * 0.6),
+        pos2(center.x + radius * 0.75, center.y),
+    ];
+    painter.add(Shape::convex_polygon(
+        points.to_vec(),
+        Color32::WHITE,
+        Stroke::NONE,
+    ));
+}
+
+pub fn draw_pause_overlay(painter: &Painter, rect: Rect) {
+    let radius = rect.size().min_elem() * 0.18;
+    let center = rect.center();
+
+    painter.circle_filled(center, radius, Color32::from_black_alpha(160));
+
+    let bar_width = radius * 0.35;
+    let bar_height = radius * 1.2;
+    let spacing = bar_width * 0.7;
+
+    let left = Rect::from_center_size(
+        pos2(center.x - spacing * 0.5, center.y),
+        vec2(bar_width, bar_height),
+    );
+    let right = Rect::from_center_size(
+        pos2(center.x + spacing * 0.5, center.y),
+        vec2(bar_width, bar_height),
+    );
+
+    let bar_corner = (bar_width * 0.25).clamp(0.0, 50.0) as u8;
+    painter.rect_filled(left, CornerRadius::same(bar_corner), Color32::WHITE);
+    painter.rect_filled(right, CornerRadius::same(bar_corner), Color32::WHITE);
+}
+
+pub fn draw_error_overlay(painter: &Painter, rect: Rect, message: &str) {
+    painter.rect_filled(rect, CornerRadius::same(6), Color32::from_black_alpha(200));
+
+    let mut truncated = message.trim().to_owned();
+    if truncated.len() > 96 {
+        truncated.truncate(96);
+        truncated.push('…');
+    }
+
+    painter.text(
+        rect.center(),
+        Align2::CENTER_CENTER,
+        truncated,
+        FontId::proportional(13.0),
+        Color32::from_rgb(255, 120, 120),
+    );
+}

--- a/crates/notedeck_ui/src/nip51_set.rs
+++ b/crates/notedeck_ui/src/nip51_set.rs
@@ -5,7 +5,7 @@ use hashbrown::{hash_map::RawEntryMut, HashMap};
 use nostrdb::{Ndb, ProfileRecord, Transaction};
 use notedeck::{
     fonts::get_font_size, get_profile_url, name::get_display_name, tr, Images, JobPool, JobsCache,
-    Localization, Nip51Set, Nip51SetCache, NotedeckTextStyle,
+    Localization, Nip51Set, Nip51SetCache, NotedeckTextStyle, VideoManager,
 };
 
 use crate::{
@@ -21,6 +21,7 @@ pub struct Nip51SetWidget<'a> {
     loc: &'a mut Localization,
     job_pool: &'a mut JobPool,
     jobs: &'a mut JobsCache,
+    video: &'a mut VideoManager,
     flags: Nip51SetWidgetFlags,
 }
 
@@ -55,6 +56,7 @@ impl<'a> Nip51SetWidget<'a> {
         images: &'a mut Images,
         job_pool: &'a mut JobPool,
         jobs: &'a mut JobsCache,
+        video: &'a mut VideoManager,
     ) -> Self {
         Self {
             state,
@@ -64,6 +66,7 @@ impl<'a> Nip51SetWidget<'a> {
             images,
             job_pool,
             jobs,
+            video,
             flags: Nip51SetWidgetFlags::default(),
         }
     }
@@ -92,6 +95,7 @@ impl<'a> Nip51SetWidget<'a> {
                     self.ui_state,
                     self.ndb,
                     self.images,
+                    self.video,
                     self.job_pool,
                     self.jobs,
                     self.loc,
@@ -157,6 +161,7 @@ fn render_pack(
     ui_state: &mut Nip51SetUiCache,
     ndb: &Ndb,
     images: &mut Images,
+    video: &mut VideoManager,
     job_pool: &mut JobPool,
     jobs: &mut JobsCache,
     loc: &mut Localization,
@@ -175,6 +180,7 @@ fn render_pack(
         let media_rect = render_media(
             ui,
             images,
+            video,
             job_pool,
             jobs,
             &media,

--- a/crates/notedeck_ui/src/note/contents.rs
+++ b/crates/notedeck_ui/src/note/contents.rs
@@ -375,6 +375,7 @@ fn render_undecorated_note_contents<'a>(
         media_action = image_carousel(
             ui,
             note_context.img_cache,
+            note_context.video,
             note_context.job_pool,
             jobs,
             &supported_medias,

--- a/crates/notedeck_ui/src/profile/picture.rs
+++ b/crates/notedeck_ui/src/profile/picture.rs
@@ -132,6 +132,7 @@ fn render_pfp(
     let img_size = 128u32;
 
     let cache_type = supported_mime_hosted_at_url(&mut img_cache.urls, url)
+        .and_then(|kind| kind.as_cache_type())
         .unwrap_or(notedeck::MediaCacheType::Image);
 
     let cur_state = get_render_state(


### PR DESCRIPTION
Title: Add GStreamer-backed MP4 playback with pause/resume fixes

  - add new notedeck_media_gst crate wired into AppContext, expose VideoManager types, and enable inline/
    fullscreen playback of HTTP(S) MP4s.
  - bundle the GStreamer dependencies (gstreamer, gstreamer-app, gstreamer-video, etc.) and thread the manager
    pipeline, poster extraction, frame uploads, and event propagation into egui.
  - harden the backend to avoid panics when playbin lacks a user-agent property, survive flush/pause paths by
    translating BoolError into FlowError::Flushing, and add frame-level tracing so pauses/resumes no longer
    freeze the video surface.
  - adjust timeline/thread.rs to fix an Into ambiguity introduced by the new deps.

### assessment

GStreamer is not very performant. Can only run on software (disableing hardware acceleration) on Linux.
  
https://github.com/damus-io/notedeck/issues/248
