### PR TITLE
Fix soft keyboard

### DIFF
--- a/crates/notedeck_chrome/src/chrome.rs
+++ b/crates/notedeck_chrome/src/chrome.rs
@@ -302,6 +302,8 @@ impl Chrome {
         // if the soft keyboard is open, shrink the chrome contents
         let mut action: Option<ChromePanelAction> = None;
         // build a strip to carve out the soft keyboard inset
+        let prev_spacing = ui.spacing().item_spacing;
+        ui.spacing_mut().item_spacing.y = 0.0;
         StripBuilder::new(ui)
             .size(Size::remainder())
             .size(Size::exact(keyboard_height))
@@ -319,6 +321,7 @@ impl Chrome {
                     }
                 });
             });
+        ui.spacing_mut().item_spacing = prev_spacing;
 
         // hovering virtual keyboard
         if virtual_keyboard {


### PR DESCRIPTION
df5cf8a1fc28a78bcb58b892717a85835da01591 caused a regression
    making the soft keyboard auto close. This PR extends the shadow
    all the way vertically without triggering the regression.