### PR TITLE
Add cargo audit to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,19 @@ jobs:
           cargo fmt --all -- --check
           cargo clippy
 
+  cargo-audit:
+    name: Cargo Audit
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - name: Run cargo audit
+        run: cargo audit --deny warnings
+
   android:
     name: Check (android)
     runs-on: ubuntu-22.04


### PR DESCRIPTION
### Cargo Audit Purpose

| **Feature** | **Description** |
|--------------|----------------|
| **Purpose** | Audits Rust dependencies for security issues |
| **Checks** | Vulnerabilities, yanked crates, unmaintained crates |
| **Database** | Uses RustSec Advisory Database |
| **Usage** | `cargo audit` |
| **Install** | `cargo install cargo-audit` |
| **Common in** | CI pipelines and security-conscious Rust projects |

### Summary

  - add a cargo-audit job to .github/workflows/rust.yml alongside the existing
    lint/test matrix
  - install cargo-audit via taiki-e/install-action and run cargo audit --deny
    warnings so advisories fail the pipeline

 ###  Testing

  - cargo audit findings Oct 27 2025 run below. Otherwise github CI run will execute the new job
- slab 0.4.10 — RUSTSEC-2025-0047 — Out-of-bounds access in get_disjoint_mut —
    upgrade to ≥0.4.11
  - tracing-subscriber 0.3.19 — RUSTSEC-2025-0055 — Logging user input can
    inject ANSI escape sequences — upgrade to ≥0.3.20
- findings addressed in standalone [PR here](https://github.com/damus-io/notedeck/pull/1181)

