### PR TITLE
feat(media): add load media by default

### DIFF
--- a/crates/notedeck/src/persist/settings_handler.rs
+++ b/crates/notedeck/src/persist/settings_handler.rs
@@ -40,6 +40,7 @@ pub struct Settings {
     #[serde(default = "default_animate_nav_transitions")]
     pub animate_nav_transitions: bool,
     pub max_hashtags_per_note: usize,
+    pub load_media_by_default: bool,
 }
 
 fn default_animate_nav_transitions() -> bool {
@@ -57,6 +58,7 @@ impl Default for Settings {
             note_body_font_size: DEFAULT_NOTE_BODY_FONT_SIZE,
             animate_nav_transitions: default_animate_nav_transitions(),
             max_hashtags_per_note: DEFAULT_MAX_HASHTAGS_PER_NOTE,
+            load_media_by_default: false,
         }
     }
 }
@@ -75,7 +77,7 @@ impl SettingsHandler {
         }
     }
 
-    fn read_from_zomfactor_file(&self) -> Option<f32> {
+    fn read_from_zoomfactor_file(&self) -> Option<f32> {
         match self.directory.get_file(ZOOM_FACTOR_FILE.to_string()) {
             Ok(contents) => serde_json::from_str::<f32>(&contents).ok(),
             Err(_) => None,
@@ -97,11 +99,11 @@ impl SettingsHandler {
         };
 
         // if zoom_factor.txt exists migrate
-        if let Some(zom_factor) = self.read_from_zomfactor_file() {
+        if let Some(zoom_factor) = self.read_from_zoomfactor_file() {
             info!("migrating theme preference from zom_factor file");
             _ = delete_file(&self.directory.file_path, ZOOM_FACTOR_FILE.to_string());
 
-            settings.zoom_factor = zom_factor;
+            settings.zoom_factor = zoom_factor;
             migrated = true;
         } else {
             info!("zoom_factor.txt exists migrate file not found, using default zoom factor");
@@ -196,6 +198,11 @@ impl SettingsHandler {
         self.try_save_settings();
     }
 
+    pub fn set_load_media_by_default(&mut self, value: bool) {
+        self.get_settings_mut().load_media_by_default = value;
+        self.try_save_settings();
+    }
+
     pub fn set_note_body_font_size(&mut self, value: f32) {
         self.get_settings_mut().note_body_font_size = value;
         self.try_save_settings();
@@ -262,6 +269,13 @@ impl SettingsHandler {
 
     pub fn is_loaded(&self) -> bool {
         self.current_settings.is_some()
+    }
+
+    pub fn load_media_by_default(&self) -> bool {
+        self.current_settings
+            .as_ref()
+            .map(|s| s.load_media_by_default)
+            .unwrap_or(false)
     }
 
     pub fn note_body_font_size(&self) -> f32 {

--- a/crates/notedeck/src/ui.rs
+++ b/crates/notedeck/src/ui.rs
@@ -1,6 +1,47 @@
+use egui::{Color32, Stroke};
+
 use crate::NotedeckTextStyle;
 
 pub const NARROW_SCREEN_WIDTH: f32 = 550.0;
+
+pub fn toggle_ui(ui: &mut egui::Ui, on: &mut bool) -> egui::Response {
+    let desired_size = ui.spacing().interact_size.y * egui::vec2(2.0, 1.0);
+    let (rect, mut response) = ui.allocate_exact_size(desired_size, egui::Sense::click());
+    if response.clicked() {
+        *on = !*on;
+        response.mark_changed();
+    }
+    response.widget_info(|| {
+        egui::WidgetInfo::selected(egui::WidgetType::Checkbox, ui.is_enabled(), *on, "")
+    });
+
+    if ui.is_rect_visible(rect) {
+        let how_on = ui.ctx().animate_bool_responsive(response.id, *on);
+        let visuals = ui.style().interact_selectable(&response, *on);
+        let rect = rect.expand(visuals.expansion);
+        let radius = 0.5 * rect.height();
+        let stroke_color = if ui.visuals().dark_mode {
+            Color32::WHITE
+        } else {
+            Color32::BLACK
+        };
+        let stroke = Stroke::new(visuals.fg_stroke.width, stroke_color);
+
+        ui.painter().rect(
+            rect,
+            radius,
+            visuals.bg_fill,
+            visuals.bg_stroke,
+            egui::StrokeKind::Inside,
+        );
+        let circle_x = egui::lerp((rect.left() + radius)..=(rect.right() - radius), how_on);
+        let center = egui::pos2(circle_x, rect.center().y);
+        ui.painter()
+            .circle(center, 0.75 * radius, visuals.bg_fill, stroke);
+    }
+
+    response
+}
 
 pub fn richtext_small<S>(text: S) -> egui::RichText
 where

--- a/crates/notedeck_columns/src/app.rs
+++ b/crates/notedeck_columns/src/app.rs
@@ -57,7 +57,6 @@ pub struct Damus {
     /// Were columns loaded from the commandline? If so disable persistence.
     pub options: AppOptions,
     pub note_options: NoteOptions,
-
     pub unrecognized_args: BTreeSet<String>,
 
     /// keep track of follow packs
@@ -373,6 +372,11 @@ fn render_damus(damus: &mut Damus, app_ctx: &mut AppContext<'_>, ui: &mut egui::
         .note_options
         .set(NoteOptions::Wide, is_narrow(ui.ctx()));
 
+    damus.note_options.set(
+        NoteOptions::LoadMediaByDefault,
+        app_ctx.settings.load_media_by_default(),
+    );
+
     let app_resp = if notedeck::ui::is_narrow(ui.ctx()) {
         render_damus_mobile(damus, app_ctx, ui)
     } else {
@@ -603,6 +607,11 @@ impl Damus {
 
 fn get_note_options(args: ColumnsArgs, settings_handler: &mut SettingsHandler) -> NoteOptions {
     let mut note_options = NoteOptions::default();
+
+    note_options.set(
+        NoteOptions::LoadMediaByDefault,
+        settings_handler.load_media_by_default(),
+    );
 
     note_options.set(
         NoteOptions::Textmode,

--- a/crates/notedeck_ui/src/note/media.rs
+++ b/crates/notedeck_ui/src/note/media.rs
@@ -58,13 +58,16 @@ pub fn image_carousel(
                         let mut media_action: Option<(usize, MediaUIAction)> = None;
 
                         for (i, media) in medias.iter().enumerate() {
+                            let trusted_media = note_options.contains(NoteOptions::TrustMedia)
+                                || img_cache.user_trusts_img(&media.url, media.media_type)
+                                || note_options.contains(NoteOptions::LoadMediaByDefault);
+
                             let media_response = render_media(
                                 ui,
                                 img_cache,
                                 jobs,
                                 media,
-                                note_options.contains(NoteOptions::TrustMedia)
-                                    || img_cache.user_trusts_img(&media.url, media.media_type),
+                                trusted_media,
                                 i18n,
                                 size,
                                 if note_options.contains(NoteOptions::NoAnimations) {

--- a/crates/notedeck_ui/src/note/options.rs
+++ b/crates/notedeck_ui/src/note/options.rs
@@ -47,6 +47,9 @@ bitflags! {
 
         /// There is enough trust to show media in this note
         const TrustMedia = 1 << 20;
+
+        /// show media by default
+        const LoadMediaByDefault = 1 << 21;
     }
 }
 


### PR DESCRIPTION
<img width="316" height="819" alt="imagen" src="https://github.com/user-attachments/assets/0abc4ffe-d734-4d8b-99f8-40a4fdf6162c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Load media by default" setting in the Settings page, giving users control over automatic media loading behavior.
  * Introduced a new custom toggle UI component for improved consistency across settings controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->