### PR TITLE
add relay note UI/badge

### DIFF
--- a/crates/notedeck_ui/src/note/mod.rs
+++ b/crates/notedeck_ui/src/note/mod.rs
@@ -958,6 +958,8 @@ fn relay_indicator(
         "Heading shown before a list of relays a note has appeared on"
     );
     // Cache the trimmed relay slices so we only walk the iterator once per frame.
+    // note.relays(txn) is guaranteed to be de-duplicated upstream, so this view layer
+    // can rely on that and simply forward the slices we receive.
     let relays: Vec<&str> = note
         .relays(txn)
         .filter_map(|relay| {

--- a/crates/notedeck_ui/src/note/mod.rs
+++ b/crates/notedeck_ui/src/note/mod.rs
@@ -968,19 +968,6 @@ fn relay_indicator(
         })
         .collect();
     let relay_count = relays.len();
-    let hover_text = if relay_count == 0 {
-        empty_state.clone()
-    } else {
-        let mut text = String::new();
-        for (idx, relay) in relays.iter().enumerate() {
-            if idx > 0 {
-                text.push('\n');
-            }
-            text.push_str(relay);
-        }
-        text
-    };
-
     let icon_size = 12.0;
     let text_color = ui.style().visuals.noninteractive().fg_stroke.color;
 
@@ -996,7 +983,15 @@ fn relay_indicator(
 
         if relay_count > 0 {
             response = response.on_hover_cursor(egui::CursorIcon::PointingHand);
-            response = response.on_hover_text(hover_text.clone());
+            // Clone the small pointer array so we can move it into the hover closure.
+            // This avoids rebuilding a String every frame while keeping the tooltip lazy.
+            let tooltip_relays = relays.clone();
+            response = response.on_hover_ui(move |ui| {
+                ui.spacing_mut().item_spacing.y = 2.0;
+                for relay in tooltip_relays {
+                    ui.label(relay);
+                }
+            });
             let _ =
                 crate::context_menu::stationary_arbitrary_menu_button(ui, response.clone(), |ui| {
                     ui.set_min_width(220.0);

--- a/crates/notedeck_ui/src/note/mod.rs
+++ b/crates/notedeck_ui/src/note/mod.rs
@@ -957,18 +957,20 @@ fn relay_indicator(
         "Seen on these relays",
         "Heading shown before a list of relays a note has appeared on"
     );
-    let relay_iter = || {
-        note.relays(txn).filter_map(|relay| {
+    // Cache the trimmed relay slices so we only walk the iterator once per frame.
+    let relays: Vec<&str> = note
+        .relays(txn)
+        .filter_map(|relay| {
             let trimmed = relay.trim();
             (!trimmed.is_empty()).then_some(trimmed)
         })
-    };
-    let relay_count = relay_iter().count();
+        .collect();
+    let relay_count = relays.len();
     let hover_text = if relay_count == 0 {
         empty_state.clone()
     } else {
         let mut text = String::new();
-        for (idx, relay) in relay_iter().enumerate() {
+        for (idx, relay) in relays.iter().enumerate() {
             if idx > 0 {
                 text.push('\n');
             }
@@ -1003,9 +1005,9 @@ fn relay_indicator(
                         .max_height(160.0)
                         .show(ui, |ui| {
                             ui.spacing_mut().item_spacing.y = 4.0;
-                            for relay in relay_iter() {
-                                ui.label(egui::RichText::new(relay).color(text_color))
-                                    .on_hover_text(relay);
+                            for relay in &relays {
+                                ui.label(egui::RichText::new(*relay).color(text_color))
+                                    .on_hover_text(*relay);
                             }
                         });
                 });


### PR DESCRIPTION
 Relay Badge Ready

<img width="466" height="242" alt="image" src="https://github.com/user-attachments/assets/432a2f8c-7188-43bf-ae4e-8357d074c365" />
<img width="367" height="242" alt="image" src="https://github.com/user-attachments/assets/956a6bb8-a02a-48ca-95a8-70e6d0492421" />


  - Relay badge icon now hides while hovered/open, keeping the server
    glyph only when idle.
  - Hover tooltip shows the full relay list (newline-separated) to match
    the popover contents.
  - Popover list is text-only; relay URLs remain sorted and deduped via
    collect_note_relays.

  File touched: crates/notedeck_ui/src/note/mod.rs

  Tests

  - cargo fmt --manifest-path Cargo.toml --all
  - cargo check -p notedeck_ui

