### PR TITLE
feat(profile_view): add profile column from context options

### DIFF
--- a/crates/notedeck/src/profile/context.rs
+++ b/crates/notedeck/src/profile/context.rs
@@ -1,6 +1,7 @@
 use enostr::Pubkey;
 
 pub enum ProfileContextSelection {
+    AddProfileColumn,
     CopyLink,
     ViewAs,
 }
@@ -20,7 +21,7 @@ impl ProfileContextSelection {
 
                 ctx.copy_text(format!("https://damus.io/{npub}"));
             }
-            ProfileContextSelection::ViewAs => {
+            ProfileContextSelection::ViewAs | ProfileContextSelection::AddProfileColumn => {
                 // handled separately in profile.rs
             }
         }

--- a/crates/notedeck_columns/src/nav.rs
+++ b/crates/notedeck_columns/src/nav.rs
@@ -567,9 +567,15 @@ fn process_render_nav_action(
                 return None;
             }
         }
-        RenderNavAction::ProfileAction(profile_action) => {
-            profile_action.process_profile_action(ui.ctx(), ctx.ndb, ctx.pool, ctx.accounts)
-        }
+        RenderNavAction::ProfileAction(profile_action) => profile_action.process_profile_action(
+            app,
+            ctx.path,
+            ctx.i18n,
+            ui.ctx(),
+            ctx.ndb,
+            ctx.pool,
+            ctx.accounts,
+        ),
         RenderNavAction::WalletAction(wallet_action) => {
             wallet_action.process(ctx.accounts, ctx.global_wallet)
         }

--- a/crates/notedeck_ui/src/profile/context.rs
+++ b/crates/notedeck_ui/src/profile/context.rs
@@ -35,6 +35,18 @@ impl ProfileContextWidget {
             ui.set_max_width(100.0);
 
             if ui
+                .button(tr!(
+                    i18n,
+                    "Add profile column",
+                    "Add new column to current deck from profile context menu"
+                ))
+                .clicked()
+            {
+                context_selection = Some(ProfileContextSelection::AddProfileColumn);
+                ui.close_menu();
+            }
+
+            if ui
                 .button(tr!(i18n, "View as", "Switch active user to this profile"))
                 .clicked()
             {


### PR DESCRIPTION
Adds an option to quickly insert the profile column, but only if it isn’t already in the deck.

<img width="337" height="187" alt="imagen" src="https://github.com/user-attachments/assets/6a130465-9784-4821-b2b9-c3333df2fd19" />
