### PR TITLE
feat: add thumbhash support for image placeholders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3864,6 +3864,7 @@ version = "0.7.1"
 dependencies = [
  "android-activity 0.6.0 (git+https://github.com/damus-io/android-activity?rev=4ee16f1585e4a75031dc10785163d4b920f95805)",
  "base32",
+ "base64 0.22.1",
  "bech32",
  "bincode",
  "bitflags 2.9.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3914,6 +3914,7 @@ dependencies = [
  "strum_macros",
  "tempfile",
  "thiserror 2.0.12",
+ "thumbhash",
  "tokenator",
  "tokio",
  "tracing",
@@ -3982,6 +3983,7 @@ dependencies = [
  "base64 0.22.1",
  "bech32",
  "bitflags 2.9.1",
+ "blurhash",
  "dirs",
  "eframe",
  "egui",
@@ -4021,6 +4023,7 @@ dependencies = [
  "strum_macros",
  "tempfile",
  "thiserror 2.0.12",
+ "thumbhash",
  "tokenator",
  "tokio",
  "tracing",
@@ -6313,6 +6316,12 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "thumbhash"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7726e0245a7331bd0c9a1fb4fd99fd695bcd478ca569f0eda2ff2cb14e7a00"
 
 [[package]]
 name = "tiff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ egui_virtual_list = { git = "https://github.com/jb55/hello_egui", rev = "a66b679
 ehttp = "0.5.0"
 hyper = { version = "1.7.0", features = ["full"] }
 hyper-util = {version = "0.1" , features = ["tokio"]}
-hyper-rustls = "0.27.7"
+hyper-rustls = { version = "0.27.7", features = ["webpki-roots", "ring"] }
 http-body-util = "0.1.3"
 rustls = "0.23.28"
 enostr = { path = "crates/enostr" } 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ openai-api-rs = "6.0.3"
 re_memory = "0.23.4"
 oot_bitset = "0.1.1"
 blurhash = "0.2.3"
+thumbhash = "0.1.0"
 android-activity = { git = "https://github.com/damus-io/android-activity", rev = "4ee16f1585e4a75031dc10785163d4b920f95805", features = [ "game-activity" ] }
 keyring = { version = "3.6.3", features = ["apple-native", "windows-native", "linux-native-sync-persistent", "vendored"] }
 android-keyring = "0.2.0"

--- a/crates/notedeck/Cargo.toml
+++ b/crates/notedeck/Cargo.toml
@@ -11,6 +11,7 @@ url = { workspace = true }
 strum = { workspace = true }
 blurhash = { workspace = true }
 thumbhash = { workspace = true }
+base64 = { workspace = true }
 strum_macros = { workspace = true }
 dirs = { workspace = true }
 enostr = { workspace = true }

--- a/crates/notedeck/Cargo.toml
+++ b/crates/notedeck/Cargo.toml
@@ -10,6 +10,7 @@ jni = { workspace = true }
 url = { workspace = true }
 strum = { workspace = true }
 blurhash = { workspace = true }
+thumbhash = { workspace = true }
 strum_macros = { workspace = true }
 dirs = { workspace = true }
 enostr = { workspace = true }

--- a/crates/notedeck/src/imgcache.rs
+++ b/crates/notedeck/src/imgcache.rs
@@ -8,6 +8,7 @@ use crate::media::{
 use crate::urls::{UrlCache, UrlMimes};
 use crate::ImageMetadata;
 use crate::ObfuscationType;
+use crate::PlaceholderHash;
 use crate::RenderableMedia;
 use crate::Result;
 use egui::TextureHandle;
@@ -309,8 +310,12 @@ impl Images {
     ) -> Option<RenderableMedia> {
         let media_type = crate::urls::supported_mime_hosted_at_url(urls, url)?;
 
+        // Select the appropriate obfuscation type based on available placeholder hash
         let obfuscation_type = match imeta.get(url) {
-            Some(blur) => ObfuscationType::Blurhash(blur.clone()),
+            Some(meta) => match &meta.hash {
+                PlaceholderHash::ThumbHash(_) => ObfuscationType::ThumbHash(meta.clone()),
+                PlaceholderHash::BlurHash(_) => ObfuscationType::Blurhash(meta.clone()),
+            },
             None => ObfuscationType::Default,
         };
 

--- a/crates/notedeck/src/lib.rs
+++ b/crates/notedeck/src/lib.rs
@@ -62,8 +62,8 @@ pub use jobs::{
     MediaJobs,
 };
 pub use media::{
-    update_imeta_blurhashes, ImageMetadata, ImageType, MediaAction, ObfuscationType,
-    PixelDimensions, PointDimensions, RenderableMedia,
+    update_imeta_placeholders, ImageMetadata, ImageType, MediaAction, ObfuscationType,
+    PixelDimensions, PlaceholderHash, PointDimensions, RenderableMedia,
 };
 pub use muted::{MuteFun, Muted};
 pub use name::NostrName;

--- a/crates/notedeck/src/media/blur.rs
+++ b/crates/notedeck/src/media/blur.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use base64::prelude::*;
 use egui::TextureHandle;
 use nostrdb::Note;
 
@@ -12,10 +13,23 @@ use crate::{
     TextureState,
 };
 
-#[derive(Clone)]
+/// Represents the type of placeholder hash available for an image.
+/// Thumbhash is preferred when available as it provides better quality
+/// and includes embedded aspect ratio information.
+#[derive(Clone, Debug)]
+pub enum PlaceholderHash {
+    /// Thumbhash binary data (more modern, better quality)
+    ThumbHash(Vec<u8>),
+    /// Blurhash string (widely supported fallback)
+    BlurHash(String),
+}
+
+#[derive(Clone, Debug)]
 pub struct ImageMetadata {
-    pub blurhash: String,
-    pub dimensions: Option<PixelDimensions>, // width and height in pixels
+    /// The placeholder hash for this image (thumbhash or blurhash)
+    pub hash: PlaceholderHash,
+    /// Original image dimensions in pixels (used for aspect ratio)
+    pub dimensions: Option<PixelDimensions>,
 }
 
 #[derive(Clone, Debug)]
@@ -96,80 +110,94 @@ impl ImageMetadata {
     }
 }
 
-/// Find blurhashes in image metadata and update our cache
-pub fn update_imeta_blurhashes(note: &Note, blurs: &mut HashMap<String, ImageMetadata>) {
+/// Extract placeholder hashes (thumbhash or blurhash) from note imeta tags.
+/// Thumbhash is preferred over blurhash when both are present.
+pub fn update_imeta_placeholders(note: &Note, metadata: &mut HashMap<String, ImageMetadata>) {
     for tag in note.tags() {
         let mut tag_iter = tag.into_iter();
-        if tag_iter
+
+        // Check if this is an imeta tag
+        let is_imeta = tag_iter
             .next()
             .and_then(|s| s.str())
-            .filter(|s| *s == "imeta")
-            .is_none()
-        {
+            .is_some_and(|s| s == "imeta");
+
+        if !is_imeta {
             continue;
         }
 
-        let Some((url, blur)) = find_blur(tag_iter) else {
+        let Some((url, meta)) = find_placeholder(tag_iter) else {
             continue;
         };
 
-        blurs.insert(url.to_string(), blur);
+        metadata.insert(url, meta);
     }
 }
 
-fn find_blur(tag_iter: nostrdb::TagIter<'_>) -> Option<(String, ImageMetadata)> {
+/// Parse an imeta tag to extract URL and placeholder hash.
+/// Prefers thumbhash over blurhash when both are available.
+fn find_placeholder(tag_iter: nostrdb::TagIter<'_>) -> Option<(String, ImageMetadata)> {
     let mut url = None;
     let mut blurhash = None;
+    let mut thumbhash = None;
     let mut dims = None;
 
     for tag_elem in tag_iter {
         let Some(s) = tag_elem.str() else { continue };
         let mut split = s.split_whitespace();
 
-        let Some(first) = split.next() else { continue };
-        let Some(second) = split.next() else { continue };
+        let Some(key) = split.next() else { continue };
+        let Some(value) = split.next() else { continue };
 
-        match first {
-            "url" => url = Some(second),
-            "blurhash" => blurhash = Some(second),
-            "dim" => dims = Some(second),
+        match key {
+            "url" => url = Some(value.to_string()),
+            "blurhash" => blurhash = Some(value.to_string()),
+            "thumbhash" => thumbhash = Some(value.to_string()),
+            "dim" => dims = Some(value),
             _ => {}
-        }
-
-        if url.is_some() && blurhash.is_some() && dims.is_some() {
-            break;
         }
     }
 
     let url = url?;
-    let blurhash = blurhash?;
+
+    // Prefer thumbhash over blurhash (better quality, includes aspect ratio)
+    let hash = if let Some(th) = thumbhash {
+        // Thumbhash in imeta tags is base64 encoded
+        let decoded = BASE64_STANDARD.decode(th).ok()?;
+        PlaceholderHash::ThumbHash(decoded)
+    } else if let Some(bh) = blurhash {
+        PlaceholderHash::BlurHash(bh)
+    } else {
+        // No placeholder hash available
+        return None;
+    };
 
     let dimensions = dims.and_then(|d| {
         let mut split = d.split('x');
         let width = split.next()?.parse::<u32>().ok()?;
         let height = split.next()?.parse::<u32>().ok()?;
-
         Some(PixelDimensions {
             x: width,
             y: height,
         })
     });
 
-    Some((
-        url.to_string(),
-        ImageMetadata {
-            blurhash: blurhash.to_string(),
-            dimensions,
-        },
-    ))
+    Some((url, ImageMetadata { hash, dimensions }))
 }
 
+/// Specifies how an image should be obfuscated while loading or for untrusted content.
+/// ThumbHash is preferred over Blurhash when available.
 #[derive(Clone)]
 pub enum ObfuscationType {
+    /// Use thumbhash placeholder (preferred - better quality)
+    ThumbHash(ImageMetadata),
+    /// Use blurhash placeholder (fallback for compatibility)
     Blurhash(ImageMetadata),
+    /// Use default solid color placeholder
     Default,
 }
 
+/// Decode a blurhash string into an egui texture at the specified dimensions.
 fn generate_blurhash_texturehandle(
     ctx: &egui::Context,
     blurhash: &str,
@@ -181,6 +209,20 @@ fn generate_blurhash_texturehandle(
         .map_err(|e| crate::Error::Generic(e.to_string()))?;
 
     let img = egui::ColorImage::from_rgba_unmultiplied([width as usize, height as usize], &bytes);
+    Ok(load_texture_checked(ctx, url, img, Default::default()))
+}
+
+/// Decode a thumbhash into an egui texture.
+/// Thumbhash automatically determines output dimensions from the hash itself.
+fn generate_thumbhash_texturehandle(
+    ctx: &egui::Context,
+    thumbhash: &[u8],
+    url: &str,
+) -> Result<egui::TextureHandle, crate::Error> {
+    let (width, height, rgba) = thumbhash::thumb_hash_to_rgba(thumbhash)
+        .map_err(|_| crate::Error::Generic("thumbhash decode failed".to_string()))?;
+
+    let img = egui::ColorImage::from_rgba_unmultiplied([width as usize, height as usize], &rgba);
     Ok(load_texture_checked(ctx, url, img, Default::default()))
 }
 
@@ -208,35 +250,88 @@ impl BlurCache {
         self.cache.get(url)
     }
 
+    /// Get a cached blur texture or request its generation.
+    /// Handles both thumbhash and blurhash placeholder types.
     pub fn get_or_request(
         &self,
         jobs: &MediaJobSender,
         ui: &egui::Ui,
         url: &str,
-        blurhash: &ImageMetadata,
+        metadata: &ImageMetadata,
         size: egui::Vec2,
     ) -> &BlurState {
         if let Some(res) = self.cache.get(url) {
             return res;
         }
 
-        let available_points = PointDimensions {
-            x: size.x,
-            y: size.y,
-        };
-        let pixel_sizes = blurhash.scaled_pixel_dimensions(ui, available_points);
-        let blurhash = blurhash.blurhash.to_owned();
-        let url = url.to_owned();
+        let url_owned = url.to_owned();
         let ctx = ui.ctx().clone();
 
+        // Dispatch based on placeholder hash type
+        match &metadata.hash {
+            PlaceholderHash::ThumbHash(data) => {
+                self.request_thumbhash_job(jobs, &ctx, &url_owned, data.clone());
+            }
+            PlaceholderHash::BlurHash(hash) => {
+                let available_points = PointDimensions {
+                    x: size.x,
+                    y: size.y,
+                };
+                let pixel_sizes = metadata.scaled_pixel_dimensions(ui, available_points);
+                self.request_blurhash_job(jobs, &ctx, &url_owned, hash.clone(), pixel_sizes);
+            }
+        }
+
+        &BlurState {
+            tex_state: TextureState::Pending,
+            finished_transitioning: false,
+        }
+    }
+
+    /// Request a thumbhash decoding job.
+    fn request_thumbhash_job(
+        &self,
+        jobs: &MediaJobSender,
+        ctx: &egui::Context,
+        url: &str,
+        data: Vec<u8>,
+    ) {
+        let url = url.to_owned();
+        let ctx = ctx.clone();
+
         if let Err(e) = jobs.send(JobPackage::new(
-            url.to_owned(),
+            url.clone(),
+            MediaJobKind::ThumbHash,
+            RunType::Output(JobRun::Sync(Box::new(move || {
+                tracing::trace!("Starting thumbhash job for {url}");
+                let res = generate_thumbhash_texturehandle(&ctx, &data, &url);
+                JobOutput::Complete(CompleteResponse::new(MediaJobResult::ThumbHash(res)))
+            }))),
+        )) {
+            tracing::error!("{e}");
+        }
+    }
+
+    /// Request a blurhash decoding job.
+    fn request_blurhash_job(
+        &self,
+        jobs: &MediaJobSender,
+        ctx: &egui::Context,
+        url: &str,
+        hash: String,
+        pixel_sizes: PixelDimensions,
+    ) {
+        let url = url.to_owned();
+        let ctx = ctx.clone();
+
+        if let Err(e) = jobs.send(JobPackage::new(
+            url.clone(),
             MediaJobKind::Blurhash,
             RunType::Output(JobRun::Sync(Box::new(move || {
-                tracing::trace!("Starting blur job for {url}");
+                tracing::trace!("Starting blurhash job for {url}");
                 let res = generate_blurhash_texturehandle(
                     &ctx,
-                    &blurhash,
+                    &hash,
                     &url,
                     pixel_sizes.x,
                     pixel_sizes.y,
@@ -245,11 +340,6 @@ impl BlurCache {
             }))),
         )) {
             tracing::error!("{e}");
-        }
-
-        &BlurState {
-            tex_state: TextureState::Pending,
-            finished_transitioning: false,
         }
     }
 

--- a/crates/notedeck/src/media/latest.rs
+++ b/crates/notedeck/src/media/latest.rs
@@ -144,8 +144,10 @@ impl<'a> UntrustedMediaLatestTex<'a> {
         obfuscation_type: &'a ObfuscationType,
         size: egui::Vec2,
     ) -> ObfuscatedTexture<'a> {
-        let ObfuscationType::Blurhash(meta) = obfuscation_type else {
-            return ObfuscatedTexture::Default;
+        // Extract metadata from either ThumbHash or Blurhash variant
+        let meta = match obfuscation_type {
+            ObfuscationType::ThumbHash(meta) | ObfuscationType::Blurhash(meta) => meta,
+            ObfuscationType::Default => return ObfuscatedTexture::Default,
         };
 
         let state = self.blur_cache.get_or_request(jobs, ui, url, meta, size);

--- a/crates/notedeck/src/media/mod.rs
+++ b/crates/notedeck/src/media/mod.rs
@@ -10,8 +10,8 @@ pub mod static_imgs;
 
 pub use action::{MediaAction, MediaInfo, ViewMediaInfo};
 pub use blur::{
-    update_imeta_blurhashes, BlurCache, ImageMetadata, ObfuscationType, PixelDimensions,
-    PointDimensions,
+    update_imeta_placeholders, BlurCache, ImageMetadata, ObfuscationType, PixelDimensions,
+    PlaceholderHash, PointDimensions,
 };
 use egui::{ColorImage, TextureHandle};
 pub use images::ImageType;

--- a/crates/notedeck_columns/Cargo.toml
+++ b/crates/notedeck_columns/Cargo.toml
@@ -54,6 +54,8 @@ urlencoding = { workspace = true }
 uuid = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
+blurhash = { workspace = true }
+thumbhash = { workspace = true }
 egui-winit = { workspace = true }
 profiling = { workspace = true }
 hashbrown = { workspace = true }

--- a/crates/notedeck_columns/src/post.rs
+++ b/crates/notedeck_columns/src/post.rs
@@ -227,6 +227,11 @@ fn add_imeta_tags<'a>(builder: NoteBuilder<'a>, media: &Vec<Nip94Event>) -> Note
         if let Some(dims) = &item.dimensions {
             builder = builder.tag_str(&format!("dim {}x{}", dims.0, dims.1));
         }
+        // Include both thumbhash and blurhash for maximum compatibility.
+        // Thumbhash is preferred but blurhash provides fallback for older clients.
+        if let Some(th) = &item.thumbhash {
+            builder = builder.tag_str(&format!("thumbhash {th}"));
+        }
         if let Some(bh) = &item.blurhash {
             builder = builder.tag_str(&format!("blurhash {bh}"));
         }

--- a/crates/notedeck_ui/src/note/contents.rs
+++ b/crates/notedeck_ui/src/note/contents.rs
@@ -7,7 +7,7 @@ use egui::{Color32, Hyperlink, Label, RichText};
 use nostrdb::{BlockType, Mention, Note, NoteKey, Transaction};
 use notedeck::Localization;
 use notedeck::RenderableMedia;
-use notedeck::{time_format, update_imeta_blurhashes, NoteCache, NoteContext, NotedeckTextStyle};
+use notedeck::{time_format, update_imeta_placeholders, NoteCache, NoteContext, NotedeckTextStyle};
 use tracing::warn;
 
 pub struct NoteContents<'a, 'd> {
@@ -263,7 +263,7 @@ fn render_undecorated_note_contents<'a>(
                         let url = block.as_str();
 
                         if !note_context.img_cache.metadata.contains_key(url) {
-                            update_imeta_blurhashes(note, &mut note_context.img_cache.metadata);
+                            update_imeta_placeholders(note, &mut note_context.img_cache.metadata);
                         }
 
                         let Some(media) = note_context.img_cache.get_renderable_media(url) else {


### PR DESCRIPTION
## Summary

- Add thumbhash encoding and decoding support alongside existing blurhash
- Thumbhash preferred over blurhash when both available (better quality, embedded aspect ratio)
- Both hashes generated client-side during uploads for maximum compatibility with other Nostr clients
- Both hashes included in imeta tags during transition period

## Changes

1. **Dependencies**: Add `thumbhash` crate (v0.1.0)

2. **Data structures**: 
   - `PlaceholderHash` enum with `ThumbHash(Vec<u8>)` and `BlurHash(String)` variants
   - Updated `ImageMetadata` and `ObfuscationType` to support both hash types

3. **Decoding**: 
   - Parse both thumbhash and blurhash from imeta tags
   - Prefer thumbhash when both present
   - Add `MediaJobKind::ThumbHash` for async decoding

4. **Encoding**: 
   - `generate_thumbhash()` and `generate_blurhash()` functions
   - Generate both hashes before NIP-96 upload
   - Include both in imeta tags when posting

5. **Tests**: Unit tests for encoding/decoding roundtrip

## Test plan

- [x] `cargo test` passes
- [x] Thumbhash decoding produces valid RGBA data
- [x] Blurhash decoding produces valid RGBA data  
- [x] Both hashes generated from test image
- [x] Invalid images return None gracefully

Closes #1218

🤖 Generated with [Claude Code](https://claude.com/claude-code)