### PR TITLE
Relay hints: nprofile parsing, hint routing, NIP-10 author pubkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+## Added
+- Relay hints: route unknown ID lookups to hint relays from nprofile/nevent mentions
+- NIP-19 nprofile parsing with relay hint extraction (ParsedNprofile)
+- NIP-10 author pubkey in reply e-tags and quote q-tags
+
 # Notedeck Beta - v0.4 - 2025-05-05
 
 # Added

--- a/crates/enostr/src/lib.rs
+++ b/crates/enostr/src/lib.rs
@@ -17,7 +17,7 @@ pub use keypair::{FilledKeypair, FullKeypair, Keypair, KeypairUnowned, Serializa
 pub use nostr::SecretKey;
 pub use note::{Note, NoteId};
 pub use profile::ProfileState;
-pub use pubkey::{Pubkey, PubkeyRef};
+pub use pubkey::{ParsedNprofile, Pubkey, PubkeyRef};
 pub use relay::message::{RelayEvent, RelayMessage};
 pub use relay::pool::{PoolEvent, PoolEventBuf, PoolRelay, RelayPool};
 pub use relay::subs_debug::{OwnedRelayEvent, RelayLogEvent, SubsDebug, TransferStats};

--- a/crates/notedeck/src/oneshot_api.rs
+++ b/crates/notedeck/src/oneshot_api.rs
@@ -1,4 +1,5 @@
-use enostr::RelayUrlPkgs;
+use enostr::{NormRelayUrl, RelayUrlPkgs};
+use hashbrown::HashSet;
 use nostrdb::Filter;
 
 use crate::{Accounts, Outbox};
@@ -23,6 +24,15 @@ impl<'o, 'a> OneshotApi<'o, 'a> {
             filters,
             RelayUrlPkgs::new(self.accounts.selected_account_read_relays()),
         );
+    }
+
+    /// Send a one-shot request to specific relay URLs (hint-based routing).
+    ///
+    /// Unlike `oneshot()` which routes to the selected account's read relays,
+    /// this routes to explicitly provided relay URLs. Used when relay hints
+    /// are available from nprofile/nevent mentions.
+    pub fn oneshot_to_relays(&mut self, filters: Vec<Filter>, relay_urls: HashSet<NormRelayUrl>) {
+        self.pool.oneshot(filters, RelayUrlPkgs::new(relay_urls));
     }
 }
 

--- a/crates/notedeck_columns/src/post.rs
+++ b/crates/notedeck_columns/src/post.rs
@@ -96,11 +96,13 @@ impl NewPost {
                 .tag_str(&hex::encode(root.id))
                 .tag_str("")
                 .tag_str("root")
+                .tag_str(&hex::encode(replying_to.pubkey()))
                 .start_tag()
                 .tag_str("e")
                 .tag_str(&hex::encode(replying_to.id()))
                 .tag_str("")
                 .tag_str("reply")
+                .tag_str(&hex::encode(replying_to.pubkey()))
                 .sign(seckey)
         } else {
             // we're replying to a post that isn't in a thread,
@@ -111,6 +113,7 @@ impl NewPost {
                 .tag_str(&hex::encode(replying_to.id()))
                 .tag_str("")
                 .tag_str("root")
+                .tag_str(&hex::encode(replying_to.pubkey()))
                 .sign(seckey)
         };
 
@@ -166,6 +169,8 @@ impl NewPost {
             .start_tag()
             .tag_str("q")
             .tag_str(&hex::encode(quoting.id()))
+            .tag_str("")
+            .tag_str(&hex::encode(quoting.pubkey()))
             .start_tag()
             .tag_str("p")
             .tag_str(&hex::encode(quoting.pubkey()))


### PR DESCRIPTION
## Summary

Rebased and simplified relay hints against the post-outbox master. Down from ~1,030 lines across 9 files to ~270 lines across 6 files by dropping dead `RelayPool` code and leveraging the existing outbox infrastructure.

- **nprofile parsing with relay hints** — `ParsedNprofile` struct preserves relay hints from NIP-19 nprofile bech32 strings (nostr crate first, manual TLV fallback for robustness)
- **Hint-based routing** — `unknown_id_send()` partitions IDs into hinted vs unhinted, routing hinted IDs to their hint relays via `oneshot_to_relays()` and unhinted to account read relays. No new state or retry logic; existing 2s debouncer handles retries naturally.
- **NIP-10 author pubkeys** — Add author pubkey as 5th element in e-tags (root + reply) and q-tags per NIP-10 spec

## Commits

1. `enostr: add ParsedNprofile and nprofile parsing with relay hints` — `pubkey.rs`, `lib.rs`
2. `notedeck: route unknown ID lookups to relay hints` — `oneshot_api.rs`, `unknowns.rs`
3. `post: add NIP-10 author pubkey to reply and quote tags` — `post.rs`, `CHANGELOG.md`

Each commit compiles independently.

## What changed from the original PR

| Original | New |
|---|---|
| `RelayPool::subscribe_to` / relay_status / canonicalize | **Dropped** — RelayPool no longer does subscriptions |
| Grace period / timeout / retry state machine | **Dropped** — existing 2s debouncer handles retry |
| `app.rs` hook points | **Dropped** — no timeout logic needed |
| `post.rs` relay_hint parameter in `to_quote()` | **Dropped** — nostrdb doesn't expose source relay |
| pool.rs tests | **Dropped** — tested dead code |

## Known limitations

- Outgoing relay hints in e-tags use `""` because nostrdb doesn't expose which relay delivered a note. A nostrdb change (storing source relay per note) would enable this.
- Root e-tag uses `replying_to.pubkey()` rather than root author's pubkey, since root author isn't available without an extra DB lookup.

## Test plan

- [x] `cargo test -p enostr` — ParsedNprofile + nprofile parsing tests pass
- [x] `cargo test -p notedeck` — oneshot_api + unknowns tests pass
- [x] `cargo test -p notedeck_columns` — post.rs tests pass
- [x] `cargo clippy -D warnings` — clean across all 3 crates
- [x] `cargo build` — full build compiles clean
- [x] Each commit compiles independently