### PR TITLE
chrome: fix debug mode crash on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 # Fixed
 
+- Fix debug mode crash on macOS due to objc2 type encoding mismatch (alltheseas)
 - Fix timelines sometimes not updating (stale feeds)
 - Fix ui bounciness when loading profile pictures
 - Fix unselectable post replies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3942,6 +3942,7 @@ dependencies = [
  "notedeck_messages",
  "notedeck_notebook",
  "notedeck_ui",
+ "objc2 0.5.2",
  "profiling",
  "puffin",
  "puffin_egui",

--- a/crates/notedeck_chrome/Cargo.toml
+++ b/crates/notedeck_chrome/Cargo.toml
@@ -62,6 +62,12 @@ tracing-logcat = "0.1.0"
 egui-winit.workspace = true
 android-keyring = { workspace = true }
 
+# Fix debug mode crash on macOS: objc2-foundation 0.2.2 has incorrect type
+# encoding for NSFastEnumeration. The relax-sign-encoding feature allows
+# signed/unsigned mismatches to pass runtime verification.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = { version = "0.5.2", features = ["relax-sign-encoding"] }
+
 [package.metadata.bundle]
 name = "Notedeck"
 short_description = "The nostr browser"


### PR DESCRIPTION
## Summary

- Fix debug mode crash on macOS where `cargo run` panics but `cargo run --release` works
- Root cause: objc2-foundation 0.2.2 type encoding mismatch (expects 'q' signed, gets 'Q' unsigned)
- Solution: Enable `relax-sign-encoding` feature on objc2 0.5.2 (macOS-only dependency)

**Note:** Version 0.5.2 is intentional - the fix relies on Cargo feature unification with the transitive `objc2 0.5.2` from `winit → objc2-app-kit 0.2.2`.

## Test plan

- [x] Verify `cargo run` no longer crashes on macOS
- [x] Verify `cargo run --release` still works
- [x] Verify `cargo fmt`, `cargo clippy`, `cargo test` pass
- [x] Dependency gated to macOS only (Linux/Windows unaffected)

Closes #1229

Signed-off-by: alltheseas <alltheseas@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)