### PR TITLE
build: convert apps into compile-time feature flags

### DIFF
--- a/crates/notedeck/src/args.rs
+++ b/crates/notedeck/src/args.rs
@@ -124,12 +124,6 @@ impl Args {
                 res.options.set(NotedeckOptions::UseKeystore, true);
             } else if arg == "--relay-debug" {
                 res.options.set(NotedeckOptions::RelayDebug, true);
-            } else if arg == "--notebook" {
-                res.options.set(NotedeckOptions::FeatureNotebook, true);
-            } else if arg == "--clndash" {
-                res.options.set(NotedeckOptions::FeatureClnDash, true);
-            } else if arg == "--messages" {
-                res.options.set(NotedeckOptions::FeatureMessages, true);
             } else {
                 unrecognized_args.insert(arg.clone());
             }

--- a/crates/notedeck/src/options.rs
+++ b/crates/notedeck/src/options.rs
@@ -22,16 +22,6 @@ bitflags! {
 
         /// Simulate is_compiled_as_mobile ?
         const Mobile = 1 << 6;
-
-        // ===== Feature Flags ======
-        /// Is notebook enabled?
-        const FeatureNotebook = 1 << 32;
-
-        /// Is clndash enabled?
-        const FeatureClnDash = 1 << 33;
-
-        /// Is the Notedeck DMs app enabled?
-        const FeatureMessages = 1 << 34;
     }
 }
 

--- a/crates/notedeck_chrome/Cargo.toml
+++ b/crates/notedeck_chrome/Cargo.toml
@@ -18,9 +18,9 @@ egui = { workspace = true }
 notedeck_columns = { workspace = true }
 notedeck_ui = { workspace = true }
 notedeck_dave = { workspace = true }
-notedeck_messages = { workspace = true }
-notedeck_notebook = { workspace = true }
-notedeck_clndash = { workspace = true }
+notedeck_messages = { workspace = true, optional = true }
+notedeck_notebook = { workspace = true, optional = true }
+notedeck_clndash = { workspace = true, optional = true }
 notedeck = { workspace = true }
 nostrdb = { workspace = true }
 puffin = { workspace = true, optional = true }
@@ -54,6 +54,9 @@ default = []
 memory = ["re_memory"]
 puffin = ["profiling/profile-with-puffin", "dep:puffin"]
 tracy = ["profiling/profile-with-tracy"]
+messages = ["notedeck_messages"]
+notebook = ["notedeck_notebook"]
+clndash = ["notedeck_clndash"]
 
 [target.'cfg(target_os = "android")'.dependencies]
 tracing-logcat = "0.1.0"

--- a/crates/notedeck_chrome/src/app.rs
+++ b/crates/notedeck_chrome/src/app.rs
@@ -1,16 +1,26 @@
 use notedeck::{AppContext, AppResponse};
-use notedeck_clndash::ClnDash;
+
 use notedeck_columns::Damus;
 use notedeck_dave::Dave;
+
+#[cfg(feature = "clndash")]
+use notedeck_clndash::ClnDash;
+
+#[cfg(feature = "messages")]
 use notedeck_messages::MessagesApp;
+
+#[cfg(feature = "notebook")]
 use notedeck_notebook::Notebook;
 
 #[allow(clippy::large_enum_variant)]
 pub enum NotedeckApp {
     Dave(Box<Dave>),
     Columns(Box<Damus>),
+    #[cfg(feature = "notebook")]
     Notebook(Box<Notebook>),
+    #[cfg(feature = "clndash")]
     ClnDash(Box<ClnDash>),
+    #[cfg(feature = "messages")]
     Messages(Box<MessagesApp>),
     Other(Box<dyn notedeck::App>),
 }
@@ -21,9 +31,16 @@ impl notedeck::App for NotedeckApp {
         match self {
             NotedeckApp::Dave(dave) => dave.update(ctx, ui),
             NotedeckApp::Columns(columns) => columns.update(ctx, ui),
+
+            #[cfg(feature = "notebook")]
             NotedeckApp::Notebook(notebook) => notebook.update(ctx, ui),
+
+            #[cfg(feature = "clndash")]
             NotedeckApp::ClnDash(clndash) => clndash.update(ctx, ui),
+
+            #[cfg(feature = "messages")]
             NotedeckApp::Messages(dms) => dms.update(ctx, ui),
+
             NotedeckApp::Other(other) => other.update(ctx, ui),
         }
     }

--- a/crates/notedeck_chrome/src/chrome.rs
+++ b/crates/notedeck_chrome/src/chrome.rs
@@ -26,8 +26,14 @@ use notedeck::{
 };
 use notedeck_columns::{timeline::TimelineKind, Damus};
 use notedeck_dave::{Dave, DaveAvatar};
+
+#[cfg(feature = "messages")]
 use notedeck_messages::MessagesApp;
-use notedeck_ui::{app_images, expanding_button, galley_centered_pos, ProfilePic};
+
+#[cfg(feature = "clndash")]
+use notedeck_ui::expanding_button;
+
+use notedeck_ui::{app_images, galley_centered_pos, ProfilePic};
 use std::collections::HashMap;
 
 #[derive(Default)]
@@ -155,15 +161,14 @@ impl Chrome {
         chrome.add_app(NotedeckApp::Columns(Box::new(columns)));
         chrome.add_app(NotedeckApp::Dave(Box::new(dave)));
 
+        #[cfg(feature = "messages")]
         chrome.add_app(NotedeckApp::Messages(Box::new(MessagesApp::new())));
 
-        if notedeck.has_option(NotedeckOptions::FeatureNotebook) {
-            chrome.add_app(NotedeckApp::Notebook(Box::default()));
-        }
+        #[cfg(feature = "notebook")]
+        chrome.add_app(NotedeckApp::Notebook(Box::default()));
 
-        if notedeck.has_option(NotedeckOptions::FeatureClnDash) {
-            chrome.add_app(NotedeckApp::ClnDash(Box::default()));
-        }
+        #[cfg(feature = "clndash")]
+        chrome.add_app(NotedeckApp::ClnDash(Box::default()));
 
         chrome.set_active(0);
 
@@ -397,6 +402,7 @@ fn milestone_name<'a>(i18n: &'a mut Localization) -> impl Widget + 'a {
     }
 }
 
+#[cfg(feature = "clndash")]
 fn clndash_button(ui: &mut egui::Ui) -> egui::Response {
     expanding_button(
         "clndash-button",
@@ -408,6 +414,7 @@ fn clndash_button(ui: &mut egui::Ui) -> egui::Response {
     )
 }
 
+#[cfg(feature = "notebook")]
 fn notebook_button(ui: &mut egui::Ui) -> egui::Response {
     expanding_button(
         "notebook-button",
@@ -774,12 +781,18 @@ fn topdown_sidebar(
         let text = match &app {
             NotedeckApp::Dave(_) => tr!(loc, "Dave", "Button to go to the Dave app"),
             NotedeckApp::Columns(_) => tr!(loc, "Columns", "Button to go to the Columns app"),
+
+            #[cfg(feature = "messages")]
             NotedeckApp::Messages(_) => {
                 tr!(loc, "Messaging", "Button to go to the messaging app")
             }
+
+            #[cfg(feature = "notebook")]
             NotedeckApp::Notebook(_) => {
                 tr!(loc, "Notebook", "Button to go to the Notebook app")
             }
+
+            #[cfg(feature = "clndash")]
             NotedeckApp::ClnDash(_) => tr!(loc, "ClnDash", "Button to go to the ClnDash app"),
             NotedeckApp::Other(_) => tr!(loc, "Other", "Button to go to the Other app"),
         };
@@ -808,14 +821,17 @@ fn topdown_sidebar(
                                     );
                                 }
 
+                                #[cfg(feature = "messages")]
                                 NotedeckApp::Messages(_dms) => {
                                     ui.add(app_images::new_message_image());
                                 }
 
+                                #[cfg(feature = "clndash")]
                                 NotedeckApp::ClnDash(_clndash) => {
                                     clndash_button(ui);
                                 }
 
+                                #[cfg(feature = "notebook")]
                                 NotedeckApp::Notebook(_notebook) => {
                                     notebook_button(ui);
                                 }


### PR DESCRIPTION
Instead of runtime flags, switch to compile-time flags. This allows us to do dev on just the apps we care about without incurring a build cost on other apps when core libraries change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Converted notebook, messages, and clndash to optional, modular components. These features can now be selectively enabled during builds, offering more flexible configuration options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->