### PR TITLE
Fix like button visibility in light theme

### DIFF
--- a/crates/notedeck_ui/src/note/mod.rs
+++ b/crates/notedeck_ui/src/note/mod.rs
@@ -1049,7 +1049,7 @@ fn like_button(
         if ui.visuals().dark_mode {
             img.tint(ui.visuals().text_color())
         } else {
-            img
+            img.tint(egui::Color32::BLACK)
         }
     };
 


### PR DESCRIPTION
The like button was invisible when toggling to light theme because it wasn't being tinted. Now applies black tint in light mode, matching the pattern used by other action buttons like reply and repost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved like button display in light mode with enhanced contrast.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->