### PR TITLE
fix(toolbar): always display toolbar at small scroll height

### DIFF
--- a/crates/notedeck/src/note/action.rs
+++ b/crates/notedeck/src/note/action.rs
@@ -7,6 +7,8 @@ use enostr::{NoteId, Pubkey};
 pub struct ScrollInfo {
     pub velocity: Vec2,
     pub offset: Vec2,
+    pub full_content_size: Vec2,
+    pub viewable_content_rect: egui::Rect,
 }
 
 #[derive(Debug)]

--- a/crates/notedeck_columns/src/actionbar.rs
+++ b/crates/notedeck_columns/src/actionbar.rs
@@ -75,9 +75,14 @@ fn execute_note_action(
             let toolbar_visible_id = egui::Id::new("toolbar_visible");
             let velocity_threshold = 50.0; // pixels per second
 
+            let viewable_content_height = scroll_info.viewable_content_rect.height();
+            let scrollable_distance = scroll_info.full_content_size.y - viewable_content_height;
+
             // velocity.y > 0 means scrolling up (content moving down) - show toolbar
             // velocity.y < 0 means scrolling down (content moving up) - hide toolbar
-            if scroll_info.velocity.y > velocity_threshold {
+            if scroll_info.velocity.y > velocity_threshold
+                || scrollable_distance < viewable_content_height
+            {
                 ui.ctx()
                     .data_mut(|d| d.insert_temp(toolbar_visible_id, true));
             } else if scroll_info.velocity.y < -velocity_threshold {

--- a/crates/notedeck_columns/src/ui/timeline.rs
+++ b/crates/notedeck_columns/src/ui/timeline.rs
@@ -205,7 +205,12 @@ fn timeline_ui(
         let velocity = scroll_output.state.velocity();
         let offset = scroll_output.state.offset;
         if velocity.length_sq() > 0.0 {
-            Some(NoteAction::Scroll(ScrollInfo { velocity, offset }))
+            Some(NoteAction::Scroll(ScrollInfo {
+                velocity,
+                offset,
+                full_content_size: scroll_output.content_size,
+                viewable_content_rect: scroll_output.inner_rect,
+            }))
         } else {
             None
         }


### PR DESCRIPTION
there was an issue where it was nearly impossible to activate the toolbar if the scroll height was very small.

the "fix" was to disable auto hide if the scrollable distance is less than three times the threshold. This is a pretty arbitrary choice, but it sounds reasonable to me. I was running into the issue at a distance of 77.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Toolbar visibility during scrolling was refined to consider content size and remaining scrollable distance in addition to scroll velocity, improving when controls appear.
  * Scroll events now include richer layout metadata so UI components can respond more accurately to the current content and viewable area.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->