### PR TITLE
Adding WEBP support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4194,6 +4194,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6639b70a7ce854b79c70d7e83f16b5dc0137cc914f3d7d03803b513ecc67ac"
 
 [[package]]
+name = "libwebp-sys"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54cd30df7c7165ce74a456e4ca9732c603e8dc5e60784558c1c6dc047f876733"
+dependencies = [
+ "cc",
+ "glob",
+]
+
+[[package]]
 name = "lightning-invoice"
 version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4904,6 +4914,7 @@ dependencies = [
  "unic-langid",
  "url",
  "uuid",
+ "webp",
  "zip 2.4.2",
 ]
 
@@ -9170,6 +9181,16 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c071456adef4aca59bf6a583c46b90ff5eb0b4f758fc347cea81290288f37ce1"
+dependencies = [
+ "image",
+ "libwebp-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 
 [workspace.dependencies]
 opener = "0.8.2"
-chrono = "0.4.40" 
+chrono = "0.4.40"
 crossbeam-channel = "0.5"
 crossbeam = "0.8.4"
 base32 = "0.4.0"
@@ -55,7 +55,7 @@ http-body-util = "0.1.3"
 # - Other platforms: aws-lc-rs (better performance)
 rustls = { version = "0.23.28", default-features = false, features = ["std", "tls12", "logging"] }
 ring = "0.17"
-enostr = { path = "crates/enostr" } 
+enostr = { path = "crates/enostr" }
 ewebsock = { version = "0.2.0", features = ["tls"] }
 fluent = "0.17.0"
 fluent-resmgr = "0.0.8"
@@ -64,6 +64,7 @@ glam = { version = "0.30", features = ["bytemuck"] }
 hex = { version = "0.4.3", features = ["serde"] }
 negentropy = { version = "0.5", default-features = false, features = ["std"] }
 image = { version = "0.25", features = ["jpeg", "png", "webp"] }
+webp = "0.3.1"
 indexmap = "2.6.0"
 log = "0.4.17"
 md5 = "0.7.0"

--- a/crates/notedeck/Cargo.toml
+++ b/crates/notedeck/Cargo.toml
@@ -18,6 +18,7 @@ egui = { workspace = true }
 egui_extras = { workspace = true }
 eframe = { workspace = true }
 image = { workspace = true }
+webp = { workspace = true }
 base32 = { workspace = true }
 poll-promise = { workspace = true }
 tracing = { workspace = true }

--- a/crates/notedeck/src/imgcache.rs
+++ b/crates/notedeck/src/imgcache.rs
@@ -31,6 +31,7 @@ pub struct TexturesCache {
     pub static_image: StaticImgTexCache,
     pub blurred: BlurCache,
     pub animated: AnimatedImgTexCache,
+    pub webp: crate::media::webp::WebpTexCache,
 }
 
 impl TexturesCache {
@@ -43,6 +44,9 @@ impl TexturesCache {
             animated: AnimatedImgTexCache::new(
                 base_dir.join(MediaCache::rel_dir(MediaCacheType::Gif)),
             ),
+            webp: crate::media::webp::WebpTexCache::new(
+                base_dir.join(MediaCache::rel_dir(MediaCacheType::Webp)),
+            ),
         }
     }
 }
@@ -51,6 +55,12 @@ pub enum TextureState<T> {
     Pending,
     Error(crate::Error),
     Loaded(T),
+}
+
+impl<T> TextureState<T> {
+    pub fn is_loaded(&self) -> bool {
+        matches!(self, TextureState::Loaded(_))
+    }
 }
 
 impl<T> std::fmt::Debug for TextureState<T> {
@@ -102,6 +112,7 @@ pub struct MediaCache {
 pub enum MediaCacheType {
     Image,
     Gif,
+    Webp,
 }
 
 impl MediaCache {
@@ -136,7 +147,20 @@ impl MediaCache {
         match cache_type {
             MediaCacheType::Image => "img",
             MediaCacheType::Gif => "gif",
+            MediaCacheType::Webp => "webp",
         }
+    }
+
+    /// Writes raw bytes directly to the cache file for a given URL.
+    ///
+    /// Use this when the original network bytes are already in the desired
+    /// format (e.g. WebP), avoiding unnecessary re-encoding.
+    pub fn write_bytes(cache_dir: &path::Path, url: &str, data: &[u8]) -> Result<()> {
+        let file_path = cache_dir.join(Self::key(url));
+        if let Some(p) = file_path.parent() {
+            create_dir_all(p)?;
+        }
+        Ok(std::fs::write(file_path, data)?)
     }
 
     pub fn write(cache_dir: &path::Path, url: &str, data: ColorImage) -> Result<()> {
@@ -272,11 +296,13 @@ pub struct Images {
     pub base_path: path::PathBuf,
     pub static_imgs: MediaCache,
     pub gifs: MediaCache,
+    pub webps: MediaCache,
     pub textures: TexturesCache,
     pub urls: UrlMimes,
     /// cached imeta data
     pub metadata: HashMap<String, ImageMetadata>,
     pub gif_states: GifStateMap,
+    pub webp_states: WebpStateMap,
 }
 
 impl Images {
@@ -286,8 +312,10 @@ impl Images {
             base_path: path.clone(),
             static_imgs: MediaCache::new(&path, MediaCacheType::Image),
             gifs: MediaCache::new(&path, MediaCacheType::Gif),
+            webps: MediaCache::new(&path, MediaCacheType::Webp),
             urls: UrlMimes::new(UrlCache::new(path.join(UrlCache::rel_dir()))),
             gif_states: Default::default(),
+            webp_states: Default::default(),
             metadata: Default::default(),
             textures: TexturesCache::new(path.clone()),
         }
@@ -295,7 +323,8 @@ impl Images {
 
     pub fn migrate_v0(&self) -> Result<()> {
         self.static_imgs.migrate_v0()?;
-        self.gifs.migrate_v0()
+        self.gifs.migrate_v0()?;
+        self.webps.migrate_v0()
     }
 
     pub fn get_renderable_media(&mut self, url: &str) -> Option<RenderableMedia> {
@@ -334,7 +363,9 @@ impl Images {
         let mut loader = NoLoadingLatestTex::new(
             &self.textures.static_image,
             &self.textures.animated,
+            &self.textures.webp,
             &mut self.gif_states,
+            &mut self.webp_states,
         );
         loader.latest(jobs, ui.ctx(), url, cache_type, img_type, animation_mode)
     }
@@ -343,6 +374,7 @@ impl Images {
         match cache_type {
             MediaCacheType::Image => &self.static_imgs,
             MediaCacheType::Gif => &self.gifs,
+            MediaCacheType::Webp => &self.webps,
         }
     }
 
@@ -350,6 +382,7 @@ impl Images {
         match cache_type {
             MediaCacheType::Image => &mut self.static_imgs,
             MediaCacheType::Gif => &mut self.gifs,
+            MediaCacheType::Webp => &mut self.webps,
         }
     }
 
@@ -368,7 +401,9 @@ impl Images {
         self.urls.cache.clear();
         self.static_imgs.clear();
         self.gifs.clear();
+        self.webps.clear();
         self.gif_states.clear();
+        self.webp_states.clear();
 
         Ok(())
     }
@@ -378,7 +413,9 @@ impl Images {
             NoLoadingLatestTex::new(
                 &self.textures.static_image,
                 &self.textures.animated,
+                &self.textures.webp,
                 &mut self.gif_states,
+                &mut self.webp_states,
             ),
             &self.textures.blurred,
         )
@@ -392,7 +429,9 @@ impl Images {
         NoLoadingLatestTex::new(
             &self.textures.static_image,
             &self.textures.animated,
+            &self.textures.webp,
             &mut self.gif_states,
+            &mut self.webp_states,
         )
     }
 
@@ -400,18 +439,16 @@ impl Images {
         match media_type {
             MediaCacheType::Image => self.textures.static_image.contains(url),
             MediaCacheType::Gif => self.textures.animated.contains(url),
+            MediaCacheType::Webp => self.textures.webp.contains(url),
         }
     }
 }
 
 pub type GifStateMap = HashMap<String, GifState>;
+pub type GifState = crate::media::animated::AnimatedFrameState;
 
-pub struct GifState {
-    pub last_frame_rendered: Instant,
-    pub last_frame_duration: Duration,
-    pub next_frame_time: Option<SystemTime>,
-    pub last_frame_index: usize,
-}
+pub type WebpStateMap = HashMap<String, WebpState>;
+pub type WebpState = crate::media::animated::AnimatedFrameState;
 
 pub struct LatestTexture {
     pub texture: TextureHandle,

--- a/crates/notedeck/src/jobs/media.rs
+++ b/crates/notedeck/src/jobs/media.rs
@@ -4,6 +4,7 @@ use egui::TextureHandle;
 
 use crate::jobs::JobCache;
 use crate::media::images::TextureRequestKey;
+use crate::media::webp::WebpCacheEntry;
 use crate::{Animation, Error, TextureState, TexturesCache};
 
 use crate::jobs::types::{JobComplete, JobId, JobPackage};
@@ -16,12 +17,15 @@ pub enum MediaJobKind {
     Blurhash,
     StaticImg { request_key: TextureRequestKey },
     AnimatedImg { request_key: TextureRequestKey },
+    WebpImg,
 }
 
 pub enum MediaJobResult {
     StaticImg(Result<TextureHandle, Error>),
     Blurhash(Result<TextureHandle, Error>),
     Animation(Result<Animation, Error>),
+    /// Completed result for a `WebpImg` job — routes to `tex_cache.webp`.
+    WebpImg(Result<WebpCacheEntry, Error>),
 }
 
 /// Converts a job result into the shared texture cache state shape.
@@ -77,6 +81,13 @@ pub fn deliver_completed_media_job(
                 .cache
                 .insert(id, into_texture_state(texture_handle).into());
         }
+        (MediaJobKind::WebpImg, MediaJobResult::WebpImg(result)) => {
+            let r = match result {
+                Ok(entry) => TextureState::Loaded(entry),
+                Err(e) => TextureState::Error(e),
+            };
+            tex_cache.webp.cache.insert(id, r);
+        }
         (job_kind, _) => {
             tracing::error!(
                 "mismatched media job completion kind for id {id_c}: {:?}",
@@ -102,6 +113,9 @@ pub fn run_media_job_pre_action(job_id: &JobId<MediaJobKind>, tex_cache: &mut Te
         }
         MediaJobKind::AnimatedImg { request_key } => {
             tex_cache.animated.set_pending(request_key.clone());
+        }
+        MediaJobKind::WebpImg => {
+            tex_cache.webp.cache.insert(id, TextureState::Pending);
         }
     }
 }

--- a/crates/notedeck/src/lib.rs
+++ b/crates/notedeck/src/lib.rs
@@ -72,7 +72,7 @@ pub use fonts::NamedFontFamily;
 pub use i18n::{CacheStats, FluentArgs, FluentValue, LanguageIdentifier, Localization};
 pub use imgcache::{
     Animation, GifState, GifStateMap, ImageFrame, Images, LatestTexture, MediaCache,
-    MediaCacheType, TextureFrame, TextureState, TexturesCache,
+    MediaCacheType, TextureFrame, TextureState, TexturesCache, WebpState, WebpStateMap,
 };
 pub use jobs::{
     deliver_completed_media_job, run_media_job_pre_action, JobCache, JobPool, MediaJobSender,

--- a/crates/notedeck/src/media/action.rs
+++ b/crates/notedeck/src/media/action.rs
@@ -116,6 +116,12 @@ impl MediaAction {
                         .animated
                         .request(jobs, ctx, &url, ImageType::Content(None))
                 }
+                MediaCacheType::Webp => {
+                    images
+                        .textures
+                        .webp
+                        .request(jobs, ctx, &url, ImageType::Content(None))
+                }
             },
             MediaAction::DoneLoading { url, cache_type: _ } => {
                 images.textures.blurred.finished_transitioning(&url);

--- a/crates/notedeck/src/media/animated.rs
+++ b/crates/notedeck/src/media/animated.rs
@@ -1,0 +1,163 @@
+use std::time::{Duration, Instant, SystemTime};
+
+use egui::{ColorImage, TextureHandle};
+
+use crate::{media::load_texture_checked, media::AnimationMode, Animation, Error, TextureFrame};
+
+/// Per-image playback state for animated media.
+pub struct AnimatedFrameState {
+    pub last_frame_rendered: Instant,
+    pub last_frame_duration: Duration,
+    pub next_frame_time: Option<SystemTime>,
+    pub last_frame_index: usize,
+}
+
+/// Result of advancing (or holding) an animated frame sequence.
+pub struct ProcessedAnimatedFrame<'a> {
+    pub texture: &'a TextureHandle,
+    pub maybe_new_state: Option<AnimatedFrameState>,
+    pub repaint_at: Option<SystemTime>,
+}
+
+/// Advances animation playback based on mode and prior state.
+pub fn process_animation_frame<'a>(
+    animation: &'a Animation,
+    frame_state: Option<&AnimatedFrameState>,
+    animation_mode: AnimationMode,
+    schedule_first_frame_repaint: bool,
+) -> ProcessedAnimatedFrame<'a> {
+    let now = Instant::now();
+
+    let Some(prev_state) = frame_state else {
+        let next_frame_time = if schedule_first_frame_repaint {
+            compute_next_frame_time(animation_mode, animation.first_frame.delay)
+        } else {
+            None
+        };
+        return ProcessedAnimatedFrame {
+            texture: &animation.first_frame.texture,
+            maybe_new_state: Some(AnimatedFrameState {
+                last_frame_rendered: now,
+                last_frame_duration: animation.first_frame.delay,
+                next_frame_time,
+                last_frame_index: 0,
+            }),
+            repaint_at: next_frame_time,
+        };
+    };
+
+    let should_advance = animation_mode.can_animate()
+        && (now - prev_state.last_frame_rendered >= prev_state.last_frame_duration);
+
+    if !should_advance {
+        return ProcessedAnimatedFrame {
+            texture: animation
+                .get_frame(prev_state.last_frame_index)
+                .map_or(&animation.first_frame.texture, |frame| &frame.texture),
+            maybe_new_state: None,
+            repaint_at: prev_state.next_frame_time,
+        };
+    }
+
+    let maybe_new_index = if prev_state.last_frame_index < animation.num_frames() - 1 {
+        prev_state.last_frame_index + 1
+    } else {
+        0
+    };
+
+    let Some(frame) = animation.get_frame(maybe_new_index) else {
+        return ProcessedAnimatedFrame {
+            texture: animation
+                .get_frame(prev_state.last_frame_index)
+                .map_or(&animation.first_frame.texture, |current| &current.texture),
+            maybe_new_state: None,
+            repaint_at: prev_state.next_frame_time,
+        };
+    };
+
+    let next_frame_time = compute_next_frame_time(animation_mode, frame.delay);
+    ProcessedAnimatedFrame {
+        texture: &frame.texture,
+        maybe_new_state: Some(AnimatedFrameState {
+            last_frame_rendered: now,
+            last_frame_duration: frame.delay,
+            next_frame_time,
+            last_frame_index: maybe_new_index,
+        }),
+        repaint_at: next_frame_time,
+    }
+}
+
+/// Calculates when to request a repaint for the next animation frame.
+pub fn compute_next_frame_time(
+    animation_mode: AnimationMode,
+    frame_delay: Duration,
+) -> Option<SystemTime> {
+    match animation_mode {
+        AnimationMode::Continuous { fps } => match fps {
+            Some(fps) => {
+                let max_delay_ms = Duration::from_millis((1000.0 / fps) as u64);
+                SystemTime::now().checked_add(frame_delay.max(max_delay_ms))
+            }
+            None => SystemTime::now().checked_add(frame_delay),
+        },
+        AnimationMode::NoAnimation | AnimationMode::Reactive => None,
+    }
+}
+
+/// Helper for building texture-backed `Animation` values frame by frame.
+pub struct AnimationBuilder {
+    first_frame: Option<TextureFrame>,
+    other_frames: Vec<TextureFrame>,
+}
+
+impl AnimationBuilder {
+    pub fn new() -> Self {
+        Self {
+            first_frame: None,
+            other_frames: Vec::new(),
+        }
+    }
+
+    pub fn push_frame(
+        &mut self,
+        ctx: &egui::Context,
+        url: &str,
+        index: usize,
+        delay: Duration,
+        color_img: ColorImage,
+    ) {
+        let tex_frame = TextureFrame {
+            delay,
+            texture: load_texture_checked(
+                ctx,
+                format!("{url}{index}"),
+                color_img,
+                Default::default(),
+            ),
+        };
+
+        if self.first_frame.is_none() {
+            self.first_frame = Some(tex_frame);
+        } else {
+            self.other_frames.push(tex_frame);
+        }
+    }
+
+    pub fn finish(self, missing_first_frame_error: &'static str) -> Result<Animation, Error> {
+        let Some(first_frame) = self.first_frame else {
+            return Err(crate::Error::Generic(missing_first_frame_error.to_owned()));
+        };
+
+        Ok(Animation {
+            first_frame,
+            other_frames: self.other_frames,
+        })
+    }
+}
+
+impl Default for AnimationBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/notedeck/src/media/gif.rs
+++ b/crates/notedeck/src/media/gif.rs
@@ -1,9 +1,4 @@
-use std::{
-    collections::VecDeque,
-    io::Cursor,
-    path::PathBuf,
-    time::{Instant, SystemTime},
-};
+use std::{collections::VecDeque, io::Cursor, path::PathBuf, time::Duration};
 
 use crate::GifState;
 use crate::{
@@ -12,25 +7,20 @@ use crate::{
         MediaJobSender, NoOutputRun, RunType,
     },
     media::{
+        animated::{process_animation_frame, AnimationBuilder, ProcessedAnimatedFrame},
         images::{
             buffer_to_color_image, normalize_image_type_for_request, process_image,
             should_persist_full_content, TextureRequestKey, TextureRequestVariant,
         },
-        load_texture_checked,
     },
-    Error, ImageFrame, ImageType, MediaCache, TextureFrame, TextureState,
+    Error, ImageFrame, ImageType, MediaCache, TextureState,
 };
 use crate::{media::AnimationMode, Animation};
-use egui::{ColorImage, TextureHandle};
+use egui::ColorImage;
 use hashbrown::HashMap;
 use image::{codecs::gif::GifDecoder, AnimationDecoder, DynamicImage, Frame};
-use std::time::Duration;
 
-pub(crate) struct ProcessedGifFrame<'a> {
-    pub texture: &'a TextureHandle,
-    pub maybe_new_state: Option<GifState>,
-    pub repaint_at: Option<SystemTime>,
-}
+pub(crate) type ProcessedGifFrame<'a> = ProcessedAnimatedFrame<'a>;
 
 /// Process a gif state frame, and optionally present a new
 /// state and when to repaint it
@@ -39,78 +29,7 @@ pub(crate) fn process_gif_frame<'a>(
     frame_state: Option<&GifState>,
     animation_mode: AnimationMode,
 ) -> ProcessedGifFrame<'a> {
-    let now = Instant::now();
-
-    let Some(prev_state) = frame_state else {
-        return ProcessedGifFrame {
-            texture: &animation.first_frame.texture,
-            maybe_new_state: Some(GifState {
-                last_frame_rendered: now,
-                last_frame_duration: animation.first_frame.delay,
-                next_frame_time: None,
-                last_frame_index: 0,
-            }),
-            repaint_at: None,
-        };
-    };
-
-    let should_advance = animation_mode.can_animate()
-        && (now - prev_state.last_frame_rendered >= prev_state.last_frame_duration);
-
-    if !should_advance {
-        let (texture, maybe_new_state) = match animation.get_frame(prev_state.last_frame_index) {
-            Some(frame) => (&frame.texture, None),
-            None => (&animation.first_frame.texture, None),
-        };
-
-        return ProcessedGifFrame {
-            texture,
-            maybe_new_state,
-            repaint_at: prev_state.next_frame_time,
-        };
-    }
-
-    let maybe_new_index = if prev_state.last_frame_index < animation.num_frames() - 1 {
-        prev_state.last_frame_index + 1
-    } else {
-        0
-    };
-
-    let Some(frame) = animation.get_frame(maybe_new_index) else {
-        let (texture, maybe_new_state) = match animation.get_frame(prev_state.last_frame_index) {
-            Some(frame) => (&frame.texture, None),
-            None => (&animation.first_frame.texture, None),
-        };
-
-        return ProcessedGifFrame {
-            texture,
-            maybe_new_state,
-            repaint_at: prev_state.next_frame_time,
-        };
-    };
-
-    let next_frame_time = match animation_mode {
-        AnimationMode::Continuous { fps } => match fps {
-            Some(fps) => {
-                let max_delay_ms = Duration::from_millis((1000.0 / fps) as u64);
-                SystemTime::now().checked_add(frame.delay.max(max_delay_ms))
-            }
-            None => SystemTime::now().checked_add(frame.delay),
-        },
-
-        AnimationMode::NoAnimation | AnimationMode::Reactive => None,
-    };
-
-    ProcessedGifFrame {
-        texture: &frame.texture,
-        maybe_new_state: Some(GifState {
-            last_frame_rendered: now,
-            last_frame_duration: frame.delay,
-            next_frame_time,
-            last_frame_index: maybe_new_index,
-        }),
-        repaint_at: next_frame_time,
-    }
+    process_animation_frame(animation, frame_state, animation_mode, true)
 }
 
 pub struct AnimatedImgTexCache {
@@ -311,38 +230,20 @@ fn generate_anim_pkg(
     process_to_egui: impl Fn(DynamicImage) -> ColorImage + Send + Copy + 'static,
 ) -> Result<AnimationPackage, Error> {
     let processed_frames = collect_processed_gif_frames(gif_bytes, process_to_egui)?;
-
     let mut imgs = Vec::with_capacity(processed_frames.len());
-    let mut other_frames = Vec::with_capacity(processed_frames.len().saturating_sub(1));
-
-    let mut first_frame = None;
+    let mut animation_builder = AnimationBuilder::new();
+    let texture_prefix = request_key.to_job_id();
     for (i, processed) in processed_frames.into_iter().enumerate() {
         let ProcessedColorFrame { delay, image: img } = processed;
         imgs.push(ImageFrame {
             delay,
             image: img.clone(),
         });
-
-        let tex_frame = generate_animation_frame(&ctx, &request_key, i, delay, img);
-
-        if first_frame.is_none() {
-            first_frame = Some(tex_frame);
-        } else {
-            other_frames.push(tex_frame);
-        }
+        animation_builder.push_frame(&ctx, &texture_prefix, i, delay, img);
     }
 
-    let Some(first_frame) = first_frame else {
-        return Err(crate::Error::Generic(
-            "first frame not found for gif".to_owned(),
-        ));
-    };
-
     Ok(AnimationPackage {
-        anim: Animation {
-            first_frame,
-            other_frames,
-        },
+        anim: animation_builder.finish("first frame not found for gif")?,
         img_frames: imgs,
     })
 }
@@ -409,24 +310,6 @@ fn generate_color_img_frame(
 ) -> ColorImage {
     let img = DynamicImage::ImageRgba8(frame.into_buffer());
     process_to_egui(img)
-}
-
-fn generate_animation_frame(
-    ctx: &egui::Context,
-    texture_key: &TextureRequestKey,
-    index: usize,
-    delay: Duration,
-    color_img: ColorImage,
-) -> TextureFrame {
-    TextureFrame {
-        delay,
-        texture: load_texture_checked(
-            ctx,
-            format!("{}:{index}", texture_key.to_job_id()),
-            color_img,
-            Default::default(),
-        ),
-    }
 }
 
 /// Applies request resizing only when the cached frame exceeds the requested bounds.

--- a/crates/notedeck/src/media/mod.rs
+++ b/crates/notedeck/src/media/mod.rs
@@ -1,4 +1,5 @@
 pub mod action;
+pub mod animated;
 pub mod blur;
 pub mod gif;
 pub mod images;
@@ -7,6 +8,7 @@ pub mod latest;
 pub mod network;
 pub mod renderable;
 pub mod static_imgs;
+pub mod webp;
 
 pub use action::{MediaAction, MediaInfo, ViewMediaInfo};
 pub use blur::{

--- a/crates/notedeck/src/media/webp.rs
+++ b/crates/notedeck/src/media/webp.rs
@@ -1,0 +1,415 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use crate::imgcache::WebpState;
+use crate::{
+    jobs::{
+        CompleteResponse, JobOutput, JobPackage, JobRun, MediaJobKind, MediaJobResult,
+        MediaJobSender, NoOutputRun, RunType,
+    },
+    media::{
+        animated::{process_animation_frame, AnimationBuilder, ProcessedAnimatedFrame},
+        images::{buffer_to_color_image, process_image},
+        load_texture_checked,
+    },
+    Error, ImageType, MediaCache, TextureState,
+};
+use crate::{media::AnimationMode, Animation};
+use egui::{ColorImage, TextureHandle};
+use image::{DynamicImage, RgbImage, Rgba, RgbaImage};
+use std::time::Duration;
+use webp::{AnimDecoder, BitstreamFeatures};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WebpType {
+    Static,
+    Animated,
+}
+
+/// Detects whether a WebP image is static or animated
+///
+/// This function analyzes the raw WebP data to determine if it contains
+/// a single frame (static) or multiple frames (animated).
+///
+/// It first checks bitstream features for a fast-path answer. If that check
+/// is unavailable or reports non-animated, it falls back to the animation
+/// decoder to avoid false negatives on animated files.
+///
+/// # Arguments
+///
+/// * `webp_bytes` - Raw WebP file data
+///
+/// # Returns
+///
+/// Returns `WebpType::Static` for single-frame images, `WebpType::Animated`
+/// for multi-frame images. On error, defaults to `WebpType::Static`.
+pub fn detect_webp_type(webp_bytes: &[u8]) -> WebpType {
+    if let Some(bit_stream) = BitstreamFeatures::new(webp_bytes) {
+        if bit_stream.has_animation() {
+            return WebpType::Animated;
+        }
+    } else {
+        tracing::warn!("Failed to read webp bitstream features, using decoder fallback");
+    }
+
+    match AnimDecoder::new(webp_bytes).decode() {
+        Ok(decoded) if decoded.len() > 1 => WebpType::Animated,
+        Ok(_) => WebpType::Static,
+        Err(e) => {
+            tracing::warn!("Failed to detect webp type via decoder fallback: {e}");
+            WebpType::Static
+        }
+    }
+}
+
+/// Decodes a static WebP image and returns a texture handle
+///
+/// This function is used when a WebP is detected as static.
+/// It decodes the image data and creates an egui texture.
+///
+/// # Arguments
+///
+/// * `ctx` - The egui context for texture creation
+/// * `url` - The URL of the image (used as texture name)
+/// * `webp_bytes` - Raw WebP file data
+///
+/// # Returns
+///
+/// Returns a `TextureHandle` on success or an `Error` on failure.
+fn decode_static_webp(
+    ctx: &egui::Context,
+    url: &str,
+    webp_bytes: &[u8],
+) -> Result<TextureHandle, Error> {
+    let decoder = webp::Decoder::new(webp_bytes);
+
+    let image = decoder
+        .decode()
+        .ok_or_else(|| Error::Generic("Failed to decode static webp".to_string()))?;
+
+    let size = [image.width() as usize, image.height() as usize];
+    let color_image = match image.layout() {
+        webp::PixelLayout::Rgb => ColorImage::from_rgb(size, image.as_ref()),
+        webp::PixelLayout::Rgba => ColorImage::from_rgba_unmultiplied(size, image.as_ref()),
+    };
+
+    Ok(load_texture_checked(
+        ctx,
+        url,
+        color_image,
+        Default::default(),
+    ))
+}
+
+/// Decodes a static WebP image with processing and returns a ColorImage
+///
+/// Similar to `decode_static_webp` but applies image processing (e.g., resizing)
+/// before returning the ColorImage. This is used for images fetched from the network.
+///
+/// # Arguments
+///
+/// * `ctx` - The egui context (unused but kept for consistency)
+/// * `url` - The URL of the image
+/// * `webp_bytes` - Raw WebP file data
+/// * `imgtype` - The image type for processing (profile, content, etc.)
+///
+/// # Returns
+///
+/// Returns a `ColorImage` on success or an `Error` on failure.
+fn decode_static_webp_processed(
+    _ctx: &egui::Context,
+    _url: &str,
+    webp_bytes: &[u8],
+    imgtype: ImageType,
+) -> Result<ColorImage, Error> {
+    let decoder = webp::Decoder::new(webp_bytes);
+
+    let image = decoder
+        .decode()
+        .ok_or_else(|| Error::Generic("Failed to decode static webp".to_string()))?;
+
+    Ok(process_image(imgtype, image.to_image()))
+}
+
+pub(crate) type ProcessedWebpFrame<'a> = ProcessedAnimatedFrame<'a>;
+
+/// Process a webp state frame, and optionally present a new
+/// state and when to repaint it
+pub(crate) fn process_webp_frame<'a>(
+    animation: &'a Animation,
+    frame_state: Option<&WebpState>,
+    animation_mode: AnimationMode,
+) -> ProcessedWebpFrame<'a> {
+    process_animation_frame(animation, frame_state, animation_mode, true)
+}
+
+pub enum WebpCacheEntry {
+    Animated(Animation),
+    Static(TextureHandle),
+}
+
+/// Cache for WebP textures (both static and animated)
+pub struct WebpTexCache {
+    pub(crate) cache: HashMap<String, TextureState<WebpCacheEntry>>,
+    path: PathBuf,
+}
+
+impl WebpTexCache {
+    /// Creates a new WebP texture cache
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the directory where cached WebP files are stored
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            cache: Default::default(),
+            path,
+        }
+    }
+
+    pub fn contains(&self, url: &str) -> bool {
+        self.cache.contains_key(url)
+    }
+
+    pub fn get(&self, url: &str) -> Option<&TextureState<WebpCacheEntry>> {
+        self.cache.get(url)
+    }
+
+    pub fn request(
+        &self,
+        jobs: &MediaJobSender,
+        ctx: &egui::Context,
+        url: &str,
+        imgtype: ImageType,
+    ) {
+        let _ = self.get_or_request(jobs, ctx, url, imgtype);
+    }
+
+    pub fn get_or_request(
+        &self,
+        jobs: &MediaJobSender,
+        ctx: &egui::Context,
+        url: &str,
+        imgtype: ImageType,
+    ) -> &TextureState<WebpCacheEntry> {
+        if let Some(res) = self.cache.get(url) {
+            return res;
+        };
+
+        let key = MediaCache::key(url);
+        let path = self.path.join(key);
+        let ctx = ctx.clone();
+        let url = url.to_owned();
+        if path.exists() {
+            if let Err(e) = jobs.send(JobPackage::new(
+                url.to_owned(),
+                MediaJobKind::WebpImg,
+                RunType::Output(JobRun::Sync(Box::new(move || {
+                    from_disk_job_run(ctx, url, path)
+                }))),
+            )) {
+                tracing::error!("{e}");
+            }
+        } else {
+            let anim_path = self.path.clone();
+            if let Err(e) = jobs.send(JobPackage::new(
+                url.to_owned(),
+                MediaJobKind::WebpImg,
+                RunType::Output(JobRun::Async(Box::pin(from_net_run(
+                    ctx, url, anim_path, imgtype,
+                )))),
+            )) {
+                tracing::error!("{e}");
+            }
+        }
+
+        &TextureState::<WebpCacheEntry>::Pending
+    }
+}
+
+fn from_disk_job_run(ctx: egui::Context, url: String, path: PathBuf) -> JobOutput<MediaJobResult> {
+    tracing::trace!("Starting webp from disk job for {url}");
+    let webp_bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) => {
+            return JobOutput::Complete(CompleteResponse::new(MediaJobResult::WebpImg(Err(
+                Error::Io(e),
+            ))))
+        }
+    };
+
+    let webp_type = detect_webp_type(&webp_bytes);
+    match webp_type {
+        WebpType::Static => {
+            tracing::trace!("Detected static webp for {url}");
+            let result = decode_static_webp(&ctx, &url, &webp_bytes).map(WebpCacheEntry::Static);
+            JobOutput::Complete(CompleteResponse::new(MediaJobResult::WebpImg(result)))
+        }
+        WebpType::Animated => {
+            tracing::trace!("Detected animated webp for {url}");
+            let result =
+                generate_webp_anim_pkg(ctx.clone(), url.to_owned(), webp_bytes.as_slice(), |img| {
+                    buffer_to_color_image(img.as_flat_samples_u8(), img.width(), img.height())
+                })
+                .map(WebpCacheEntry::Animated);
+            JobOutput::Complete(CompleteResponse::new(MediaJobResult::WebpImg(result)))
+        }
+    }
+}
+
+async fn from_net_run(
+    ctx: egui::Context,
+    url: String,
+    path: PathBuf,
+    imgtype: ImageType,
+) -> JobOutput<MediaJobResult> {
+    let res = match crate::media::network::http_req(&url).await {
+        Ok(r) => r,
+        Err(e) => {
+            return JobOutput::complete(MediaJobResult::WebpImg(Err(crate::Error::Generic(
+                format!("Http error: {e}"),
+            ))));
+        }
+    };
+
+    JobOutput::Next(JobRun::Sync(Box::new(move || {
+        tracing::trace!("Starting webp from net job for {url}");
+
+        let webp_type = detect_webp_type(&res.bytes);
+        match webp_type {
+            WebpType::Static => {
+                tracing::trace!("Detected static webp from net for {url}");
+                match decode_static_webp_processed(&ctx, &url, &res.bytes, imgtype) {
+                    Ok(image) => {
+                        let texture =
+                            load_texture_checked(&ctx, &url, image.clone(), Default::default());
+
+                        JobOutput::Complete(
+                            CompleteResponse::new(MediaJobResult::WebpImg(Ok(
+                                WebpCacheEntry::Static(texture),
+                            )))
+                            .run_no_output(NoOutputRun::Sync(
+                                Box::new(move || {
+                                    tracing::trace!("writing static webp to file for {url}");
+                                    if let Err(e) = MediaCache::write(&path, &url, image) {
+                                        tracing::error!("Could not write static webp to disk: {e}");
+                                    }
+                                }),
+                            )),
+                        )
+                    }
+                    Err(e) => {
+                        JobOutput::Complete(CompleteResponse::new(MediaJobResult::WebpImg(Err(e))))
+                    }
+                }
+            }
+            WebpType::Animated => {
+                tracing::trace!("Detected animated webp from net for {url}");
+                let animation = match generate_webp_anim_pkg(
+                    ctx.clone(),
+                    url.to_owned(),
+                    &res.bytes,
+                    move |img| process_image(imgtype, img),
+                ) {
+                    Ok(a) => a,
+                    Err(e) => {
+                        return JobOutput::Complete(CompleteResponse::new(
+                            MediaJobResult::WebpImg(Err(e)),
+                        ));
+                    }
+                };
+                let raw_bytes = res.bytes;
+                JobOutput::Complete(
+                    CompleteResponse::new(MediaJobResult::WebpImg(Ok(WebpCacheEntry::Animated(
+                        animation,
+                    ))))
+                    .run_no_output(NoOutputRun::Sync(Box::new(move || {
+                        tracing::trace!("writing animated webp to file for {url}");
+                        if let Err(e) = MediaCache::write_bytes(&path, &url, &raw_bytes) {
+                            tracing::error!("Could not write webp to disk: {e}");
+                        }
+                    }))),
+                )
+            }
+        }
+    })))
+}
+
+/// Decodes an animated WebP and prepares texture-backed animation frames.
+#[profiling::function]
+fn generate_webp_anim_pkg(
+    ctx: egui::Context,
+    url: String,
+    webp_bytes: &[u8],
+    process_to_egui: impl Fn(DynamicImage) -> ColorImage + Send + Copy + 'static,
+) -> Result<Animation, Error> {
+    let decoded = match AnimDecoder::new(webp_bytes).decode() {
+        Ok(image) => {
+            if image.len() == 0 {
+                return Err(crate::Error::Generic("No frames found in webp".to_owned()));
+            }
+
+            image
+        }
+        Err(e) => {
+            return Err(crate::Error::Generic(format!(
+                "Failed to decode webp frames: {e}"
+            )))
+        }
+    };
+
+    let Some(frames) = decoded.get_frames(0..decoded.len()) else {
+        return Err(crate::Error::Generic(
+            "Failed to iterate decoded webp frames".to_owned(),
+        ));
+    };
+
+    let mut animation_builder = AnimationBuilder::new();
+
+    let mut prev_delay = Duration::from_millis(100);
+    for (i, frame) in frames.iter().enumerate() {
+        let delay = match frames.get(i + 1) {
+            Some(next) => {
+                let cur_ts = frame.get_time_ms().max(0) as u64;
+                let next_ts = next.get_time_ms().max(0) as u64;
+                // Avoiding zero-delay frames which can cause tight repaint loops.
+                Duration::from_millis(next_ts.saturating_sub(cur_ts).max(1))
+            }
+            None => prev_delay,
+        };
+
+        let img = generate_color_img_frame(frame, process_to_egui);
+        animation_builder.push_frame(&ctx, &url, i, delay, img);
+
+        prev_delay = delay;
+    }
+
+    animation_builder.finish("first frame not found for webp")
+}
+
+fn generate_color_img_frame(
+    frame: &webp::AnimFrame<'_>,
+    process_to_egui: impl Fn(DynamicImage) -> ColorImage + Send + Copy + 'static,
+) -> ColorImage {
+    let width = frame.width();
+    let height = frame.height();
+    let data = frame.get_image();
+
+    let dynamic_img = match frame.get_layout() {
+        webp::PixelLayout::Rgb => match RgbImage::from_raw(width, height, data.to_vec()) {
+            Some(img) => DynamicImage::ImageRgb8(img),
+            None => {
+                tracing::warn!("Failed to build RGB image from webp anim frame");
+                DynamicImage::ImageRgba8(RgbaImage::from_pixel(1, 1, Rgba([0, 0, 0, 0])))
+            }
+        },
+        webp::PixelLayout::Rgba => match RgbaImage::from_raw(width, height, data.to_vec()) {
+            Some(img) => DynamicImage::ImageRgba8(img),
+            None => {
+                tracing::warn!("Failed to build RGBA image from webp anim frame");
+                DynamicImage::ImageRgba8(RgbaImage::from_pixel(1, 1, Rgba([0, 0, 0, 0])))
+            }
+        },
+    };
+
+    process_to_egui(dynamic_img)
+}

--- a/crates/notedeck/src/urls.rs
+++ b/crates/notedeck/src/urls.rs
@@ -531,6 +531,8 @@ impl SupportedMimeType {
 fn mime_to_cache_type(mime: &Mime) -> MediaCacheType {
     if *mime == mime_guess::mime::IMAGE_GIF {
         MediaCacheType::Gif
+    } else if mime.essence_str() == "image/webp" {
+        MediaCacheType::Webp
     } else {
         MediaCacheType::Image
     }

--- a/crates/notedeck_ui/src/note/media.rs
+++ b/crates/notedeck_ui/src/note/media.rs
@@ -131,9 +131,9 @@ pub fn render_media(
     } = media;
 
     let animation_mode = animation_mode.unwrap_or_else(|| {
-        // if animations aren't disabled, we cap it at 24fps for gifs in carousels
+        // if animations aren't disabled, we cap it at 24fps for gifs/webps in carousels
         let fps = match media_type {
-            MediaCacheType::Gif => Some(24.0),
+            MediaCacheType::Gif | MediaCacheType::Webp => Some(24.0),
             MediaCacheType::Image => None,
         };
         AnimationMode::Continuous { fps }


### PR DESCRIPTION
Addressing #753 to support both static and animated WEBPs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebP support (static and animated): auto-detection, on-disk/network caching, decoding, and per-frame playback integrated with renderers. GIF and WebP now share a unified animation playback system; FPS inference treats WebP like GIF.

* **Chores**
  * Wired WebP handling throughout media pipelines and added workspace WebP dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->