### PR TITLE
Fix Windows installer to use 64-bit Program Files

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -207,10 +207,6 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
 
-      # Build
-      - name: Build (Native Only)
-        run: cargo build --release
-
       # Create packages directory
       - name: Create packages directory
         run: mkdir packages
@@ -231,43 +227,11 @@ jobs:
           Write-Output "Building for target: $target"
           cargo build --release --target=$target
 
-      # Generate ISS Script
-      - name: Generate Inno Setup Script
-        shell: pwsh
-        run: |
-          $arch = "${{ matrix.arch }}"
-          $issContent = @"
-          [Setup]
-          AppName=Damus Notedeck
-          AppVersion=0.1
-          DefaultDirName={pf}\Notedeck
-          DefaultGroupName=Damus Notedeck
-          OutputDir=..\packages\$arch
-          OutputBaseFilename=DamusNotedeckInstaller
-          Compression=lzma
-          SolidCompression=yes
-
-          [Files]
-          Source: "..\target\$arch-pc-windows-msvc\release\notedeck.exe"; DestDir: "{app}"; Flags: ignoreversion
-
-          [Icons]
-          Name: "{group}\Damus Notedeck"; Filename: "{app}\notedeck.exe"
-
-          [Run]
-          Filename: "{app}\notedeck.exe"; Description: "Launch Damus Notedeck"; Flags: nowait postinstall skipifsilent
-          "@
-          Set-Content -Path "scripts/windows-installer-$arch.iss" -Value $issContent
-
       # Build Installer
       - name: Run Inno Setup Script
         run: |
-          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" "scripts\windows-installer-${{ matrix.arch }}.iss"
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DBuildArch=${{ matrix.arch }} "scripts\windows-installer.iss"
 
-      # Move output
-      - name: Move Inno Script outputs to architecture-specific folder
-        run: |
-          New-Item -ItemType Directory -Force -Path packages\${{ matrix.arch }}
-          Move-Item -Path packages\${{ matrix.arch }}\DamusNotedeckInstaller.exe -Destination packages\${{ matrix.arch }}\DamusNotedeckInstaller.exe
       # Upload the installer as an artifact
       - name: Upload Installer
         uses: actions/upload-artifact@v4

--- a/scripts/windows-installer.iss
+++ b/scripts/windows-installer.iss
@@ -1,15 +1,34 @@
+#ifndef BuildArch
+  #define BuildArch ""
+#endif
+
+#if BuildArch != ""
+  #define ExeSource "..\target\" + BuildArch + "-pc-windows-msvc\release\notedeck.exe"
+  #define PkgOutputDir "..\packages\" + BuildArch
+#else
+  #define ExeSource "..\target\release\notedeck.exe"
+  #define PkgOutputDir "..\packages"
+#endif
+
 [Setup]
 AppName=Damus Notedeck
 AppVersion=0.1
-DefaultDirName={pf}\Notedeck
+DefaultDirName={autopf}\Notedeck
 DefaultGroupName=Damus Notedeck
-OutputDir=..\packages
+OutputDir={#PkgOutputDir}
 OutputBaseFilename=DamusNotedeckInstaller
 Compression=lzma
 SolidCompression=yes
+#if BuildArch == "aarch64"
+ArchitecturesAllowed=arm64
+ArchitecturesInstallIn64BitMode=arm64
+#else
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+#endif
 
 [Files]
-Source: "..\target\release\notedeck.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#ExeSource}"; DestDir: "{app}"; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\Damus Notedeck"; Filename: "{app}\notedeck.exe"


### PR DESCRIPTION
## Summary
- Fix Inno Setup installer using `{pf}` (32-bit Program Files) instead of `{autopf}` (auto-detecting 64-bit)
- Add `ArchitecturesAllowed=x64compatible` and `ArchitecturesInstallIn64BitMode=x64compatible` to ensure proper 64-bit installation
- This resolves CreateProcess error 216 (architecture mismatch) on Windows 11

Closes #1298

## Test plan
- [ ] Build the installer with Inno Setup and verify it targets `C:\Program Files\Notedeck` on 64-bit Windows
- [ ] Verify notedeck.exe launches successfully after installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced Windows installer with proper 64-bit architecture support
  * Installer now automatically launches the application upon successful installation completion
  * Streamlined installer build process for more reliable deployments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->