### PR TITLE
fix(android): use try_init for tracing subscriber to prevent panic on activity recreation

### DIFF
--- a/crates/notedeck_chrome/src/android.rs
+++ b/crates/notedeck_chrome/src/android.rs
@@ -36,10 +36,10 @@ pub async fn android_main(android_app: AndroidApp) {
         .or_else(|_| EnvFilter::try_new("info"))
         .unwrap();
 
-    tracing_subscriber::registry()
+    let _ = tracing_subscriber::registry()
         .with(filter_layer)
         .with(fmt_layer)
-        .init();
+        .try_init();
 
     let _ = android_keyring::set_android_keyring_credential_builder();
 


### PR DESCRIPTION
## Problem

On Android, the native activity can be recreated (e.g. on configuration change, or when the system reclaims memory and relaunches). When this happens, `android_main` is called again but the global tracing subscriber from the first invocation is still installed.

`.init()` panics:
```
SetGlobalDefaultError("a global default trace dispatcher has already been set")
```

This panic on a background thread causes the app to hang on the Damus splash screen. Logcat shows:
```
E RustPanic: failed to set global default subscriber: SetGlobalDefaultError(...)
W InputDispatcher: Not sending touch gesture to ... because it has config NO_INPUT_CHANNEL
```

## Fix

One-line change: `.init()` → `.try_init()`, which silently succeeds if a subscriber is already installed.

## Testing

Verified on Android emulator (Pixel, API 34). App no longer hangs on splash screen after force-stop + relaunch.

Changelog-Fixed: Android app hanging on splash screen after activity recreation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app stability by making initialization more resilient to failure scenarios, ensuring the app continues running regardless of initialization errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->