### PR TITLE
updater: add auto-update from GitHub Releases (DECK-468)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3933,7 +3933,7 @@ dependencies = [
  "tar",
  "ureq 3.1.4",
  "vcpkg",
- "zip",
+ "zip 6.0.0",
 ]
 
 [[package]]
@@ -4578,6 +4578,7 @@ dependencies = [
  "egui_extras",
  "ehttp",
  "enostr",
+ "flate2",
  "fluent",
  "fluent-langneg",
  "fluent-resmgr",
@@ -4608,11 +4609,14 @@ dependencies = [
  "ring",
  "rustls",
  "secp256k1 0.30.0",
+ "self-replace",
+ "semver",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "strum",
  "strum_macros",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tokenator",
@@ -4621,6 +4625,7 @@ dependencies = [
  "unic-langid",
  "url",
  "uuid",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -6842,6 +6847,17 @@ checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9768,6 +9784,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.9.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,11 @@ android-activity = { git = "https://github.com/damus-io/android-activity", rev =
 keyring = { version = "3.6.3", features = ["apple-native", "windows-native", "linux-native-sync-persistent", "vendored"] }
 android-keyring = "0.2.0"
 rfd = "0.15"
+semver = "1"
+self-replace = "1"
+flate2 = "1"
+tar = "0.4"
+zip = { version = "2", default-features = false, features = ["deflate"] }
 
 [profile.small]
 inherits = 'release'

--- a/crates/notedeck/Cargo.toml
+++ b/crates/notedeck/Cargo.toml
@@ -60,6 +60,11 @@ http-body-util = { workspace = true }
 # rustls and hyper-rustls are specified in platform-specific sections below
 # (Windows uses ring, others use aws-lc-rs)
 keyring = { workspace = true }
+semver = { workspace = true }
+self-replace = { workspace = true }
+flate2 = { workspace = true }
+tar = { workspace = true }
+zip = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/notedeck/src/app.rs
+++ b/crates/notedeck/src/app.rs
@@ -89,6 +89,9 @@ pub struct Notedeck {
     nip05_cache: Nip05Cache,
     i18n: Localization,
 
+    #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+    updater: crate::updater::Updater,
+
     #[cfg(target_os = "android")]
     android_app: Option<AndroidApp>,
 }
@@ -160,6 +163,27 @@ impl eframe::App for Notedeck {
         {
             profiling::scope!("outbox ingestion");
             drop(app_ctx);
+        }
+
+        #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+        {
+            self.updater.poll();
+            if let Some(version) = self.updater.update_ready() {
+                let version = version.to_string();
+                egui::TopBottomPanel::bottom("update_bar").show(ctx, |ui| {
+                    ui.horizontal(|ui| {
+                        ui.label(format!("Notedeck {version} is available"));
+                        if ui.button("Restart to update").clicked() {
+                            if let Err(e) = self.updater.apply_and_restart() {
+                                error!("failed to apply update: {e}");
+                            }
+                        }
+                        if ui.button("Later").clicked() {
+                            self.updater.dismiss();
+                        }
+                    });
+                });
+            }
         }
 
         self.settings.update_batch(|settings| {
@@ -342,6 +366,8 @@ impl Notedeck {
             media_jobs: media_job_cache,
             nip05_cache: Nip05Cache::new(),
             i18n,
+            #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+            updater: crate::updater::Updater::new(&path, ctx),
             #[cfg(target_os = "android")]
             android_app: None,
         };

--- a/crates/notedeck/src/lib.rs
+++ b/crates/notedeck/src/lib.rs
@@ -48,6 +48,8 @@ mod timecache;
 pub mod timed_serializer;
 pub mod ui;
 mod unknowns;
+#[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+pub mod updater;
 mod urls;
 mod user_account;
 mod wallet;

--- a/crates/notedeck/src/storage/file_storage.rs
+++ b/crates/notedeck/src/storage/file_storage.rs
@@ -36,6 +36,7 @@ impl DataPath {
             DataPathType::SelectedKey => PathBuf::from("storage").join("selected_account"),
             DataPathType::Db => PathBuf::from("db"),
             DataPathType::Cache => PathBuf::from("cache"),
+            DataPathType::Update => PathBuf::from("update"),
         }
     }
 
@@ -57,6 +58,7 @@ pub enum DataPathType {
     SelectedKey,
     Db,
     Cache,
+    Update,
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/crates/notedeck/src/updater/github.rs
+++ b/crates/notedeck/src/updater/github.rs
@@ -1,0 +1,192 @@
+use tracing::{info, warn};
+
+/// Information about a release asset available for download
+#[derive(Debug, Clone)]
+pub struct ReleaseInfo {
+    pub version: String,
+    pub asset_url: String,
+    pub asset_name: String,
+}
+
+/// Returns the expected asset name for the current platform/arch
+fn target_asset_name() -> &'static str {
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        "notedeck-x86_64-linux.tar.gz"
+    }
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    {
+        "notedeck-aarch64-linux.tar.gz"
+    }
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    {
+        "notedeck-x86_64-macos.tar.gz"
+    }
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        "notedeck-aarch64-macos.tar.gz"
+    }
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    {
+        "notedeck-x86_64-windows.zip"
+    }
+    #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+    {
+        "notedeck-aarch64-windows.zip"
+    }
+}
+
+const GITHUB_API_URL: &str = "https://api.github.com/repos/damus-io/notedeck/releases/latest";
+
+/// Check GitHub Releases for a newer version. Calls the callback with
+/// `Ok(Some(ReleaseInfo))` if an update is available, `Ok(None)` if
+/// up-to-date, or `Err` on failure.
+pub fn check_for_update(
+    current_version: &str,
+    on_done: impl FnOnce(Result<Option<ReleaseInfo>, String>) + Send + 'static,
+) {
+    let current_version = current_version.to_string();
+
+    let mut request = ehttp::Request::get(GITHUB_API_URL);
+    request
+        .headers
+        .insert("User-Agent".to_string(), "notedeck-updater".to_string());
+    request.headers.insert(
+        "Accept".to_string(),
+        "application/vnd.github+json".to_string(),
+    );
+
+    ehttp::fetch(request, move |response| {
+        let result = parse_update_response(&current_version, response);
+        on_done(result);
+    });
+}
+
+fn parse_update_response(
+    current_version: &str,
+    response: Result<ehttp::Response, String>,
+) -> Result<Option<ReleaseInfo>, String> {
+    let response = response.map_err(|e| format!("HTTP request failed: {e}"))?;
+
+    if response.status != 200 {
+        return Err(format!("GitHub API returned status {}", response.status));
+    }
+
+    let body = response
+        .text()
+        .ok_or_else(|| "Response body is not valid UTF-8".to_string())?;
+
+    let json: serde_json::Value =
+        serde_json::from_str(body).map_err(|e| format!("Failed to parse JSON: {e}"))?;
+
+    let tag_name = json["tag_name"]
+        .as_str()
+        .ok_or_else(|| "Missing tag_name in release".to_string())?;
+
+    let remote_version_str = tag_name.strip_prefix('v').unwrap_or(tag_name);
+
+    let current = semver::Version::parse(current_version)
+        .map_err(|e| format!("Failed to parse current version '{current_version}': {e}"))?;
+    let remote = semver::Version::parse(remote_version_str)
+        .map_err(|e| format!("Failed to parse remote version '{remote_version_str}': {e}"))?;
+
+    if remote <= current {
+        info!("up to date: current={current_version}, latest={remote_version_str}");
+        return Ok(None);
+    }
+
+    info!("update available: {current_version} -> {remote_version_str}");
+
+    let expected_name = target_asset_name();
+    let assets = json["assets"]
+        .as_array()
+        .ok_or_else(|| "Missing assets array in release".to_string())?;
+
+    for asset in assets {
+        let name = asset["name"].as_str().unwrap_or_default();
+        if name == expected_name {
+            let download_url = asset["browser_download_url"]
+                .as_str()
+                .ok_or_else(|| "Missing download URL for asset".to_string())?;
+
+            return Ok(Some(ReleaseInfo {
+                version: remote_version_str.to_string(),
+                asset_url: download_url.to_string(),
+                asset_name: name.to_string(),
+            }));
+        }
+    }
+
+    warn!("update {remote_version_str} found but no matching asset '{expected_name}'");
+    Err(format!(
+        "No matching asset '{expected_name}' in release {remote_version_str}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_response(json: &str) -> Result<ehttp::Response, String> {
+        Ok(ehttp::Response {
+            status: 200,
+            status_text: "OK".to_string(),
+            url: GITHUB_API_URL.to_string(),
+            bytes: json.as_bytes().to_vec(),
+            headers: Default::default(),
+            ok: true,
+        })
+    }
+
+    #[test]
+    fn test_up_to_date() {
+        let json = r#"{"tag_name": "v0.7.1", "assets": []}"#;
+        let result = parse_update_response("0.7.1", make_response(json));
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn test_older_remote() {
+        let json = r#"{"tag_name": "v0.6.0", "assets": []}"#;
+        let result = parse_update_response("0.7.1", make_response(json));
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn test_update_available() {
+        let expected = target_asset_name();
+        let json = format!(
+            r#"{{
+                "tag_name": "v1.0.0",
+                "assets": [
+                    {{
+                        "name": "{expected}",
+                        "browser_download_url": "https://example.com/download/{expected}"
+                    }}
+                ]
+            }}"#
+        );
+        let result = parse_update_response("0.7.1", make_response(&json));
+        let info = result.unwrap().unwrap();
+        assert_eq!(info.version, "1.0.0");
+        assert_eq!(info.asset_name, expected);
+    }
+
+    #[test]
+    fn test_update_no_matching_asset() {
+        let json = r#"{
+            "tag_name": "v1.0.0",
+            "assets": [
+                {"name": "some-other-asset.zip", "browser_download_url": "https://example.com/other"}
+            ]
+        }"#;
+        let result = parse_update_response("0.7.1", make_response(json));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_http_error() {
+        let result = parse_update_response("0.7.1", Err("connection refused".to_string()));
+        assert!(result.is_err());
+    }
+}

--- a/crates/notedeck/src/updater/mod.rs
+++ b/crates/notedeck/src/updater/mod.rs
@@ -1,0 +1,226 @@
+mod github;
+mod platform;
+
+use crate::{DataPath, DataPathType};
+use std::path::PathBuf;
+use std::sync::mpsc;
+use tracing::{error, info, warn};
+
+pub use github::ReleaseInfo;
+
+/// Messages sent from background tasks to the Updater
+enum UpdateMsg {
+    /// Result of checking GitHub for updates
+    CheckResult(Result<Option<ReleaseInfo>, String>),
+    /// Download completed
+    DownloadComplete(Result<PathBuf, String>),
+}
+
+/// The current state of the auto-updater
+enum UpdateState {
+    /// Haven't started checking yet
+    Idle,
+    /// Waiting for GitHub API response
+    Checking,
+    /// Downloading the update archive
+    Downloading { version: String },
+    /// Downloaded and ready to install
+    ReadyToInstall {
+        version: String,
+        binary_path: PathBuf,
+    },
+    /// Already up to date or user dismissed
+    UpToDate,
+    /// Something went wrong (non-fatal)
+    #[allow(dead_code)]
+    Error(String),
+}
+
+/// Auto-updater that checks GitHub Releases for new versions,
+/// downloads updates in the background, and prompts the user
+/// to restart.
+pub struct Updater {
+    state: UpdateState,
+    rx: mpsc::Receiver<UpdateMsg>,
+    tx: mpsc::Sender<UpdateMsg>,
+    staging_dir: PathBuf,
+    ctx: egui::Context,
+}
+
+impl Updater {
+    /// Create a new updater. Begins in `Idle` state.
+    pub fn new(data_path: &DataPath, ctx: &egui::Context) -> Self {
+        let (tx, rx) = mpsc::channel();
+        let staging_dir = data_path.path(DataPathType::Update);
+        let _ = std::fs::create_dir_all(&staging_dir);
+
+        Self {
+            state: UpdateState::Idle,
+            rx,
+            tx,
+            staging_dir,
+            ctx: ctx.clone(),
+        }
+    }
+
+    /// Poll for state changes. Call this every frame from `eframe::App::update()`.
+    /// This is non-blocking — it only does `try_recv()` on the channel.
+    pub fn poll(&mut self) {
+        // Process any messages from background tasks
+        while let Ok(msg) = self.rx.try_recv() {
+            match msg {
+                UpdateMsg::CheckResult(result) => self.handle_check_result(result),
+                UpdateMsg::DownloadComplete(result) => self.handle_download_complete(result),
+            }
+        }
+
+        // Auto-transition from Idle to Checking
+        if matches!(self.state, UpdateState::Idle) {
+            self.start_check();
+        }
+    }
+
+    /// Returns the new version string if an update is ready to install.
+    pub fn update_ready(&self) -> Option<&str> {
+        match &self.state {
+            UpdateState::ReadyToInstall { version, .. } => Some(version),
+            _ => None,
+        }
+    }
+
+    /// Apply the staged update and restart the application.
+    /// This function does not return on success (the process exits).
+    pub fn apply_and_restart(&self) -> Result<(), String> {
+        match &self.state {
+            UpdateState::ReadyToInstall {
+                binary_path,
+                version,
+                ..
+            } => {
+                info!("applying update to version {version}");
+                platform::install_and_restart(binary_path)
+            }
+            _ => Err("No update ready to install".to_string()),
+        }
+    }
+
+    /// User dismissed the update notification
+    pub fn dismiss(&mut self) {
+        if matches!(self.state, UpdateState::ReadyToInstall { .. }) {
+            self.state = UpdateState::UpToDate;
+        }
+    }
+
+    fn start_check(&mut self) {
+        info!("checking for updates...");
+        self.state = UpdateState::Checking;
+
+        let tx = self.tx.clone();
+        let current_version = env!("CARGO_PKG_VERSION").to_string();
+        let ctx = self.ctx.clone();
+
+        github::check_for_update(&current_version, move |result| {
+            let _ = tx.send(UpdateMsg::CheckResult(result));
+            ctx.request_repaint();
+        });
+    }
+
+    fn handle_check_result(&mut self, result: Result<Option<ReleaseInfo>, String>) {
+        match result {
+            Ok(Some(release)) => {
+                info!("update available: v{}", release.version);
+                self.start_download(release);
+            }
+            Ok(None) => {
+                info!("already up to date");
+                self.state = UpdateState::UpToDate;
+            }
+            Err(e) => {
+                warn!("update check failed: {e}");
+                self.state = UpdateState::Error(e);
+            }
+        }
+    }
+
+    fn start_download(&mut self, release: ReleaseInfo) {
+        let version = release.version.clone();
+        self.state = UpdateState::Downloading {
+            version: version.clone(),
+        };
+
+        let tx = self.tx.clone();
+        let staging_dir = self.staging_dir.clone();
+        let ctx = self.ctx.clone();
+
+        // Download the asset
+        let mut request = ehttp::Request::get(&release.asset_url);
+        request
+            .headers
+            .insert("User-Agent".to_string(), "notedeck-updater".to_string());
+
+        info!("downloading update: {}", release.asset_url);
+
+        ehttp::fetch(request, move |response| {
+            let result = handle_download(response, &release.asset_name, &staging_dir);
+            let _ = tx.send(UpdateMsg::DownloadComplete(result));
+            ctx.request_repaint();
+        });
+    }
+
+    fn handle_download_complete(&mut self, result: Result<PathBuf, String>) {
+        match result {
+            Ok(binary_path) => {
+                let version = match &self.state {
+                    UpdateState::Downloading { version } => version.clone(),
+                    _ => "unknown".to_string(),
+                };
+                info!(
+                    "update downloaded and extracted to '{}'",
+                    binary_path.display()
+                );
+                self.state = UpdateState::ReadyToInstall {
+                    version,
+                    binary_path,
+                };
+            }
+            Err(e) => {
+                error!("download failed: {e}");
+                self.state = UpdateState::Error(e);
+            }
+        }
+    }
+}
+
+/// Handle a completed download: save to disk, extract, find binary
+fn handle_download(
+    response: Result<ehttp::Response, String>,
+    asset_name: &str,
+    staging_dir: &Path,
+) -> Result<PathBuf, String> {
+    let response = response.map_err(|e| format!("Download failed: {e}"))?;
+
+    if response.status != 200 {
+        return Err(format!("Download returned status {}", response.status));
+    }
+
+    // Save archive to staging dir
+    let archive_path = staging_dir.join(asset_name);
+    std::fs::write(&archive_path, &response.bytes)
+        .map_err(|e| format!("Failed to write archive: {e}"))?;
+
+    info!(
+        "saved {} bytes to '{}'",
+        response.bytes.len(),
+        archive_path.display()
+    );
+
+    // Extract and find the binary
+    let binary_path = platform::extract_archive(&archive_path, staging_dir)?;
+
+    // Clean up the archive
+    let _ = std::fs::remove_file(&archive_path);
+
+    Ok(binary_path)
+}
+
+use std::path::Path;

--- a/crates/notedeck/src/updater/platform.rs
+++ b/crates/notedeck/src/updater/platform.rs
@@ -1,0 +1,200 @@
+use std::path::{Path, PathBuf};
+use tracing::info;
+
+/// Install the downloaded update and relaunch the application.
+///
+/// `staged_path` is the path to the new binary (or .app bundle on macOS)
+/// that has been extracted from the downloaded archive.
+pub fn install_and_restart(staged_path: &Path) -> Result<(), String> {
+    let current_exe =
+        std::env::current_exe().map_err(|e| format!("Failed to get current exe: {e}"))?;
+
+    info!(
+        "installing update from '{}' over '{}'",
+        staged_path.display(),
+        current_exe.display()
+    );
+
+    #[cfg(target_os = "macos")]
+    {
+        install_macos(staged_path, &current_exe)?;
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        install_replace(staged_path, &current_exe)?;
+    }
+
+    relaunch(&current_exe)
+}
+
+/// On macOS, replace the entire .app bundle to preserve code signing.
+#[cfg(target_os = "macos")]
+fn install_macos(staged_path: &Path, current_exe: &Path) -> Result<(), String> {
+    // current_exe is something like /Applications/Notedeck.app/Contents/MacOS/notedeck
+    // We need to find the .app bundle root
+    let bundle_path = find_app_bundle(current_exe)?;
+
+    // Check if the staged path is a .app bundle or a raw binary
+    if staged_path.extension().and_then(|e| e.to_str()) == Some("app") {
+        // Replacing entire .app bundle
+        let backup = bundle_path.with_extension("app.old");
+
+        info!(
+            "swapping .app bundle: '{}' -> '{}'",
+            bundle_path.display(),
+            backup.display()
+        );
+
+        // Atomic-ish swap: rename current, move new, cleanup
+        std::fs::rename(&bundle_path, &backup)
+            .map_err(|e| format!("Failed to move current .app to backup: {e}"))?;
+
+        if let Err(e) = std::fs::rename(staged_path, &bundle_path) {
+            // Try to restore backup
+            let _ = std::fs::rename(&backup, &bundle_path);
+            return Err(format!("Failed to move new .app into place: {e}"));
+        }
+
+        // Best-effort cleanup of old bundle
+        let _ = std::fs::remove_dir_all(&backup);
+        Ok(())
+    } else {
+        // Raw binary — use self-replace on the binary inside the bundle
+        install_replace(staged_path, current_exe)
+    }
+}
+
+/// Find the .app bundle root from an executable path inside it.
+/// e.g. /Applications/Notedeck.app/Contents/MacOS/notedeck -> /Applications/Notedeck.app
+#[cfg(target_os = "macos")]
+fn find_app_bundle(exe_path: &Path) -> Result<PathBuf, String> {
+    let mut path = exe_path;
+    while let Some(parent) = path.parent() {
+        if let Some(ext) = path.extension() {
+            if ext == "app" {
+                return Ok(path.to_path_buf());
+            }
+        }
+        path = parent;
+    }
+    Err(format!(
+        "Could not find .app bundle containing '{}'",
+        exe_path.display()
+    ))
+}
+
+/// Use self-replace to atomically swap the binary (Linux/Windows, or macOS raw binary)
+fn install_replace(staged_path: &Path, _current_exe: &Path) -> Result<(), String> {
+    self_replace::self_replace(staged_path).map_err(|e| format!("self-replace failed: {e}"))?;
+
+    // Clean up the staged file
+    let _ = std::fs::remove_file(staged_path);
+
+    Ok(())
+}
+
+/// Relaunch the application after update
+fn relaunch(current_exe: &Path) -> Result<(), String> {
+    info!("relaunching '{}'", current_exe.display());
+
+    #[cfg(target_os = "macos")]
+    {
+        // On macOS, find the .app bundle and use `open` to relaunch
+        if let Ok(bundle) = find_app_bundle(current_exe) {
+            std::process::Command::new("open")
+                .arg("-n")
+                .arg(&bundle)
+                .spawn()
+                .map_err(|e| format!("Failed to relaunch via open: {e}"))?;
+            std::process::exit(0);
+        }
+    }
+
+    // Fallback: direct exec
+    std::process::Command::new(current_exe)
+        .spawn()
+        .map_err(|e| format!("Failed to relaunch: {e}"))?;
+
+    std::process::exit(0);
+}
+
+/// Extract a downloaded archive to the staging directory.
+/// Returns the path to the extracted binary or .app bundle.
+pub fn extract_archive(archive_path: &Path, staging_dir: &Path) -> Result<PathBuf, String> {
+    let file_name = archive_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_default();
+
+    if file_name.ends_with(".tar.gz") || file_name.ends_with(".tgz") {
+        extract_tar_gz(archive_path, staging_dir)
+    } else if file_name.ends_with(".zip") {
+        extract_zip(archive_path, staging_dir)
+    } else {
+        // Assume it's a raw binary
+        let dest = staging_dir.join("notedeck");
+        std::fs::copy(archive_path, &dest).map_err(|e| format!("Failed to copy binary: {e}"))?;
+        Ok(dest)
+    }
+}
+
+fn extract_tar_gz(archive_path: &Path, staging_dir: &Path) -> Result<PathBuf, String> {
+    let file =
+        std::fs::File::open(archive_path).map_err(|e| format!("Failed to open archive: {e}"))?;
+
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+
+    archive
+        .unpack(staging_dir)
+        .map_err(|e| format!("Failed to extract tar.gz: {e}"))?;
+
+    find_binary_in_dir(staging_dir)
+}
+
+fn extract_zip(archive_path: &Path, staging_dir: &Path) -> Result<PathBuf, String> {
+    let file =
+        std::fs::File::open(archive_path).map_err(|e| format!("Failed to open archive: {e}"))?;
+
+    let mut archive = zip::ZipArchive::new(file).map_err(|e| format!("Failed to read zip: {e}"))?;
+
+    archive
+        .extract(staging_dir)
+        .map_err(|e| format!("Failed to extract zip: {e}"))?;
+
+    find_binary_in_dir(staging_dir)
+}
+
+/// Find the notedeck binary (or .app bundle) in the extracted directory
+fn find_binary_in_dir(dir: &Path) -> Result<PathBuf, String> {
+    // Look for .app bundle first (macOS)
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("app") {
+                return Ok(path);
+            }
+        }
+    }
+
+    // Look for notedeck binary
+    let candidates = ["notedeck", "notedeck.exe"];
+    for name in &candidates {
+        let path = dir.join(name);
+        if path.exists() {
+            // Ensure it's executable on Unix
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755));
+            }
+            return Ok(path);
+        }
+    }
+
+    Err(format!(
+        "Could not find notedeck binary in '{}'",
+        dir.display()
+    ))
+}


### PR DESCRIPTION
## Summary
- Add self-updating system that checks GitHub Releases for newer versions, downloads in background, and prompts user to restart
- Custom lightweight updater (~400 lines) using `ehttp` + `semver` + `self-replace` — no heavy framework
- State machine polled each frame via `try_recv()` keeps UI non-blocking
- Platform-specific install: macOS `.app` bundle swap, Linux/Windows atomic binary replacement via `self-replace`

## Architecture
```
crates/notedeck/src/updater/
    mod.rs          — Updater state machine (Idle → Checking → Downloading → ReadyToInstall)
    github.rs       — GitHub Releases API client, version comparison, asset matching
    platform.rs     — Platform-specific install + relaunch (macOS .app, Linux/Windows binary)
```

## Still needed
- [ ] CI: publish binary assets to GitHub Releases (raw binaries + archives per platform)
- [ ] Rate limiting / check interval (currently checks every launch)
- [ ] SHA256 checksum verification of downloaded binary
- [ ] Streaming download instead of buffering entire binary in memory
- [ ] Staging dir cleanup on launch
- [ ] `auto_update` setting toggle

## Test plan
- [ ] Unit tests pass (`cargo test -p notedeck --lib updater` — 5 tests)
- [ ] Build with version `0.0.1`, create test GitHub Release with `v0.7.1` + binary asset, verify update flow
- [ ] Test on Linux (simplest), then macOS (.app bundle swap), then Windows
- [ ] Verify app continues normally when GitHub API is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)