### PR TITLE
Dashboard: new contact list creations by client

### DIFF
--- a/crates/notedeck_dashboard/src/lib.rs
+++ b/crates/notedeck_dashboard/src/lib.rs
@@ -53,6 +53,7 @@ struct Bucket {
     pub clients: rustc_hash::FxHashMap<String, u32>,
     pub client_pubkeys: rustc_hash::FxHashMap<String, FxHashSet<Pubkey>>,
     pub kind1_authors: rustc_hash::FxHashMap<Pubkey, u32>,
+    pub new_contact_list_clients: rustc_hash::FxHashMap<String, u32>,
 }
 
 fn note_client_tag<'a>(note: &Note<'a>) -> Option<&'a str> {
@@ -95,6 +96,14 @@ impl Bucket {
         } else {
             // TODO(jb55): client fingerprinting ?
         }
+    }
+
+    #[inline(always)]
+    pub fn bump_new_contact_list(&mut self, client: &str) {
+        *self
+            .new_contact_list_clients
+            .entry(client.to_string())
+            .or_default() += 1;
     }
 }
 
@@ -162,6 +171,19 @@ impl RollingCache {
         }
 
         self.buckets[idx].bump(note);
+    }
+
+    #[inline(always)]
+    pub fn bump_new_contact_list(&mut self, ts: i64, client: &str) {
+        let delta = (self.anchor_end_ts - 1) - ts;
+        if delta < 0 {
+            return;
+        }
+        let idx = (delta / self.bucket_size_secs) as usize;
+        if idx >= self.buckets.len() {
+            return;
+        }
+        self.buckets[idx].bump_new_contact_list(client);
     }
 }
 
@@ -435,8 +457,14 @@ fn spawn_worker(
         .expect("failed to spawn dashboard worker thread");
 }
 
+struct FirstKind3 {
+    created_at: i64,
+    client: String,
+}
+
 struct Acc {
     last_emit: Instant,
+    first_kind3: FxHashMap<Pubkey, FirstKind3>,
 
     state: DashboardState,
 }
@@ -462,6 +490,7 @@ fn materialize_single_pass(
 
     let mut acc = Acc {
         last_emit: Instant::now(),
+        first_kind3: FxHashMap::default(),
         state: DashboardState {
             total: Bucket::default(),
             daily: RollingCache::daily(now, days),
@@ -478,6 +507,25 @@ fn materialize_single_pass(
         acc.state.weekly.bump(&note);
         acc.state.monthly.bump(&note);
 
+        if note.kind() == 3
+            && let Some(client) = note_client_tag(&note)
+        {
+            let pk = Pubkey::new(*note.pubkey());
+            let ts = note.created_at() as i64;
+            acc.first_kind3
+                .entry(pk)
+                .and_modify(|e| {
+                    if ts < e.created_at {
+                        e.created_at = ts;
+                        e.client = client.to_string();
+                    }
+                })
+                .or_insert_with(|| FirstKind3 {
+                    created_at: ts,
+                    client: client.to_string(),
+                });
+        }
+
         let now = Instant::now();
         if now.saturating_duration_since(acc.last_emit) >= emit_every {
             acc.last_emit = now;
@@ -493,6 +541,20 @@ fn materialize_single_pass(
 
         acc
     });
+
+    // Post-fold: attribute each pubkey's earliest kind 3 to its client bucket
+    for fk3 in acc.first_kind3.values() {
+        acc.state.total.bump_new_contact_list(&fk3.client);
+        acc.state
+            .daily
+            .bump_new_contact_list(fk3.created_at, &fk3.client);
+        acc.state
+            .weekly
+            .bump_new_contact_list(fk3.created_at, &fk3.client);
+        acc.state
+            .monthly
+            .bump_new_contact_list(fk3.created_at, &fk3.client);
+    }
 
     Ok(acc.state)
 }
@@ -548,6 +610,22 @@ fn top_kinds_over(cache: &RollingCache, limit: usize) -> Vec<(u64, u64)> {
         }
     }
 
+    let mut v: Vec<_> = agg.into_iter().collect();
+    v.sort_unstable_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    v.truncate(limit);
+    v
+}
+
+pub(crate) fn top_new_contact_list_clients_over(
+    cache: &RollingCache,
+    limit: usize,
+) -> Vec<(String, u64)> {
+    let mut agg: FxHashMap<String, u64> = FxHashMap::default();
+    for b in &cache.buckets {
+        for (client, count) in &b.new_contact_list_clients {
+            *agg.entry(client.clone()).or_default() += *count as u64;
+        }
+    }
     let mut v: Vec<_> = agg.into_iter().collect();
     v.sort_unstable_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
     v.truncate(limit);

--- a/crates/notedeck_dashboard/src/ui.rs
+++ b/crates/notedeck_dashboard/src/ui.rs
@@ -20,6 +20,7 @@ use crate::chart::horizontal_bar_chart;
 use crate::chart::palette;
 use crate::top_kind1_authors_over;
 use crate::top_kinds_over;
+use crate::top_new_contact_list_clients_over;
 
 pub fn period_picker_ui(ui: &mut egui::Ui, period: &mut Period) {
     ui.horizontal(|ui| {
@@ -305,6 +306,9 @@ fn dashboard_ui_inner(dashboard: &mut Dashboard, ui: &mut egui::Ui, ctx: &mut Ap
                 card_ui(ui, min_card, |ui| clients_trends_ui(dashboard, ui))
             });
             ui.add_sized(size, |ui: &mut egui::Ui| {
+                card_ui(ui, min_card, |ui| new_contact_lists_ui(dashboard, ui))
+            });
+            ui.add_sized(size, |ui: &mut egui::Ui| {
                 card_ui(ui, min_card, |ui| top_posters_ui(dashboard, ui, ctx))
             });
         },
@@ -493,6 +497,78 @@ fn top_clients_over(cache: &RollingCache, limit: usize) -> Vec<ClientStats> {
 
     out.truncate(limit);
     out
+}
+
+fn new_contact_list_series(cache: &RollingCache, client: &str) -> Vec<f32> {
+    let n = cache.buckets.len();
+    let mut out = Vec::with_capacity(n);
+    for i in (0..n).rev() {
+        let v = cache.buckets[i]
+            .new_contact_list_clients
+            .get(client)
+            .copied()
+            .unwrap_or(0) as f32;
+        out.push(v);
+    }
+    out
+}
+
+pub fn new_contact_lists_ui(dashboard: &mut Dashboard, ui: &mut egui::Ui) {
+    card_header_ui(ui, "New Contact Lists by Client");
+    ui.add_space(8.0);
+
+    let limit = 10;
+    let cache = dashboard.selected_cache();
+    let top = top_new_contact_list_clients_over(cache, limit);
+
+    if top.is_empty() && dashboard.last_error.is_none() {
+        ui.label(RichText::new("...").font(FontId::proportional(24.0)).weak());
+        return;
+    }
+    if top.is_empty() {
+        ui.label("No data");
+        return;
+    }
+
+    let spark_w = (ui.available_width() - 140.0).max(80.0);
+    let spark_h = 18.0;
+
+    for (row_i, (client, total)) in top.iter().enumerate() {
+        ui.horizontal(|ui| {
+            ui.label(RichText::new(client).small());
+            ui.add_space(6.0);
+
+            let series = new_contact_list_series(cache, client);
+            let resp = crate::sparkline::sparkline(
+                ui,
+                egui::vec2(spark_w, spark_h),
+                &series,
+                palette(row_i),
+                crate::sparkline::SparkStyle::default(),
+            );
+
+            if resp.hovered() {
+                let last = series.last().copied().unwrap_or(0.0);
+                resp.on_hover_text(format!(
+                    "{} new contact lists\nlatest bucket: {:.0}",
+                    total, last
+                ));
+            }
+
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                ui.label(RichText::new(total.to_string()).small().strong());
+            });
+        });
+        ui.add_space(4.0);
+    }
+
+    footer_status_ui(
+        ui,
+        dashboard.running,
+        dashboard.last_error.as_deref(),
+        dashboard.last_snapshot,
+        dashboard.last_duration,
+    );
 }
 
 pub fn top_posters_ui(dashboard: &mut Dashboard, ui: &mut egui::Ui, ctx: &mut AppContext<'_>) {


### PR DESCRIPTION
## Summary
- Track first-seen kind 3 (contact list) events per pubkey and attribute them to the client that created them
- Add "New Contact Lists by Client" card to the dashboard UI with sparklines and totals
- Aggregate across daily/weekly/monthly rolling caches

Changelog-Added: dashboard card showing new contact list creations by client
Closes: https://linear.app/damus/issue/DECK-846

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Introduced "New Contact Lists by Client" dashboard panel with per-client sparkline visualizations and interactive hover tooltips. Displays aggregated contact list creation metrics for each client including totals and status information. Provides insight into which clients generate new contact lists with enhanced data visibility and empty-state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->