### PR TITLE
android: APK self-update via nostr/zapstore updater

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,8 +20,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2
-
       - name: Additional Setup (if specified)
         if: ${{ inputs.additional-setup != '' }}
         run: ${{ inputs.additional-setup }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -126,6 +126,10 @@ jobs:
       matrix:
         arch: [x86_64, aarch64]
 
+    env:
+      PKG_CONFIG_ALLOW_CROSS: 1
+      PKG_CONFIG_PATH: /usr/lib/aarch64-linux-gnu/pkgconfig
+
     steps:
       # Checkout the repository
       - name: Checkout Code
@@ -139,7 +143,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libasound2-dev
           if [ "${{ matrix.arch }}" != "$(uname -m)" ]; then
-            sudo apt-get install -y gcc-${{ matrix.arch }}-linux-gnu g++-aarch64-linux-gnu
+            sudo dpkg --add-architecture arm64
+            sudo sed -i 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list
+            echo "deb [arch=arm64] http://ports.ubuntu.com/ jammy main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/arm64.list
+            echo "deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64.list
+            sudo apt-get update
+            sudo apt-get install -y gcc-${{ matrix.arch }}-linux-gnu g++-aarch64-linux-gnu libasound2-dev:arm64
             rustup target add ${{ matrix.arch }}-unknown-linux-gnu
           fi
           cargo install cargo-generate-rpm cargo-deb

--- a/crates/enostr/tests/outbox_integration.rs
+++ b/crates/enostr/tests/outbox_integration.rs
@@ -9,9 +9,18 @@ use enostr::{
 };
 use hashbrown::HashSet;
 use nostr_relay_builder::{LocalRelay, RelayBuilder};
-use nostrdb::{Filter, NoteBuilder};
+use nostrdb::{Config, Filter, NoteBuilder};
 use std::sync::Once;
 use std::time::Duration;
+
+/// Returns a [`Config`] with a small mapsize suitable for tests on Windows.
+fn test_config() -> Config {
+    if cfg!(target_os = "windows") {
+        Config::new().set_mapsize(32 * 1024 * 1024)
+    } else {
+        Config::new()
+    }
+}
 
 static TRACING_INIT: Once = Once::new();
 
@@ -1185,7 +1194,7 @@ async fn publish_receive_ndb_ingest() {
     let tmpdir = tempfile::TempDir::new().expect("tmpdir");
     let db_path = tmpdir.path().join("db");
     std::fs::create_dir_all(&db_path).expect("create db dir");
-    let ndb = nostrdb::Ndb::new(db_path.to_str().unwrap(), &nostrdb::Config::new()).expect("ndb");
+    let ndb = nostrdb::Ndb::new(db_path.to_str().unwrap(), &test_config()).expect("ndb");
 
     // Subscriber pool
     let mut sub_pool = OutboxPool::default();

--- a/crates/notedeck/src/lib.rs
+++ b/crates/notedeck/src/lib.rs
@@ -44,6 +44,8 @@ mod setup;
 pub mod sound;
 pub mod storage;
 mod style;
+#[cfg(test)]
+pub(crate) mod test_util;
 pub mod theme;
 mod time;
 mod timecache;

--- a/crates/notedeck/src/oneshot_api.rs
+++ b/crates/notedeck/src/oneshot_api.rs
@@ -29,14 +29,15 @@ impl<'o, 'a> OneshotApi<'o, 'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util::test_config;
     use crate::{EguiWakeup, UnknownIds, FALLBACK_PUBKEY};
     use enostr::{OutboxPool, OutboxSessionHandler, OutboxSubId};
-    use nostrdb::{Config, Ndb, Transaction};
+    use nostrdb::{Ndb, Transaction};
     use tempfile::TempDir;
 
     fn test_accounts_with_forced_relay(relay: &str) -> (TempDir, crate::Accounts) {
         let tmp = TempDir::new().expect("tmp dir");
-        let mut ndb = Ndb::new(tmp.path().to_str().expect("path"), &Config::new()).expect("ndb");
+        let mut ndb = Ndb::new(tmp.path().to_str().expect("path"), &test_config()).expect("ndb");
         let txn = Transaction::new(&ndb).expect("txn");
         let mut unknown_ids = UnknownIds::default();
 

--- a/crates/notedeck/src/persist/settings_handler.rs
+++ b/crates/notedeck/src/persist/settings_handler.rs
@@ -50,6 +50,14 @@ pub struct Settings {
     pub sounds_enabled: bool,
     #[serde(default = "default_sound_volume")]
     pub sound_volume: f32,
+    #[serde(default = "default_release_channel")]
+    pub release_channel: String,
+}
+
+const DEFAULT_RELEASE_CHANNEL: &str = "main";
+
+fn default_release_channel() -> String {
+    DEFAULT_RELEASE_CHANNEL.to_string()
 }
 
 fn default_animate_nav_transitions() -> bool {
@@ -85,6 +93,7 @@ impl Default for Settings {
             age_verified: false,
             sounds_enabled: default_sounds_enabled(),
             sound_volume: default_sound_volume(),
+            release_channel: default_release_channel(),
         }
     }
 }
@@ -322,6 +331,18 @@ impl SettingsHandler {
             .as_ref()
             .map(|s| s.tos_accepted)
             .unwrap_or(false)
+    }
+
+    pub fn release_channel(&self) -> &str {
+        self.current_settings
+            .as_ref()
+            .map(|s| s.release_channel.as_str())
+            .unwrap_or(DEFAULT_RELEASE_CHANNEL)
+    }
+
+    pub fn set_release_channel(&mut self, channel: &str) {
+        self.get_settings_mut().release_channel = channel.to_string();
+        self.try_save_settings();
     }
 
     pub fn accept_tos(&mut self) {

--- a/crates/notedeck/src/publish.rs
+++ b/crates/notedeck/src/publish.rs
@@ -76,14 +76,15 @@ impl<'o, 'a> PublishApi<'o, 'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util::test_config;
     use crate::{EguiWakeup, UnknownIds, FALLBACK_PUBKEY};
     use enostr::{FullKeypair, NormRelayUrl, OutboxPool, OutboxSessionHandler};
-    use nostrdb::{Config, Ndb, Note, NoteBuilder, Transaction};
+    use nostrdb::{Ndb, Note, NoteBuilder, Transaction};
     use tempfile::TempDir;
 
     fn test_accounts_with_forced_relay(relay: &str) -> (TempDir, crate::Accounts) {
         let tmp = TempDir::new().expect("tmp dir");
-        let mut ndb = Ndb::new(tmp.path().to_str().expect("path"), &Config::new()).expect("ndb");
+        let mut ndb = Ndb::new(tmp.path().to_str().expect("path"), &test_config()).expect("ndb");
         let txn = Transaction::new(&ndb).expect("txn");
         let mut unknown_ids = UnknownIds::default();
 

--- a/crates/notedeck/src/sound.rs
+++ b/crates/notedeck/src/sound.rs
@@ -25,6 +25,7 @@ pub enum SoundEffect {
     Notification,
     Opened,
     Closed,
+    Startup,
 }
 
 #[cfg(feature = "sound")]
@@ -100,6 +101,10 @@ mod inner {
             sounds.insert(
                 SoundEffect::Closed,
                 include_bytes!("../../../assets/sounds/close.mp3").as_slice(),
+            );
+            sounds.insert(
+                SoundEffect::Startup,
+                include_bytes!("../../../assets/sounds/startup.mp3").as_slice(),
             );
 
             let pending: HashMap<SoundEffect, AtomicU64> =

--- a/crates/notedeck/src/test_util.rs
+++ b/crates/notedeck/src/test_util.rs
@@ -1,0 +1,14 @@
+use nostrdb::Config;
+
+/// Returns a [`Config`] with a small mapsize suitable for tests.
+///
+/// On Windows LMDB actually allocates the full mapsize on disk, so tests
+/// that use the default (very large) mapsize can exhaust disk space or hit
+/// CI resource limits.
+pub fn test_config() -> Config {
+    if cfg!(target_os = "windows") {
+        Config::new().set_mapsize(32 * 1024 * 1024) // 32 MiB
+    } else {
+        Config::new()
+    }
+}

--- a/crates/notedeck/src/updater/mod.rs
+++ b/crates/notedeck/src/updater/mod.rs
@@ -70,7 +70,7 @@ impl Updater {
         let (tx, rx) = mpsc::channel();
         let staging_dir = data_path.path(DataPathType::Update);
         let _ = std::fs::create_dir_all(&staging_dir);
-        let filters = nostr::release_filter(&release_pubkey, channel);
+        let filters = nostr::release_filter(&release_pubkey);
         let release_sub = ndb.subscribe(&filters).expect("release subscription");
 
         Self {
@@ -168,22 +168,23 @@ impl Updater {
     }
 
     /// Unsubscribe from the current release filter and resubscribe with
-    /// the current pubkey and channel.
+    /// the current pubkey.
+    #[cfg(feature = "snapshot-testing")]
     fn resubscribe(&mut self, ndb: &mut Ndb) {
         let _ = ndb.unsubscribe(self.release_sub);
-        let filters = nostr::release_filter(&self.release_pubkey, self.channel);
+        let filters = nostr::release_filter(&self.release_pubkey);
         self.release_sub = ndb.subscribe(&filters).expect("release subscription");
         self.sent_relay_filter = false;
     }
 
-    /// Change the release channel and resubscribe
-    pub fn set_channel(&mut self, ndb: &mut Ndb, channel: nostr::ReleaseChannel) {
+    /// Change the release channel. Since channel filtering is done client-side
+    /// via semver, no resubscription is needed — just reset state to re-evaluate.
+    pub fn set_channel(&mut self, channel: nostr::ReleaseChannel) {
         if self.channel == channel {
             return;
         }
         self.channel = channel;
-        self.resubscribe(ndb);
-        // Reset to re-check with the new channel
+        // Reset to re-check with the new channel acceptance criteria
         if matches!(
             self.state,
             UpdateState::UpToDate | UpdateState::WaitingForRelease

--- a/crates/notedeck/src/updater/mod.rs
+++ b/crates/notedeck/src/updater/mod.rs
@@ -65,11 +65,11 @@ impl Updater {
         ndb: &Ndb,
         ctx: &egui::Context,
         release_pubkey: [u8; 32],
+        channel: nostr::ReleaseChannel,
     ) -> Self {
         let (tx, rx) = mpsc::channel();
         let staging_dir = data_path.path(DataPathType::Update);
         let _ = std::fs::create_dir_all(&staging_dir);
-        let channel = nostr::ReleaseChannel::default();
         let filters = nostr::release_filter(&release_pubkey, channel);
         let release_sub = ndb.subscribe(&filters).expect("release subscription");
 
@@ -167,12 +167,36 @@ impl Updater {
         }
     }
 
+    /// Unsubscribe from the current release filter and resubscribe with
+    /// the current pubkey and channel.
+    fn resubscribe(&mut self, ndb: &mut Ndb) {
+        let _ = ndb.unsubscribe(self.release_sub);
+        let filters = nostr::release_filter(&self.release_pubkey, self.channel);
+        self.release_sub = ndb.subscribe(&filters).expect("release subscription");
+        self.sent_relay_filter = false;
+    }
+
+    /// Change the release channel and resubscribe
+    pub fn set_channel(&mut self, ndb: &mut Ndb, channel: nostr::ReleaseChannel) {
+        if self.channel == channel {
+            return;
+        }
+        self.channel = channel;
+        self.resubscribe(ndb);
+        // Reset to re-check with the new channel
+        if matches!(
+            self.state,
+            UpdateState::UpToDate | UpdateState::WaitingForRelease
+        ) {
+            self.state = UpdateState::Idle;
+        }
+    }
+
     /// Override the release signing pubkey and resubscribe (for tests)
     #[cfg(feature = "snapshot-testing")]
-    pub fn set_release_pubkey(&mut self, ndb: &Ndb, pubkey: [u8; 32]) {
+    pub fn set_release_pubkey(&mut self, ndb: &mut Ndb, pubkey: [u8; 32]) {
         self.release_pubkey = pubkey;
-        let filters = nostr::release_filter(&pubkey, self.channel);
-        self.release_sub = ndb.subscribe(&filters).expect("release subscription");
+        self.resubscribe(ndb);
     }
 
     /// Force the updater into ReadyToInstall state (for snapshot tests)

--- a/crates/notedeck/src/updater/mod.rs
+++ b/crates/notedeck/src/updater/mod.rs
@@ -6,7 +6,12 @@ use nostrdb::{Ndb, Subscription};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
+use std::time::{Duration, Instant};
 use tracing::{error, info};
+
+/// How long to wait after receiving the first release event before
+/// picking the best version. Gives slower relays time to respond.
+const GATHER_DEBOUNCE: Duration = Duration::from_secs(3);
 
 /// Information about a release asset available for download
 #[derive(Debug, Clone)]
@@ -29,6 +34,8 @@ enum UpdateState {
     Idle,
     /// Waiting for a release event from ndb
     WaitingForRelease,
+    /// Got at least one release event, waiting for more relays to respond
+    GatheringReleases { deadline: Instant },
     /// Downloading the update archive
     Downloading { version: String },
     /// Downloaded and ready to install
@@ -118,9 +125,12 @@ impl Updater {
         }
     }
 
-    /// Whether the updater is waiting for a release to be provided
+    /// Whether the updater is listening for release events
     pub fn wants_release(&self) -> bool {
-        matches!(self.state, UpdateState::WaitingForRelease)
+        matches!(
+            self.state,
+            UpdateState::WaitingForRelease | UpdateState::GatheringReleases { .. }
+        )
     }
 
     /// Whether the release filter needs to be sent to remote relays.
@@ -133,14 +143,45 @@ impl Updater {
         true
     }
 
-    /// Provide a verified release (from a signed Nostr event) to begin downloading
-    pub fn provide_release(&mut self, release: ReleaseInfo) {
-        if !self.wants_release() {
+    /// Signal that new release events have arrived. Starts or resets the
+    /// debounce timer so slower relays have time to deliver their events.
+    pub fn note_received(&mut self) {
+        match self.state {
+            UpdateState::WaitingForRelease | UpdateState::GatheringReleases { .. } => {
+                self.state = UpdateState::GatheringReleases {
+                    deadline: Instant::now() + GATHER_DEBOUNCE,
+                };
+            }
+            _ => {}
+        }
+    }
+
+    /// Check if the gathering debounce has expired. If so, query ndb for
+    /// the best release and start downloading. Call this every frame.
+    pub fn check_gathering(&mut self, ndb: &Ndb) {
+        let deadline = match self.state {
+            UpdateState::GatheringReleases { deadline } => deadline,
+            _ => return,
+        };
+
+        if Instant::now() < deadline {
             return;
         }
 
-        info!("update available: v{}", release.version);
-        self.start_download(release);
+        let channel = self.channel;
+        if let Ok(txn) = nostrdb::Transaction::new(ndb) {
+            if let Some(release) =
+                nostr::find_latest_release(ndb, &txn, &self.release_pubkey, channel)
+            {
+                info!("update available: v{}", release.version);
+                self.start_download(release);
+                return;
+            }
+        }
+
+        // No valid release found after gathering — go back to waiting
+        info!("updater: no matching release found after debounce, continuing to wait");
+        self.state = UpdateState::WaitingForRelease;
     }
 
     /// Returns the new version string if an update is ready to install.
@@ -187,7 +228,9 @@ impl Updater {
         // Reset to re-check with the new channel acceptance criteria
         if matches!(
             self.state,
-            UpdateState::UpToDate | UpdateState::WaitingForRelease
+            UpdateState::UpToDate
+                | UpdateState::WaitingForRelease
+                | UpdateState::GatheringReleases { .. }
         ) {
             self.state = UpdateState::Idle;
         }

--- a/crates/notedeck/src/updater/nostr.rs
+++ b/crates/notedeck/src/updater/nostr.rs
@@ -53,6 +53,45 @@ impl ReleaseChannel {
     pub fn from_setting(s: &str) -> Self {
         Self::parse(s).unwrap_or_default()
     }
+
+    /// Derive the release channel from a semver version string.
+    /// - No prerelease → Main (e.g. `1.0.0`)
+    /// - Prerelease starting with "beta" → Beta (e.g. `1.0.0-beta.1`)
+    /// - Prerelease starting with "nightly" → Nightly (e.g. `1.0.0-nightly.20260327`)
+    /// - Prerelease starting with "dev" → Dev (e.g. `1.0.0-dev.123`)
+    /// - Unknown prerelease → Dev (most permissive)
+    pub fn from_version(version: &semver::Version) -> Self {
+        if version.pre.is_empty() {
+            return Self::Main;
+        }
+        let pre = version.pre.as_str();
+        if pre.starts_with("beta") {
+            Self::Beta
+        } else if pre.starts_with("nightly") {
+            Self::Nightly
+        } else if pre.starts_with("dev") {
+            Self::Dev
+        } else {
+            // Unknown prerelease identifiers are treated as dev
+            Self::Dev
+        }
+    }
+
+    /// Whether this channel setting accepts releases from the given channel.
+    /// Hierarchy: Dev > Nightly > Beta > Main
+    /// e.g. Beta accepts Beta and Main releases, but not Nightly or Dev.
+    pub fn accepts(&self, release_channel: ReleaseChannel) -> bool {
+        self.tier() >= release_channel.tier()
+    }
+
+    fn tier(&self) -> u8 {
+        match self {
+            Self::Main => 0,
+            Self::Beta => 1,
+            Self::Nightly => 2,
+            Self::Dev => 3,
+        }
+    }
 }
 
 /// Returns the expected asset name for the current platform/arch
@@ -121,15 +160,17 @@ pub fn target_platform_tag() -> &'static str {
 
 /// Build nostrdb filters for NIP-82 release events and asset events from the given pubkey.
 /// Returns two filters: one for kind 30063 (releases) and one for kind 3063 (assets).
-pub fn release_filter(pubkey: &[u8; 32], channel: ReleaseChannel) -> Vec<Filter> {
+/// Channel filtering is done client-side via semver prerelease identifiers after
+/// parsing the version tag from release events.
+pub fn release_filter(pubkey: &[u8; 32]) -> Vec<Filter> {
     vec![
-        // Kind 30063: Software Release events filtered by app id and channel
+        // Kind 30063: Software Release events filtered by app id.
+        // Generous limit so prereleases don't push stable out of results.
         Filter::new()
             .authors([pubkey])
             .kinds([RELEASE_KIND])
             .tags([APP_ID], 'i')
-            .tags([channel.as_str()], 'c')
-            .limit(10)
+            .limit(200)
             .build(),
         // Kind 3063: Software Asset events (we need these to resolve release references)
         Filter::new()
@@ -289,9 +330,9 @@ pub fn find_latest_release(
     pubkey: &[u8; 32],
     channel: ReleaseChannel,
 ) -> Option<ReleaseInfo> {
-    let filters = release_filter(pubkey, channel);
+    let filters = release_filter(pubkey);
 
-    let results = match ndb.query(txn, &filters, 50) {
+    let results = match ndb.query(txn, &filters, 200) {
         Ok(r) => r,
         Err(e) => {
             warn!("failed to query ndb for release events: {e}");
@@ -312,12 +353,21 @@ pub fn find_latest_release(
             Err(_) => continue,
         };
 
+        // Derive channel from semver prerelease and check hierarchy
+        let remote_version = match semver::Version::parse(&release_info.version) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let release_ch = ReleaseChannel::from_version(&remote_version);
+        if !channel.accepts(release_ch) {
+            continue;
+        }
+
         // Check if this version is better than our current best
         let dominated = best.as_ref().is_some_and(|b| {
-            semver::Version::parse(&release_info.version)
+            semver::Version::parse(&b.version)
                 .ok()
-                .zip(semver::Version::parse(&b.version).ok())
-                .is_some_and(|(new, old)| new <= old)
+                .is_some_and(|old| remote_version <= old)
         });
 
         if dominated {
@@ -571,8 +621,50 @@ mod tests {
     }
 
     #[test]
+    fn test_release_channel_from_version() {
+        let v = |s: &str| semver::Version::parse(s).unwrap();
+        assert_eq!(
+            ReleaseChannel::from_version(&v("1.0.0")),
+            ReleaseChannel::Main
+        );
+        assert_eq!(
+            ReleaseChannel::from_version(&v("1.0.0-beta.1")),
+            ReleaseChannel::Beta
+        );
+        assert_eq!(
+            ReleaseChannel::from_version(&v("1.0.0-nightly.20260327")),
+            ReleaseChannel::Nightly
+        );
+        assert_eq!(
+            ReleaseChannel::from_version(&v("1.0.0-dev.123")),
+            ReleaseChannel::Dev
+        );
+        // Unknown prerelease → Dev
+        assert_eq!(
+            ReleaseChannel::from_version(&v("1.0.0-rc.1")),
+            ReleaseChannel::Dev
+        );
+    }
+
+    #[test]
+    fn test_release_channel_accepts_hierarchy() {
+        // Main only accepts Main
+        assert!(ReleaseChannel::Main.accepts(ReleaseChannel::Main));
+        assert!(!ReleaseChannel::Main.accepts(ReleaseChannel::Beta));
+
+        // Beta accepts Main + Beta
+        assert!(ReleaseChannel::Beta.accepts(ReleaseChannel::Main));
+        assert!(ReleaseChannel::Beta.accepts(ReleaseChannel::Beta));
+        assert!(!ReleaseChannel::Beta.accepts(ReleaseChannel::Nightly));
+
+        // Dev accepts everything
+        assert!(ReleaseChannel::Dev.accepts(ReleaseChannel::Main));
+        assert!(ReleaseChannel::Dev.accepts(ReleaseChannel::Dev));
+    }
+
+    #[test]
     fn test_release_filter_builds() {
-        let filters = release_filter(&DEFAULT_RELEASE_PUBKEY, ReleaseChannel::Main);
+        let filters = release_filter(&DEFAULT_RELEASE_PUBKEY);
         assert_eq!(filters.len(), 2, "should have release + asset filters");
     }
 

--- a/crates/notedeck/src/updater/nostr.rs
+++ b/crates/notedeck/src/updater/nostr.rs
@@ -76,6 +76,10 @@ pub fn target_asset_name() -> &'static str {
     {
         "notedeck-aarch64-windows.zip"
     }
+    #[cfg(target_os = "android")]
+    {
+        "notedeck.apk"
+    }
 }
 
 /// Returns the platform tag value for the current platform/arch (NIP-82 "f" tag)
@@ -103,6 +107,10 @@ pub fn target_platform_tag() -> &'static str {
     #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
     {
         "windows-aarch64"
+    }
+    #[cfg(target_os = "android")]
+    {
+        "android-aarch64"
     }
 }
 

--- a/crates/notedeck/src/updater/nostr.rs
+++ b/crates/notedeck/src/updater/nostr.rs
@@ -565,7 +565,8 @@ pub mod test_helpers {
 mod tests {
     use super::test_helpers::*;
     use super::*;
-    use nostrdb::{Config, IngestMetadata, Ndb};
+    use crate::test_util::test_config;
+    use nostrdb::{IngestMetadata, Ndb};
     use tempfile::TempDir;
 
     /// Hex pubkey string for use with make_*_event_json (skip_validation tests)
@@ -574,7 +575,7 @@ mod tests {
 
     fn test_ndb() -> (TempDir, Ndb) {
         let tmp = TempDir::new().unwrap();
-        let cfg = Config::new().skip_validation(true);
+        let cfg = test_config().skip_validation(true);
         let ndb = Ndb::new(tmp.path().to_str().unwrap(), &cfg).unwrap();
         (tmp, ndb)
     }

--- a/crates/notedeck/src/updater/nostr.rs
+++ b/crates/notedeck/src/updater/nostr.rs
@@ -10,7 +10,7 @@ const RELEASE_KIND: u64 = 30063;
 const ASSET_KIND: u64 = 3063;
 
 /// The app identifier used in NIP-82 "i" tags
-pub const APP_ID: &str = "io.damus.notedeck";
+pub const APP_ID: &str = "com.damus.notedeck";
 
 /// Default trusted release signing pubkey
 /// TODO: Replace with the actual release signing pubkey before shipping

--- a/crates/notedeck/src/updater/nostr.rs
+++ b/crates/notedeck/src/updater/nostr.rs
@@ -48,6 +48,11 @@ impl ReleaseChannel {
             _ => None,
         }
     }
+
+    /// Parse a channel from the settings string, defaulting to Main
+    pub fn from_setting(s: &str) -> Self {
+        Self::parse(s).unwrap_or_default()
+    }
 }
 
 /// Returns the expected asset name for the current platform/arch

--- a/crates/notedeck/src/updater/platform.rs
+++ b/crates/notedeck/src/updater/platform.rs
@@ -180,7 +180,7 @@ pub fn extract_archive(archive_path: &Path, staging_dir: &Path) -> Result<PathBu
         // APK is the final artifact — no extraction needed
         let dest = staging_dir.join(file_name);
         std::fs::copy(archive_path, &dest).map_err(|e| format!("Failed to copy APK: {e}"))?;
-        return Ok(dest);
+        Ok(dest)
     } else if file_name.ends_with(".tar.gz") || file_name.ends_with(".tgz") {
         extract_tar_gz(archive_path, staging_dir)
     } else if file_name.ends_with(".zip") {

--- a/crates/notedeck/src/updater/platform.rs
+++ b/crates/notedeck/src/updater/platform.rs
@@ -3,9 +3,22 @@ use tracing::info;
 
 /// Install the downloaded update and relaunch the application.
 ///
-/// `staged_path` is the path to the new binary (or .app bundle on macOS)
-/// that has been extracted from the downloaded archive.
+/// `staged_path` is the path to the new binary (or .app bundle on macOS,
+/// or .apk on Android) that has been extracted from the downloaded archive.
 pub fn install_and_restart(staged_path: &Path) -> Result<(), String> {
+    #[cfg(target_os = "android")]
+    {
+        install_apk_android(staged_path)
+    }
+
+    #[cfg(not(target_os = "android"))]
+    {
+        install_and_restart_desktop(staged_path)
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+fn install_and_restart_desktop(staged_path: &Path) -> Result<(), String> {
     let current_exe =
         std::env::current_exe().map_err(|e| format!("Failed to get current exe: {e}"))?;
 
@@ -26,6 +39,42 @@ pub fn install_and_restart(staged_path: &Path) -> Result<(), String> {
     }
 
     relaunch(&current_exe)
+}
+
+/// On Android, call into Java to fire ACTION_VIEW intent with the APK.
+/// The system package installer handles the rest.
+#[cfg(target_os = "android")]
+fn install_apk_android(apk_path: &Path) -> Result<(), String> {
+    use jni::objects::{JObject, JValue};
+
+    info!("installing APK update from '{}'", apk_path.display());
+
+    let path_str = apk_path
+        .to_str()
+        .ok_or_else(|| "APK path is not valid UTF-8".to_string())?;
+
+    let vm = unsafe { jni::JavaVM::from_raw(ndk_context::android_context().vm().cast()) }
+        .map_err(|e| format!("Failed to get JavaVM: {e}"))?;
+
+    let mut env = vm
+        .attach_current_thread()
+        .map_err(|e| format!("Failed to attach JNI thread: {e}"))?;
+
+    let context = unsafe { JObject::from_raw(ndk_context::android_context().context().cast()) };
+
+    let jpath = env
+        .new_string(path_str)
+        .map_err(|e| format!("Failed to create JNI string: {e}"))?;
+
+    env.call_method(
+        context,
+        "installApk",
+        "(Ljava/lang/String;)V",
+        &[JValue::Object(&jpath.into())],
+    )
+    .map_err(|e| format!("Failed to call installApk: {e}"))?;
+
+    Ok(())
 }
 
 /// On macOS, replace the entire .app bundle to preserve code signing.
@@ -127,7 +176,12 @@ pub fn extract_archive(archive_path: &Path, staging_dir: &Path) -> Result<PathBu
         .and_then(|n| n.to_str())
         .unwrap_or_default();
 
-    if file_name.ends_with(".tar.gz") || file_name.ends_with(".tgz") {
+    if file_name.ends_with(".apk") {
+        // APK is the final artifact — no extraction needed
+        let dest = staging_dir.join(file_name);
+        std::fs::copy(archive_path, &dest).map_err(|e| format!("Failed to copy APK: {e}"))?;
+        return Ok(dest);
+    } else if file_name.ends_with(".tar.gz") || file_name.ends_with(".tgz") {
         extract_tar_gz(archive_path, staging_dir)
     } else if file_name.ends_with(".zip") {
         extract_zip(archive_path, staging_dir)

--- a/crates/notedeck/src/zaps/zap.rs
+++ b/crates/notedeck/src/zaps/zap.rs
@@ -227,9 +227,10 @@ fn get_zap_tags(ev: nostrdb::Note) -> Option<ZapTags> {
 mod tests {
     use enostr::{NoteId, Pubkey};
 
-    use nostrdb::{Config, Filter, IngestMetadata, Ndb, Transaction};
+    use nostrdb::{Filter, IngestMetadata, Ndb, Transaction};
     use tempfile::TempDir;
 
+    use crate::test_util::test_config;
     use crate::zaps::zap::{valid_zap_request, Zap};
 
     // a random zap receipt
@@ -251,7 +252,7 @@ mod tests {
                 .unwrap();
 
         let tmp_dir = TempDir::new().unwrap();
-        let ndb = Ndb::new(tmp_dir.path().to_str().unwrap(), &Config::new()).unwrap();
+        let ndb = Ndb::new(tmp_dir.path().to_str().unwrap(), &test_config()).unwrap();
 
         let ev = format!(r#"["EVENT", "random_string", {ZAP_RECEIPT}]"#);
         let filter = Filter::new().authors([pk.bytes()]).build();

--- a/crates/notedeck_chrome/android/app/build.gradle
+++ b/crates/notedeck_chrome/android/app/build.gradle
@@ -10,7 +10,7 @@ if (keystorePropertiesFile.exists()) {
 
 android {
     namespace "com.damus.notedeck"
-    compileSdk 31
+    compileSdk 34
 
     defaultConfig {
         minSdk 19

--- a/crates/notedeck_chrome/android/app/build.gradle
+++ b/crates/notedeck_chrome/android/app/build.gradle
@@ -44,6 +44,7 @@ android {
 }
 
 dependencies {
+    implementation "androidx.core:core:1.7.0"
     implementation "com.google.android.material:material:1.5.0"
     implementation "androidx.games:games-activity:4.0.0"
 }

--- a/crates/notedeck_chrome/android/app/src/main/AndroidManifest.xml
+++ b/crates/notedeck_chrome/android/app/src/main/AndroidManifest.xml
@@ -22,6 +22,16 @@
                 android:name="android.app.lib_name"
                 android:value="notedeck_chrome" />
         </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
     <queries>
@@ -39,4 +49,5 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 </manifest>

--- a/crates/notedeck_chrome/android/app/src/main/java/com/damus/notedeck/MainActivity.java
+++ b/crates/notedeck_chrome/android/app/src/main/java/com/damus/notedeck/MainActivity.java
@@ -4,16 +4,19 @@ import android.content.ClipData;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.ParcelFileDescriptor;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.provider.OpenableColumns;
+import android.provider.Settings;
 import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.core.content.FileProvider;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowCompat;
@@ -23,12 +26,15 @@ import androidx.core.view.WindowInsetsControllerCompat;
 import com.google.androidgamesdk.GameActivity;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.FileDescriptor;
 import java.io.IOException;
 import java.io.InputStream;
 
 public class MainActivity extends GameActivity {
     static final int REQUEST_CODE_PICK_FILE = 420;
+    static final int REQUEST_CODE_INSTALL_PERMISSION = 421;
+    private String pendingApkPath = null;
 
   private native void nativeOnFilePickedFailed(String uri, String e);
   private native void nativeOnFilePickedWithContent(Object[] uri_info, byte[] content);
@@ -40,6 +46,30 @@ public class MainActivity extends GameActivity {
                 durationMs, VibrationEffect.DEFAULT_AMPLITUDE);
             vibrator.vibrate(effect);
         }
+  }
+
+  public void installApk(String path) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                && !getPackageManager().canRequestPackageInstalls()) {
+            pendingApkPath = path;
+            Intent settingsIntent = new Intent(
+                    Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+                    Uri.parse("package:" + getPackageName()));
+            startActivityForResult(settingsIntent, REQUEST_CODE_INSTALL_PERMISSION);
+            return;
+        }
+        launchApkInstall(path);
+  }
+
+  private void launchApkInstall(String path) {
+        File apkFile = new File(path);
+        Uri apkUri = FileProvider.getUriForFile(this,
+                getPackageName() + ".fileprovider", apkFile);
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setDataAndType(apkUri, "application/vnd.android.package-archive");
+        intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION
+                | Intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(intent);
   }
 
   public void openFilePicker() {
@@ -176,6 +206,19 @@ public class MainActivity extends GameActivity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == REQUEST_CODE_INSTALL_PERMISSION) {
+            if (pendingApkPath != null) {
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O
+                        || getPackageManager().canRequestPackageInstalls()) {
+                    launchApkInstall(pendingApkPath);
+                } else {
+                    Log.w("MainActivity", "Install permission still not granted");
+                }
+                pendingApkPath = null;
+            }
+            return;
+        }
 
         if (requestCode == REQUEST_CODE_PICK_FILE && resultCode == RESULT_OK) {
             if (data == null) return;

--- a/crates/notedeck_chrome/android/app/src/main/res/xml/file_paths.xml
+++ b/crates/notedeck_chrome/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <!-- Exposes app-private internal files dir for APK updates.
+         The updater stages APKs under {filesDir}/notedeck/update/ -->
+    <files-path name="updates" path="update/" />
+</paths>

--- a/crates/notedeck_chrome/src/chrome.rs
+++ b/crates/notedeck_chrome/src/chrome.rs
@@ -635,14 +635,13 @@ fn poll_updater(updater: &mut notedeck::updater::Updater, ctx: &mut notedeck::Ap
     let setting_str = ctx.settings.release_channel();
     if setting_str != updater.channel().as_str() {
         if let Some(ch) = notedeck::updater::nostr::ReleaseChannel::parse(setting_str) {
-            updater.set_channel(ctx.ndb, ch);
+            updater.set_channel(ch);
         }
     }
 
     if updater.needs_relay_sub() {
         let release_pubkey = *updater.release_pubkey();
-        let channel = updater.channel();
-        let filters = notedeck::updater::nostr::release_filter(&release_pubkey, channel);
+        let filters = notedeck::updater::nostr::release_filter(&release_pubkey);
         let mut oneshot = ctx.remote.oneshot(ctx.accounts);
         oneshot.oneshot(filters);
     }

--- a/crates/notedeck_chrome/src/chrome.rs
+++ b/crates/notedeck_chrome/src/chrome.rs
@@ -650,20 +650,10 @@ fn poll_updater(updater: &mut notedeck::updater::Updater, ctx: &mut notedeck::Ap
         let release_sub = updater.release_sub();
         let nks = ctx.ndb.poll_for_notes(release_sub, 10);
         if !nks.is_empty() {
-            let release_pubkey = *updater.release_pubkey();
-            let channel = updater.channel();
-            if let Ok(txn) = nostrdb::Transaction::new(ctx.ndb) {
-                if let Some(release) = notedeck::updater::nostr::find_latest_release(
-                    ctx.ndb,
-                    &txn,
-                    &release_pubkey,
-                    channel,
-                ) {
-                    updater.provide_release(release);
-                }
-            }
+            updater.note_received();
         }
     }
+    updater.check_gathering(ctx.ndb);
     updater.poll();
 }
 

--- a/crates/notedeck_chrome/src/chrome.rs
+++ b/crates/notedeck_chrome/src/chrome.rs
@@ -206,6 +206,9 @@ impl Chrome {
                 &notedeck_ref.app_ctx.ndb,
                 &cc.egui_ctx,
                 notedeck::updater::nostr::DEFAULT_RELEASE_PUBKEY,
+                notedeck::updater::nostr::ReleaseChannel::from_setting(
+                    notedeck_ref.app_ctx.settings.release_channel(),
+                ),
             ),
         };
 
@@ -300,6 +303,9 @@ impl Chrome {
                 &ctx.ndb,
                 egui_ctx,
                 notedeck::updater::nostr::DEFAULT_RELEASE_PUBKEY,
+                notedeck::updater::nostr::ReleaseChannel::from_setting(
+                    ctx.settings.release_channel(),
+                ),
             ),
         };
         chrome.add_app(NotedeckApp::Columns(Box::new(damus)));
@@ -309,7 +315,7 @@ impl Chrome {
 
     /// Override the release signing pubkey and resubscribe to ndb.
     #[cfg(all(feature = "auto-update", feature = "snapshot-testing"))]
-    pub fn set_release_pubkey(&mut self, ndb: &nostrdb::Ndb, pubkey: [u8; 32]) {
+    pub fn set_release_pubkey(&mut self, ndb: &mut nostrdb::Ndb, pubkey: [u8; 32]) {
         self.updater.set_release_pubkey(ndb, pubkey);
     }
 
@@ -625,6 +631,14 @@ impl Chrome {
 
 #[cfg(feature = "auto-update")]
 fn poll_updater(updater: &mut notedeck::updater::Updater, ctx: &mut notedeck::AppContext) {
+    // Sync release channel from settings (cheap string compare, only parses on change)
+    let setting_str = ctx.settings.release_channel();
+    if setting_str != updater.channel().as_str() {
+        if let Some(ch) = notedeck::updater::nostr::ReleaseChannel::parse(setting_str) {
+            updater.set_channel(ctx.ndb, ch);
+        }
+    }
+
     if updater.needs_relay_sub() {
         let release_pubkey = *updater.release_pubkey();
         let channel = updater.channel();

--- a/crates/notedeck_chrome/src/chrome.rs
+++ b/crates/notedeck_chrome/src/chrome.rs
@@ -271,6 +271,11 @@ impl Chrome {
 
         chrome.set_active(0);
 
+        notedeck_ref
+            .app_ctx
+            .sound
+            .play(notedeck::SoundEffect::Startup);
+
         Ok(chrome)
     }
 

--- a/crates/notedeck_chrome/tests/ui_tests.rs
+++ b/crates/notedeck_chrome/tests/ui_tests.rs
@@ -248,7 +248,7 @@ fn snapshot_update_bar() {
     };
 
     chrome.set_release_pubkey(
-        &notedeck_ctx.notedeck.app_context(&ctx).ndb,
+        notedeck_ctx.notedeck.app_context(&ctx).ndb,
         test_helpers::TEST_PUBKEY,
     );
 

--- a/crates/notedeck_columns/src/onboarding.rs
+++ b/crates/notedeck_columns/src/onboarding.rs
@@ -185,8 +185,8 @@ fn get_trusted_authors(
 mod tests {
     use super::*;
     use enostr::{OutboxPool, OutboxSessionHandler};
-    use nostrdb::Config;
     use notedeck::{Accounts, EguiWakeup, ScopedSubsState, FALLBACK_PUBKEY};
+    use notedeck_testing::fixtures::test_config;
     use tempfile::TempDir;
 
     fn test_harness() -> (
@@ -198,7 +198,7 @@ mod tests {
         OutboxPool,
     ) {
         let tmp = TempDir::new().expect("tmp dir");
-        let mut ndb = Ndb::new(tmp.path().to_str().expect("path"), &Config::new()).expect("ndb");
+        let mut ndb = Ndb::new(tmp.path().to_str().expect("path"), &test_config()).expect("ndb");
         let txn = Transaction::new(&ndb).expect("txn");
         let mut unknown_ids = UnknownIds::default();
         let accounts = Accounts::new(

--- a/crates/notedeck_columns/src/timeline/mod.rs
+++ b/crates/notedeck_columns/src/timeline/mod.rs
@@ -38,7 +38,7 @@ mod unit;
 pub use cache::TimelineCache;
 pub use kind::{ColumnTitle, PubkeySource, ThreadSelection, TimelineKind};
 pub use note_units::{CompositeType, InsertionResponse, NoteUnits};
-pub use timeline_units::{TimelineUnits, UnknownPks};
+pub use timeline_units::{MergeResponse, TimelineUnits, UnknownPks};
 pub use unit::{CompositeUnit, NoteUnit, ReactionUnit, RepostUnit};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -235,9 +235,9 @@ impl TimelineTab {
         txn: &Transaction,
         reversed: bool,
         use_front_insert: bool,
-    ) -> Option<UnknownPks<'a>> {
+    ) -> MergeResponse<'a> {
         if payloads.is_empty() {
-            return None;
+            return MergeResponse::empty();
         }
 
         let num_refs = payloads.len();
@@ -247,9 +247,9 @@ impl TimelineTab {
         let InsertManyResponse::Some {
             entries_merged,
             merge_kind,
-        } = resp.insertion_response
+        } = &resp.insertion_response
         else {
-            return resp.tl_response;
+            return resp;
         };
 
         let mut list = self.list.borrow_mut();
@@ -272,12 +272,12 @@ impl TimelineTab {
                 // default is reverse-chronological. yeah it's confusing.
                 if !reversed {
                     debug!("inserting {num_refs} new notes at start");
-                    list.items_inserted_at_start(entries_merged);
+                    list.items_inserted_at_start(*entries_merged);
                 }
             }
         };
 
-        resp.tl_response
+        resp
     }
 
     pub fn select_down(&mut self) {
@@ -300,7 +300,7 @@ impl TimelineTab {
 }
 
 impl<'a> UnknownPks<'a> {
-    pub fn process(&self, unknown_ids: &mut UnknownIds, ndb: &Ndb, txn: &Transaction) {
+    pub fn process_unknown_pks(&self, unknown_ids: &mut UnknownIds, ndb: &Ndb, txn: &Transaction) {
         for pk in &self.unknown_pks {
             unknown_ids.add_pubkey_if_missing(ndb, txn, pk);
         }
@@ -574,14 +574,16 @@ impl Timeline {
                 }
             }
 
-            if let Some(res) = view.insert(
+            let res = view.insert(
                 filtered_payloads,
                 ndb,
                 txn,
                 reversed,
                 self.enable_front_insert,
-            ) {
-                res.process(unknown_ids, ndb, txn);
+            );
+
+            if let Some(unknown_pks) = res.tl_response {
+                unknown_pks.process_unknown_pks(unknown_ids, ndb, txn);
             }
         }
 

--- a/crates/notedeck_columns/src/timeline/mod.rs
+++ b/crates/notedeck_columns/src/timeline/mod.rs
@@ -529,17 +529,18 @@ impl Timeline {
     /// inserting into multiple views if we have them. All timeline note
     /// insertions should use this function.
     #[profiling::function]
-    pub fn insert(
+    pub fn insert<'txn>(
         &mut self,
         new_note_ids: &[NoteKey],
         ndb: &Ndb,
-        txn: &Transaction,
+        txn: &'txn Transaction,
         unknown_ids: &mut UnknownIds,
         note_cache: &mut NoteCache,
         reversed: bool,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let mut payloads: Vec<NotePayload> = Vec::with_capacity(new_note_ids.len());
         let now = unix_time_secs();
+        let mut any_front_insert = false;
 
         for key in new_note_ids {
             let note = if let Ok(note) = ndb.get_note_by_key(txn, *key) {
@@ -582,12 +583,14 @@ impl Timeline {
                 self.enable_front_insert,
             );
 
+            any_front_insert = any_front_insert || res.insertion_response.is_front_insert();
+
             if let Some(unknown_pks) = res.tl_response {
                 unknown_pks.process_unknown_pks(unknown_ids, ndb, txn);
             }
         }
 
-        Ok(())
+        Ok(any_front_insert)
     }
 
     #[profiling::function]
@@ -616,13 +619,24 @@ impl Timeline {
             profiling::scope!("big ndb poll");
             ndb.poll_for_notes(sub, 500)
         };
+
         if new_note_ids.is_empty() {
             return Ok(false);
-        } else {
+        };
+
+        let any_front_insert =
+            self.insert(&new_note_ids, ndb, txn, unknown_ids, note_cache, reversed)?;
+
+        if any_front_insert {
+            // front inserts (not merged insert) typically mean we have something new to notify on,
+            // otherwise its likely just an old note that slid into the notification timeline
+            // somewhere
+            //
+            // While this isn't perfect, since we might have a notification that slid in just
+            // behind the latest, it is a pragmatic heuristic for now.
             self.seen_latest_notes = false;
         }
 
-        self.insert(&new_note_ids, ndb, txn, unknown_ids, note_cache, reversed)?;
         Ok(true)
     }
 

--- a/crates/notedeck_columns/src/timeline/note_units.rs
+++ b/crates/notedeck_columns/src/timeline/note_units.rs
@@ -273,6 +273,16 @@ pub enum InsertManyResponse {
     },
 }
 
+impl InsertManyResponse {
+    pub fn is_front_insert(&self) -> bool {
+        if let Self::Some { merge_kind, .. } = self {
+            matches!(merge_kind, MergeKind::FrontInsert)
+        } else {
+            false
+        }
+    }
+}
+
 pub struct Values<'a> {
     set: &'a NoteUnits,
     front: usize,

--- a/crates/notedeck_columns/src/timeline/timeline_units.rs
+++ b/crates/notedeck_columns/src/timeline/timeline_units.rs
@@ -89,6 +89,15 @@ pub struct MergeResponse<'a> {
     pub tl_response: Option<UnknownPks<'a>>,
 }
 
+impl<'a> MergeResponse<'a> {
+    pub fn empty() -> Self {
+        Self {
+            insertion_response: InsertManyResponse::Zero,
+            tl_response: None,
+        }
+    }
+}
+
 pub struct UnknownPks<'a> {
     pub(crate) unknown_pks: HashSet<&'a [u8; 32]>,
 }

--- a/crates/notedeck_columns/src/ui/settings.rs
+++ b/crates/notedeck_columns/src/ui/settings.rs
@@ -33,6 +33,7 @@ pub enum SettingsAction {
     SetRepliestNewestFirst(bool),
     SetAnimateNavTransitions(bool),
     SetMaxHashtagsPerNote(usize),
+    SetReleaseChannel(String),
     OpenRelays,
     OpenCacheFolder,
     ClearCacheFolder,
@@ -93,6 +94,9 @@ impl SettingsAction {
             Self::SetSoundVolume(value) => {
                 app_ctx.sound.set_volume(value);
                 app_ctx.settings.set_sound_volume(value);
+            }
+            Self::SetReleaseChannel(channel) => {
+                app_ctx.settings.set_release_channel(&channel);
             }
             Self::CompactDatabase => {
                 let own_pubkeys: Vec<[u8; 32]> = app_ctx
@@ -704,6 +708,29 @@ impl<'a> SettingsView<'a> {
                 ui.label(
                     richtext_small(&text).color(ui.visuals().gray_out(ui.visuals().text_color())),
                 );
+            });
+
+            ui.horizontal_wrapped(|ui| {
+                ui.label(richtext_small("Release channel:"));
+
+                let channels = ["main", "beta", "nightly", "dev"];
+                let mut selected = self.settings.release_channel.clone();
+                ComboBox::from_id_salt("release_channel")
+                    .selected_text(richtext_small(&selected))
+                    .show_ui(ui, |ui| {
+                        for ch in &channels {
+                            if ui
+                                .selectable_value(
+                                    &mut selected,
+                                    ch.to_string(),
+                                    richtext_small(*ch),
+                                )
+                                .changed()
+                            {
+                                action = Some(SettingsAction::SetReleaseChannel(selected.clone()));
+                            }
+                        }
+                    });
             });
         });
 

--- a/crates/notedeck_columns/tests/columns_e2e.rs
+++ b/crates/notedeck_columns/tests/columns_e2e.rs
@@ -9,11 +9,11 @@ use nostr_relay_builder::{
     prelude::{MemoryDatabase, MemoryDatabaseOptions, NostrEventsDatabase},
     LocalRelay, RelayBuilder,
 };
-use nostrdb::{Config, FilterBuilder, Ndb, NoteBuilder};
+use nostrdb::{FilterBuilder, Ndb, NoteBuilder};
 use notedeck_columns::Damus;
 use notedeck_testing::{
     device::{build_device_in_tmpdir_with_relays, DeviceHarness},
-    fixtures::{ndb_path, wait_for_import_count},
+    fixtures::{ndb_path, test_config, wait_for_import_count},
     init_tracing,
 };
 use serial_test::serial;
@@ -75,7 +75,7 @@ fn seed_notes_in_tmpdir(tmpdir: &TempDir, note_jsons: &[String], kind: u64) {
     let db_path = ndb_path(tmpdir.path());
     std::fs::create_dir_all(&db_path).expect("create db dir");
 
-    let ndb = Ndb::new(db_path.to_str().expect("db path"), &Config::new()).expect("ndb");
+    let ndb = Ndb::new(db_path.to_str().expect("db path"), &test_config()).expect("ndb");
     for note_json in note_jsons {
         ndb.process_client_event(note_json)
             .expect("ingest pre-seeded note");

--- a/crates/notedeck_dashboard/tests/snapshot_tests.rs
+++ b/crates/notedeck_dashboard/tests/snapshot_tests.rs
@@ -3,9 +3,10 @@ use std::time::Duration;
 use egui_kittest::Harness;
 use egui_kittest::kittest::Queryable;
 use enostr::FullKeypair;
-use nostrdb::{Config, FilterBuilder, Ndb, NoteBuilder};
+use nostrdb::{FilterBuilder, Ndb, NoteBuilder};
 use notedeck::{App, Notedeck};
 use notedeck_dashboard::Dashboard;
+use notedeck_testing::fixtures::test_config;
 use notedeck_testing::ui::wait_for_label;
 
 const NUM_NOTES: usize = 50;
@@ -39,7 +40,7 @@ fn seed_dashboard_notes(data_dir: &std::path::Path) {
     let db_path = notedeck::DataPath::new(data_dir).path(notedeck::DataPathType::Db);
     std::fs::create_dir_all(&db_path).expect("create db dir");
 
-    let ndb = Ndb::new(db_path.to_str().unwrap(), &Config::new()).expect("ndb");
+    let ndb = Ndb::new(db_path.to_str().unwrap(), &test_config()).expect("ndb");
     let account = FullKeypair::generate();
     let account2 = FullKeypair::generate();
 

--- a/crates/notedeck_dave/src/lib.rs
+++ b/crates/notedeck_dave/src/lib.rs
@@ -4344,6 +4344,14 @@ mod tests {
     use std::time::Duration;
     use tempfile::TempDir;
 
+    fn test_config() -> Config {
+        if cfg!(target_os = "windows") {
+            Config::new().set_mapsize(32 * 1024 * 1024)
+        } else {
+            Config::new()
+        }
+    }
+
     fn test_secret_key() -> [u8; 32] {
         let mut key = [0u8; 32];
         key[0] = 1;
@@ -4352,7 +4360,7 @@ mod tests {
 
     fn test_dave(data_path: &DataPath) -> Dave {
         let ndb_dir = TempDir::new().unwrap();
-        let ndb = Ndb::new(ndb_dir.path().to_str().unwrap(), &Config::new()).unwrap();
+        let ndb = Ndb::new(ndb_dir.path().to_str().unwrap(), &test_config()).unwrap();
         Dave::new(None, ndb, egui::Context::default(), data_path)
     }
 
@@ -4404,7 +4412,7 @@ mod tests {
 
         // Set up ndb
         let tmp_dir = TempDir::new().unwrap();
-        let ndb = Ndb::new(tmp_dir.path().to_str().unwrap(), &Config::new()).unwrap();
+        let ndb = Ndb::new(tmp_dir.path().to_str().unwrap(), &test_config()).unwrap();
 
         let filter = nostrdb::Filter::new()
             .kinds([session_events::AI_CONVERSATION_KIND as u64])
@@ -4531,7 +4539,7 @@ mod tests {
 
         // Set up ndb
         let tmp_dir = TempDir::new().unwrap();
-        let ndb = Ndb::new(tmp_dir.path().to_str().unwrap(), &Config::new()).unwrap();
+        let ndb = Ndb::new(tmp_dir.path().to_str().unwrap(), &test_config()).unwrap();
 
         let filter = nostrdb::Filter::new()
             .kinds([session_events::AI_CONVERSATION_KIND as u64])
@@ -4653,7 +4661,7 @@ mod tests {
         .unwrap();
 
         let tmp_dir = TempDir::new().unwrap();
-        let ndb = Ndb::new(tmp_dir.path().to_str().unwrap(), &Config::new()).unwrap();
+        let ndb = Ndb::new(tmp_dir.path().to_str().unwrap(), &test_config()).unwrap();
 
         let filter = nostrdb::Filter::new()
             .kinds([session_events::AI_CONVERSATION_KIND as u64])

--- a/crates/notedeck_dave/src/session_events.rs
+++ b/crates/notedeck_dave/src/session_events.rs
@@ -1010,6 +1010,14 @@ pub fn build_set_permission_mode_event(
 mod tests {
     use super::*;
 
+    fn test_config() -> nostrdb::Config {
+        if cfg!(target_os = "windows") {
+            nostrdb::Config::new().set_mapsize(32 * 1024 * 1024)
+        } else {
+            nostrdb::Config::new()
+        }
+    }
+
     // Test secret key (32 bytes, not for real use)
     fn test_secret_key() -> [u8; 32] {
         let mut key = [0u8; 32];
@@ -1254,7 +1262,7 @@ mod tests {
     #[tokio::test]
     async fn test_full_roundtrip() {
         use crate::session_reconstructor;
-        use nostrdb::{Config, IngestMetadata, Ndb, Transaction};
+        use nostrdb::{IngestMetadata, Ndb, Transaction};
         use serde_json::Value;
         use tempfile::TempDir;
 
@@ -1269,7 +1277,7 @@ mod tests {
 
         // Set up ndb
         let tmp_dir = TempDir::new().unwrap();
-        let ndb = Ndb::new(tmp_dir.path().to_str().unwrap(), &Config::new()).unwrap();
+        let ndb = Ndb::new(tmp_dir.path().to_str().unwrap(), &test_config()).unwrap();
 
         // Build and ingest events one at a time, waiting for each
         let sk = test_secret_key();
@@ -1631,7 +1639,7 @@ mod tests {
     /// are sorted correctly, simulating the mobile sync scenario.
     #[tokio::test]
     async fn test_reconstruction_ordering_with_permission_requests() {
-        use nostrdb::{Config, IngestMetadata, Ndb, Transaction};
+        use nostrdb::{IngestMetadata, Ndb, Transaction};
         use tempfile::TempDir;
 
         let sk = test_secret_key();
@@ -1683,7 +1691,7 @@ mod tests {
 
         // Ingest events into ndb in REVERSED order (simulating relay out-of-order delivery)
         let tmp_dir = TempDir::new().unwrap();
-        let ndb = Ndb::new(tmp_dir.path().to_str().unwrap(), &Config::new()).unwrap();
+        let ndb = Ndb::new(tmp_dir.path().to_str().unwrap(), &test_config()).unwrap();
 
         let filter = nostrdb::Filter::new()
             .kinds([AI_CONVERSATION_KIND as u64])

--- a/crates/notedeck_messages/src/nip17/mod.rs
+++ b/crates/notedeck_messages/src/nip17/mod.rs
@@ -380,7 +380,8 @@ pub fn parse_chat_message<'a>(note: &Note<'a>) -> Option<Nip17ChatMessage<'a>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nostrdb::{Config, Ndb, NoteBuilder, Transaction};
+    use nostrdb::{Ndb, NoteBuilder, Transaction};
+    use notedeck_testing::fixtures::test_config;
     use std::time::{Duration, Instant};
     use tempfile::tempdir;
 
@@ -461,7 +462,7 @@ mod tests {
     #[test]
     fn known_participant_dm_relay_list_authors_skips_selected_account() {
         let tempdir = tempdir().expect("tempdir");
-        let ndb = Ndb::new(tempdir.path().to_str().expect("db path"), &Config::new()).expect("ndb");
+        let ndb = Ndb::new(tempdir.path().to_str().expect("db path"), &test_config()).expect("ndb");
         let selected = FullKeypair::generate();
         let participant_a = FullKeypair::generate();
         let participant_b = FullKeypair::generate();

--- a/crates/notedeck_messages/tests/harness/fixtures.rs
+++ b/crates/notedeck_messages/tests/harness/fixtures.rs
@@ -10,7 +10,7 @@ use nostr::{
     nips::nip44,
     util::JsonUtil,
 };
-use nostrdb::{Config, FilterBuilder, Ndb, Note, NoteBuilder, Transaction};
+use nostrdb::{FilterBuilder, Ndb, Note, NoteBuilder, Transaction};
 use notedeck::{unix_time_secs, RelayType};
 use notedeck_messages::nip17::{
     conversation_filter, parse_chat_message, parse_dm_relay_list_relays,
@@ -20,7 +20,7 @@ use notedeck_messages::nip17::{
 // Re-export general fixtures from the shared harness.
 pub use notedeck_testing::fixtures::{
     ndb_path, nostr_pubkey, open_ndb, seed_cluster_known_profiles, seed_local_notes_in_data_dir,
-    seed_local_profile_metadata, wait_for_import_count,
+    seed_local_profile_metadata, test_config, wait_for_import_count,
 };
 
 use super::{AccountCluster, DeviceHarness, TEST_TIMEOUT};
@@ -41,7 +41,7 @@ pub fn seed_local_giftwraps_in_data_dir(
     let db_path = ndb_path(data_dir);
     std::fs::create_dir_all(&db_path).expect("create messages db dir");
 
-    let ndb = Ndb::new(db_path.to_str().expect("db path"), &Config::new()).expect("ndb");
+    let ndb = Ndb::new(db_path.to_str().expect("db path"), &test_config()).expect("ndb");
     ndb.add_key(&account.secret_key.secret_bytes());
 
     for note_json in note_jsons {

--- a/crates/notedeck_messages/tests/messages_e2e.rs
+++ b/crates/notedeck_messages/tests/messages_e2e.rs
@@ -2605,6 +2605,7 @@ async fn offline_same_account_sender_refreshes_stale_participant_relay_list_afte
     let recipient = FullKeypair::generate();
     let recipient_npub = recipient.pubkey.npub().expect("recipient npub");
     let now = unix_time_secs();
+    let initial_route_a_ts = now.saturating_add(600);
 
     let mut sender_current =
         build_messages_device_with_relays(&[&relay_a_url, &relay_b_url], &sender);
@@ -2629,7 +2630,7 @@ async fn offline_same_account_sender_refreshes_stale_participant_relay_list_afte
             sender_device,
             &recipient,
             &[&relay_a_url],
-            Some(now.saturating_sub(60)),
+            Some(initial_route_a_ts),
         );
         seed_local_profile_metadata(sender_device, &recipient, "relay-list-recipient");
     }
@@ -2637,13 +2638,13 @@ async fn offline_same_account_sender_refreshes_stale_participant_relay_list_afte
         &mut recipient_a,
         &recipient,
         &[&relay_a_url],
-        Some(now.saturating_sub(60)),
+        Some(initial_route_a_ts),
     );
     seed_local_dm_relay_list_with_relays(
         &mut recipient_b,
         &recipient,
         &[&relay_a_url],
-        Some(now.saturating_sub(60)),
+        Some(initial_route_a_ts),
     );
 
     step_device_group(&mut [
@@ -2707,7 +2708,7 @@ async fn offline_same_account_sender_refreshes_stale_participant_relay_list_afte
         &mut recipient_b,
         &recipient,
         &[&relay_b_url],
-        Some(now.saturating_add(1)),
+        Some(initial_route_a_ts.saturating_add(1)),
     );
     step_device_group(&mut [&mut sender_current, &mut recipient_b]);
     std::thread::sleep(Duration::from_millis(100));
@@ -2719,7 +2720,7 @@ async fn offline_same_account_sender_refreshes_stale_participant_relay_list_afte
         &offline_path,
     );
     let expected_new_version = (
-        now.saturating_add(1),
+        initial_route_a_ts.saturating_add(1),
         vec![relay_b_url.trim_end_matches('/').to_owned()],
     );
     let local_version_deadline = Instant::now() + TEST_TIMEOUT;
@@ -2816,6 +2817,7 @@ async fn restart_should_prefetch_newer_known_participant_relay_list_e2e() {
     let recipient = FullKeypair::generate();
     let recipient_npub = recipient.pubkey.npub().expect("recipient npub");
     let now = unix_time_secs();
+    let initial_route_a_ts = now.saturating_add(600);
 
     let mut sender_current =
         build_messages_device_with_relays(&[&relay_a_url, &relay_b_url], &sender);
@@ -2832,9 +2834,15 @@ async fn restart_should_prefetch_newer_known_participant_relay_list_e2e() {
     for sender_device in [&mut sender_current, &mut sender_offline] {
         seed_local_dm_relay_list_with_relays(
             sender_device,
+            &sender,
+            &[&relay_a_url, &relay_b_url],
+            None,
+        );
+        seed_local_dm_relay_list_with_relays(
+            sender_device,
             &recipient,
             &[&relay_a_url],
-            Some(now.saturating_sub(60)),
+            Some(initial_route_a_ts),
         );
         seed_local_profile_metadata(sender_device, &recipient, "relay-prefetch-recipient");
     }
@@ -2842,13 +2850,13 @@ async fn restart_should_prefetch_newer_known_participant_relay_list_e2e() {
         &mut recipient_a,
         &recipient,
         &[&relay_a_url],
-        Some(now.saturating_sub(60)),
+        Some(initial_route_a_ts),
     );
     seed_local_dm_relay_list_with_relays(
         &mut recipient_b,
         &recipient,
         &[&relay_a_url],
-        Some(now.saturating_sub(60)),
+        Some(initial_route_a_ts),
     );
 
     step_device_group(&mut [
@@ -2916,7 +2924,7 @@ async fn restart_should_prefetch_newer_known_participant_relay_list_e2e() {
         &mut recipient_b,
         &recipient,
         &[&relay_b_url],
-        Some(now.saturating_add(1)),
+        Some(initial_route_a_ts.saturating_add(1)),
     );
     step_device_group(&mut [&mut sender_current, &mut recipient_b]);
     std::thread::sleep(Duration::from_millis(100));
@@ -2928,7 +2936,7 @@ async fn restart_should_prefetch_newer_known_participant_relay_list_e2e() {
         &offline_path,
     );
     let expected_new_version = (
-        now.saturating_add(1),
+        initial_route_a_ts.saturating_add(1),
         vec![relay_b_url.trim_end_matches('/').to_owned()],
     );
     let local_version_deadline = Instant::now() + TEST_TIMEOUT;

--- a/crates/notedeck_messages/tests/relay_delivery.rs
+++ b/crates/notedeck_messages/tests/relay_delivery.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeSet;
 use std::time::Duration;
 
 use enostr::FullKeypair;
-use harness::fixtures::seed_local_dm_relay_list;
+use harness::fixtures::{seed_local_dm_relay_list, test_config};
 use harness::ui::{open_conversation_via_ui, send_message_via_ui};
 use harness::{
     build_messages_device, init_tracing, local_chat_messages, publish_note_via_device,
@@ -99,7 +99,7 @@ async fn thread_leak_isolation() {
         let tmp = tempfile::TempDir::new().unwrap();
         let db = tmp.path().join("db");
         std::fs::create_dir_all(&db).unwrap();
-        let cfg = nostrdb::Config::new().set_ingester_threads(2);
+        let cfg = test_config().set_ingester_threads(2);
         let _ndb = nostrdb::Ndb::new(db.to_str().unwrap(), &cfg).unwrap();
     }
     std::thread::sleep(Duration::from_secs(1));
@@ -111,7 +111,7 @@ async fn thread_leak_isolation() {
         let tmp = tempfile::TempDir::new().unwrap();
         let db = tmp.path().join("db");
         std::fs::create_dir_all(&db).unwrap();
-        let cfg = nostrdb::Config::new().set_ingester_threads(2);
+        let cfg = test_config().set_ingester_threads(2);
         let _ndb = nostrdb::Ndb::new(db.to_str().unwrap(), &cfg).unwrap();
         let _pool = enostr::OutboxPool::default();
     }
@@ -126,7 +126,7 @@ async fn thread_leak_isolation() {
         let tmp = tempfile::TempDir::new().unwrap();
         let db = tmp.path().join("db");
         std::fs::create_dir_all(&db).unwrap();
-        let cfg = nostrdb::Config::new().set_ingester_threads(2);
+        let cfg = test_config().set_ingester_threads(2);
         let _ndb = nostrdb::Ndb::new(db.to_str().unwrap(), &cfg).unwrap();
         let mut pool = enostr::OutboxPool::default();
         {
@@ -156,7 +156,7 @@ async fn thread_leak_isolation() {
         let tmp = tempfile::TempDir::new().unwrap();
         let db = tmp.path().join("db");
         std::fs::create_dir_all(&db).unwrap();
-        let cfg = nostrdb::Config::new().set_ingester_threads(2);
+        let cfg = test_config().set_ingester_threads(2);
         let _ndb = nostrdb::Ndb::new(db.to_str().unwrap(), &cfg).unwrap();
         let _job_pool = notedeck::jobs::JobPool::default();
     }

--- a/crates/notedeck_release/README.md
+++ b/crates/notedeck_release/README.md
@@ -12,7 +12,7 @@ Follows the zapstore convention with two event kinds:
   "kind": 3063,
   "content": "",
   "tags": [
-    ["i", "io.damus.notedeck"],
+    ["i", "com.damus.notedeck"],
     ["url", "https://github.com/damus-io/notedeck/releases/download/v1.2.0/notedeck-x86_64-linux.tar.gz"],
     ["x", "<sha256_hex>"],
     ["version", "1.2.0"],
@@ -30,8 +30,8 @@ Follows the zapstore convention with two event kinds:
   "kind": 30063,
   "content": "",
   "tags": [
-    ["d", "io.damus.notedeck@1.2.0"],
-    ["i", "io.damus.notedeck"],
+    ["d", "com.damus.notedeck@1.2.0"],
+    ["i", "com.damus.notedeck"],
     ["version", "1.2.0"],
     ["c", "main"],
     ["e", "<asset_event_id_1>"],

--- a/crates/notedeck_release/src/main.rs
+++ b/crates/notedeck_release/src/main.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use tungstenite::{connect, Message};
 
 /// NIP-82 app identifier
-const APP_ID: &str = "io.damus.notedeck";
+const APP_ID: &str = "com.damus.notedeck";
 
 fn usage() {
     eprintln!(

--- a/crates/notedeck_release/src/main.rs
+++ b/crates/notedeck_release/src/main.rs
@@ -30,7 +30,9 @@ fn usage() {
 const GITHUB_REPO: &str = "damus-io/notedeck";
 
 /// File extensions recognized as release artifacts
-const ARTIFACT_EXTENSIONS: &[&str] = &[".tar.gz", ".zip", ".dmg", ".deb", ".rpm", ".exe", ".msi"];
+const ARTIFACT_EXTENSIONS: &[&str] = &[
+    ".tar.gz", ".zip", ".dmg", ".deb", ".rpm", ".exe", ".msi", ".apk",
+];
 
 /// Valid release channels
 const VALID_CHANNELS: &[&str] = &["main", "beta", "nightly", "dev"];
@@ -48,6 +50,8 @@ fn mime_for_artifact(name: &str) -> &'static str {
         "application/zip"
     } else if name.ends_with(".dmg") {
         "application/x-apple-diskimage"
+    } else if name.ends_with(".apk") {
+        "application/vnd.android.package-archive"
     } else {
         "application/octet-stream"
     }
@@ -77,6 +81,11 @@ fn normalize_arch(arch: &str) -> Option<&'static str> {
 ///   notedeck-0.8.0-1.x86_64.rpm    → linux-x86_64    (rpm implies linux)
 ///   notedeck_0.8.0-1_amd64.deb     → linux-x86_64    (deb implies linux, amd64=x86_64)
 fn platform_tag_from_name(name: &str) -> Option<String> {
+    // .apk → android (currently only aarch64 builds)
+    if name.ends_with(".apk") {
+        return Some("android-aarch64".to_string());
+    }
+
     // .exe / .msi → windows (currently only x86_64 builds)
     if name.ends_with(".exe") || name.ends_with(".msi") {
         return Some("windows-x86_64".to_string());

--- a/crates/notedeck_release/tests/github_dry_run.rs
+++ b/crates/notedeck_release/tests/github_dry_run.rs
@@ -106,7 +106,7 @@ fn test_github_dry_run() {
             .expect("i tag");
         assert_eq!(
             i_tag[1].as_str().unwrap(),
-            "io.damus.notedeck",
+            "com.damus.notedeck",
             "app id mismatch"
         );
 

--- a/crates/notedeck_testing/src/fixtures.rs
+++ b/crates/notedeck_testing/src/fixtures.rs
@@ -24,6 +24,20 @@ pub fn seed_cluster_known_profiles(
     }
 }
 
+/// Returns a [`Config`] with a small mapsize suitable for tests.
+///
+/// On Windows LMDB actually allocates the full mapsize on disk, so tests
+/// that use the default (very large) mapsize can exhaust disk space or hit
+/// CI resource limits.  On other platforms the map is only virtually mapped,
+/// so we leave the default alone.
+pub fn test_config() -> Config {
+    if cfg!(target_os = "windows") {
+        Config::new().set_mapsize(32 * 1024 * 1024) // 32 MiB
+    } else {
+        Config::new()
+    }
+}
+
 /// Seeds raw local note JSON into one device's on-disk NostrDB before app startup.
 pub fn seed_local_notes_in_data_dir(
     data_dir: &Path,
@@ -33,7 +47,7 @@ pub fn seed_local_notes_in_data_dir(
     let db_path = ndb_path(data_dir);
     fs::create_dir_all(&db_path).expect("create db dir");
 
-    let ndb = Ndb::new(db_path.to_str().expect("db path"), &Config::new()).expect("ndb");
+    let ndb = Ndb::new(db_path.to_str().expect("db path"), &test_config()).expect("ndb");
     for note_json in note_jsons {
         ndb.process_client_event(note_json)
             .expect("ingest pre-seeded local note history");
@@ -88,7 +102,7 @@ pub fn ndb_path(data_dir: &Path) -> PathBuf {
 /// Opens a NostrDB for one prepared device data directory.
 pub fn open_ndb(data_dir: &Path) -> Ndb {
     let db_path = ndb_path(data_dir);
-    Ndb::new(db_path.to_str().expect("db path"), &Config::new()).expect("ndb")
+    Ndb::new(db_path.to_str().expect("db path"), &test_config()).expect("ndb")
 }
 
 /// Waits until at least `expected_count` events are queryable through the given filters.

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,5 @@
 { pkgs ? import <nixpkgs> { }
-, android ? "https://github.com/tadfisher/android-nixpkgs/archive/refs/tags/2025-01-27.tar.gz"
+, android ? "https://github.com/tadfisher/android-nixpkgs/archive/refs/tags/2026-03-28.tar.gz"
 , use_android ? true
 , android_emulator ? false
 }:
@@ -54,15 +54,15 @@ mkShell ({
     let
       android-nixpkgs = callPackage (fetchTarball android) { };
       #ndk-version = "24.0.8215888";
-      ndk-version = "27.2.12479018";
-      android-version = "31";
+      ndk-version = "29.0.14206865";
+      android-version = "34";
 
       android-sdk = android-nixpkgs.sdk (sdkPkgs: with sdkPkgs; [
         cmdline-tools-latest
         build-tools-34-0-0
         platform-tools
-        platforms-android-31
-        ndk-27-2-12479018
+        platforms-android-34
+        ndk-29-0-14206865
         #ndk-24-0-8215888
       ] ++ lib.optional android_emulator emulator);
 


### PR DESCRIPTION
## Summary
- Add Android platform support to the NIP-82 updater: platform detection (`android-aarch64`), APK staging (copy, no extraction), and JNI bridge to `installApk()`
- Java side: `FileProvider` + `ACTION_VIEW` intent for the system package installer, with `canRequestPackageInstalls()` permission check and settings redirect flow
- `notedeck_release`: `.apk` artifact recognition, MIME type, and platform tagging

## Test plan
- [ ] Publish a test NIP-82 release event with an `.apk` asset to a private relay
- [ ] Verify the updater discovers the release and downloads the APK
- [ ] Verify the install permission prompt appears on first install
- [ ] Verify the system package installer launches after granting permission
- [ ] Verify the APK installs successfully
- [x] https://github.com/damus-io/notedeck/issues/1416

## Closes

- Closes #1413
- Closes #1414
- Closes #1415

🤖 Generated with [Claude Code](https://claude.com/claude-code)