### PR TITLE
fix max hashtags per note persist

### DIFF
--- a/crates/notedeck/src/account/accounts.rs
+++ b/crates/notedeck/src/account/accounts.rs
@@ -27,6 +27,7 @@ pub struct Accounts {
     storage_writer: Option<AccountStorageWriter>,
     relay_defaults: RelayDefaults,
     ndb_subs: AccountNdbSubs,
+    max_hashtags_per_note: usize,
     scoped_remote_initialized: bool,
 }
 
@@ -36,13 +37,14 @@ impl Accounts {
         key_store: Option<AccountStorage>,
         forced_relays: Vec<String>,
         fallback: Pubkey,
+        max_hashtags_per_note: usize,
         ndb: &mut Ndb,
         txn: &Transaction,
         unknown_ids: &mut UnknownIds,
     ) -> Self {
         let (mut cache, unknown_id) = AccountCache::new(UserAccount::new(
             Keypair::only_pubkey(fallback),
-            AccountData::new(fallback.bytes()),
+            AccountData::new(fallback.bytes(), max_hashtags_per_note),
         ));
 
         unknown_id.process_action(unknown_ids, ndb, txn);
@@ -53,11 +55,8 @@ impl Accounts {
             match reader.get_accounts() {
                 Ok(accounts) => {
                     for account in accounts {
-                        add_account_from_storage(&mut cache, account).process_action(
-                            unknown_ids,
-                            ndb,
-                            txn,
-                        )
+                        add_account_from_storage(&mut cache, account, max_hashtags_per_note)
+                            .process_action(unknown_ids, ndb, txn)
                     }
                 }
                 Err(e) => {
@@ -85,6 +84,7 @@ impl Accounts {
             storage_writer,
             relay_defaults,
             ndb_subs,
+            max_hashtags_per_note,
             scoped_remote_initialized: false,
         }
     }
@@ -147,7 +147,7 @@ impl Accounts {
             acc.key = kp.clone();
             AccType::Acc(&*acc)
         } else {
-            let new_account_data = AccountData::new(kp.pubkey.bytes());
+            let new_account_data = AccountData::new(kp.pubkey.bytes(), self.max_hashtags_per_note);
             AccType::Entry(
                 self.cache
                     .add(UserAccount::new(kp.clone(), new_account_data)),
@@ -269,6 +269,11 @@ impl Accounts {
             }
         }
 
+        let max_hashtags_per_note = self.max_hashtags_per_note;
+        self.get_selected_account_mut()
+            .data
+            .muted
+            .update_max_hashtags(max_hashtags_per_note);
         self.get_selected_account_mut().data.query(ndb, txn);
         self.ndb_subs.swap_to(ndb, &self.cache.selected().data);
 
@@ -290,6 +295,7 @@ impl Accounts {
     }
 
     pub fn update_max_hashtags_per_note(&mut self, max_hashtags: usize) {
+        self.max_hashtags_per_note = max_hashtags;
         for account in self.cache.accounts_mut() {
             account.data.muted.update_max_hashtags(max_hashtags);
         }
@@ -383,8 +389,9 @@ impl<'a> AccType<'a> {
 fn add_account_from_storage(
     cache: &mut AccountCache,
     user_account_serializable: UserAccountSerializable,
+    max_hashtags_per_note: usize,
 ) -> SingleUnkIdAction {
-    let Some(acc) = get_acc_from_storage(user_account_serializable) else {
+    let Some(acc) = get_acc_from_storage(user_account_serializable, max_hashtags_per_note) else {
         return SingleUnkIdAction::NoAction;
     };
 
@@ -394,9 +401,12 @@ fn add_account_from_storage(
     SingleUnkIdAction::pubkey(pk)
 }
 
-fn get_acc_from_storage(user_account_serializable: UserAccountSerializable) -> Option<UserAccount> {
+fn get_acc_from_storage(
+    user_account_serializable: UserAccountSerializable,
+    max_hashtags_per_note: usize,
+) -> Option<UserAccount> {
     let keypair = user_account_serializable.key;
-    let new_account_data = AccountData::new(keypair.pubkey.bytes());
+    let new_account_data = AccountData::new(keypair.pubkey.bytes(), max_hashtags_per_note);
 
     let mut wallet = None;
     if let Some(wallet_s) = user_account_serializable.wallet {
@@ -424,10 +434,10 @@ pub struct AccountData {
 }
 
 impl AccountData {
-    pub fn new(pubkey: &[u8; 32]) -> Self {
+    pub fn new(pubkey: &[u8; 32], max_hashtags_per_note: usize) -> Self {
         Self {
             relay: AccountRelayData::new(pubkey),
-            muted: AccountMutedData::new(pubkey),
+            muted: AccountMutedData::new(pubkey, max_hashtags_per_note),
             contacts: Contacts::new(pubkey),
         }
     }

--- a/crates/notedeck/src/account/mute.rs
+++ b/crates/notedeck/src/account/mute.rs
@@ -12,7 +12,7 @@ pub(crate) struct AccountMutedData {
 }
 
 impl AccountMutedData {
-    pub fn new(pubkey: &[u8; 32]) -> Self {
+    pub fn new(pubkey: &[u8; 32], max_hashtags_per_note: usize) -> Self {
         // Construct a filter for the user's NIP-51 muted list
         let filter = Filter::new()
             .authors([pubkey])
@@ -20,7 +20,10 @@ impl AccountMutedData {
             .limit(1)
             .build();
 
-        let muted = Arc::new(Muted::default());
+        let muted = Arc::new(Muted {
+            max_hashtags_per_note,
+            ..Default::default()
+        });
 
         AccountMutedData { filter, muted }
     }

--- a/crates/notedeck/src/app.rs
+++ b/crates/notedeck/src/app.rs
@@ -294,6 +294,7 @@ impl Notedeck {
             keystore,
             parsed_args.relays.clone(),
             FALLBACK_PUBKEY(),
+            settings.max_hashtags_per_note(),
             &mut ndb,
             &txn,
             &mut unknown_ids,
@@ -612,4 +613,139 @@ fn tick_relay_limit_jobs(
 pub struct NotedeckCtx {
     pub notedeck: Notedeck,
     pub outbox_session: OutboxSession,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enostr::FullKeypair;
+    use nostr::nips::nip19::ToBech32;
+    use nostrdb::NoteBuilder;
+    use tempfile::TempDir;
+
+    fn test_args(account: &FullKeypair) -> Vec<String> {
+        vec![
+            "notedeck-test".to_owned(),
+            "--testrunner".to_owned(),
+            "--no-keystore".to_owned(),
+            "--nsec".to_owned(),
+            account.secret_key.to_bech32().expect("nsec bech32"),
+        ]
+    }
+
+    fn init_notedeck(
+        ctx: &egui::Context,
+        data_dir: &std::path::Path,
+        account: &FullKeypair,
+    ) -> Notedeck {
+        Notedeck::init(ctx, data_dir, &test_args(account)).notedeck
+    }
+
+    fn hashtag_note(author: &FullKeypair, hashtags: &[&str]) -> nostrdb::Note<'static> {
+        let mut builder = NoteBuilder::new().kind(1).content("hashtag note");
+        for hashtag in hashtags {
+            builder = builder.start_tag().tag_str("t").tag_str(hashtag);
+        }
+
+        builder
+            .sign(&author.secret_key.secret_bytes())
+            .build()
+            .expect("note")
+    }
+
+    #[test]
+    fn updating_max_hashtags_refreshes_selected_account_mute_threshold() {
+        let tmp = TempDir::new().expect("tmpdir");
+        let ctx = egui::Context::default();
+        let selected = FullKeypair::generate();
+        let author = FullKeypair::generate();
+        let note = hashtag_note(&author, &["a", "b", "c", "d"]);
+        let mut notedeck = init_notedeck(&ctx, tmp.path(), &selected);
+
+        {
+            let app_ctx = &mut notedeck.app_context(&ctx);
+            let initial_mute = app_ctx.accounts.mutefun();
+            assert!(initial_mute(&note, note.id()));
+
+            app_ctx.settings.set_max_hashtags_per_note(4);
+            app_ctx.accounts.update_max_hashtags_per_note(4);
+
+            assert_eq!(app_ctx.settings.max_hashtags_per_note(), 4);
+            assert_eq!(app_ctx.accounts.mute().max_hashtags_per_note, 4);
+
+            let updated_mute = app_ctx.accounts.mutefun();
+            assert!(!updated_mute(&note, note.id()));
+        }
+    }
+
+    #[test]
+    fn persisted_max_hashtags_setting_applies_after_restart() {
+        let tmp = TempDir::new().expect("tmpdir");
+        let ctx = egui::Context::default();
+        let selected = FullKeypair::generate();
+        let author = FullKeypair::generate();
+        let note = hashtag_note(&author, &["a", "b", "c", "d"]);
+
+        {
+            let mut notedeck = init_notedeck(&ctx, tmp.path(), &selected);
+            let app_ctx = &mut notedeck.app_context(&ctx);
+            app_ctx.settings.set_max_hashtags_per_note(4);
+            app_ctx.accounts.update_max_hashtags_per_note(4);
+
+            let mute = app_ctx.accounts.mutefun();
+            assert!(!mute(&note, note.id()));
+        }
+
+        {
+            let mut notedeck = init_notedeck(&ctx, tmp.path(), &selected);
+            let app_ctx = &mut notedeck.app_context(&ctx);
+
+            assert_eq!(app_ctx.settings.max_hashtags_per_note(), 4);
+            assert_eq!(app_ctx.accounts.mute().max_hashtags_per_note, 4);
+
+            let mute = app_ctx.accounts.mutefun();
+            assert!(
+                !mute(&note, note.id()),
+                "persisted max_hashtags_per_note should apply on startup"
+            );
+        }
+    }
+
+    #[test]
+    fn switching_to_new_account_preserves_max_hashtags_setting() {
+        let tmp = TempDir::new().expect("tmpdir");
+        let ctx = egui::Context::default();
+        let selected = FullKeypair::generate();
+        let second = FullKeypair::generate();
+        let author = FullKeypair::generate();
+        let note = hashtag_note(&author, &["a", "b", "c", "d"]);
+        let mut notedeck = init_notedeck(&ctx, tmp.path(), &selected);
+
+        {
+            let app_ctx = &mut notedeck.app_context(&ctx);
+            app_ctx.settings.set_max_hashtags_per_note(4);
+            app_ctx.accounts.update_max_hashtags_per_note(4);
+
+            let txn = Transaction::new(app_ctx.ndb).expect("txn");
+            let resp = app_ctx
+                .accounts
+                .add_account(second.clone().to_keypair())
+                .expect("new account");
+            resp.unk_id_action
+                .process_action(app_ctx.unknown_ids, app_ctx.ndb, &txn);
+
+            app_ctx
+                .accounts
+                .select_account(&second.pubkey, app_ctx.ndb, &txn, &mut app_ctx.remote);
+
+            assert_eq!(app_ctx.settings.max_hashtags_per_note(), 4);
+            assert_eq!(app_ctx.accounts.mute().max_hashtags_per_note, 4);
+
+            let mute = app_ctx.accounts.mutefun();
+            assert!(
+                !mute(&note, note.id()),
+                "switched account should inherit current max_hashtags_per_note"
+            );
+        }
+    }
 }

--- a/crates/notedeck/src/note/mod.rs
+++ b/crates/notedeck/src/note/mod.rs
@@ -268,3 +268,182 @@ pub fn get_p_tags<'a>(note: &Note<'a>) -> Vec<&'a [u8; 32]> {
 
     items
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::test_config;
+    use enostr::FullKeypair;
+    use nostrdb::NoteBuilder;
+    use std::time::{Duration, Instant};
+    use tempfile::TempDir;
+
+    fn test_note(
+        account: &FullKeypair,
+        content: &str,
+        created_at: u64,
+        tags: &[&[&str]],
+    ) -> Note<'static> {
+        let mut builder = NoteBuilder::new()
+            .kind(1)
+            .content(content)
+            .created_at(created_at);
+
+        for tag in tags {
+            builder = builder.start_tag();
+            for component in *tag {
+                builder = builder.tag_str(component);
+            }
+        }
+
+        builder
+            .sign(&account.secret_key.secret_bytes())
+            .build()
+            .expect("note")
+    }
+
+    fn setup_ndb() -> (TempDir, Ndb) {
+        let tmp = TempDir::new().expect("tmpdir");
+        let ndb = Ndb::new(tmp.path().to_str().expect("db path"), &test_config()).expect("ndb");
+        (tmp, ndb)
+    }
+
+    fn ingest(ndb: &Ndb, note: &Note<'_>) {
+        ndb.process_client_event(&note.json().expect("note json"))
+            .expect("ingest note");
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let txn = Transaction::new(ndb).expect("txn");
+            if ndb.get_note_by_id(&txn, note.id()).is_ok() {
+                break;
+            }
+
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for note import"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[test]
+    fn root_note_id_returns_selected_for_root_note() {
+        let (_tmp, ndb) = setup_ndb();
+        let account = FullKeypair::generate();
+        let root = test_note(&account, "root", 1_700_000_000, &[]);
+        ingest(&ndb, &root);
+
+        let txn = Transaction::new(&ndb).expect("txn");
+        let mut note_cache = NoteCache::default();
+        let resolved =
+            root_note_id_from_selected_id(&ndb, &mut note_cache, &txn, root.id()).expect("root id");
+
+        assert_eq!(resolved.bytes(), root.id());
+    }
+
+    #[test]
+    fn root_note_id_resolves_marked_root_for_direct_reply() {
+        let (_tmp, ndb) = setup_ndb();
+        let root_author = FullKeypair::generate();
+        let reply_author = FullKeypair::generate();
+        let root = test_note(&root_author, "root", 1_700_000_000, &[]);
+        let root_hex = hex::encode(root.id());
+        let direct_reply = test_note(
+            &reply_author,
+            "direct reply",
+            1_700_000_001,
+            &[&[
+                "e",
+                root_hex.as_str(),
+                "wss://relay.example",
+                "root",
+                &root_author.pubkey.hex(),
+            ]],
+        );
+        ingest(&ndb, &root);
+        ingest(&ndb, &direct_reply);
+
+        let txn = Transaction::new(&ndb).expect("txn");
+        let mut note_cache = NoteCache::default();
+        let resolved =
+            root_note_id_from_selected_id(&ndb, &mut note_cache, &txn, direct_reply.id())
+                .expect("root id");
+
+        assert_eq!(resolved.bytes(), root.id());
+    }
+
+    #[test]
+    fn root_note_id_resolves_deprecated_single_e_reply() {
+        let (_tmp, ndb) = setup_ndb();
+        let root_author = FullKeypair::generate();
+        let reply_author = FullKeypair::generate();
+        let root = test_note(&root_author, "root", 1_700_000_000, &[]);
+        let root_hex = hex::encode(root.id());
+        let direct_reply = test_note(
+            &reply_author,
+            "deprecated direct reply",
+            1_700_000_001,
+            &[&["e", root_hex.as_str()]],
+        );
+        ingest(&ndb, &root);
+        ingest(&ndb, &direct_reply);
+
+        let txn = Transaction::new(&ndb).expect("txn");
+        let mut note_cache = NoteCache::default();
+        let resolved =
+            root_note_id_from_selected_id(&ndb, &mut note_cache, &txn, direct_reply.id())
+                .expect("root id");
+
+        assert_eq!(resolved.bytes(), root.id());
+    }
+
+    #[test]
+    fn root_note_id_resolves_root_for_nested_reply() {
+        let (_tmp, ndb) = setup_ndb();
+        let root_author = FullKeypair::generate();
+        let reply_author = FullKeypair::generate();
+        let nested_author = FullKeypair::generate();
+        let root = test_note(&root_author, "root", 1_700_000_000, &[]);
+        let root_hex = hex::encode(root.id());
+        let direct_reply = test_note(
+            &reply_author,
+            "direct reply",
+            1_700_000_001,
+            &[&["e", root_hex.as_str(), "", "root"]],
+        );
+        let direct_reply_hex = hex::encode(direct_reply.id());
+        let nested_reply = test_note(
+            &nested_author,
+            "nested reply",
+            1_700_000_002,
+            &[
+                &["e", root_hex.as_str(), "", "root"],
+                &["e", direct_reply_hex.as_str(), "", "reply"],
+            ],
+        );
+        ingest(&ndb, &root);
+        ingest(&ndb, &direct_reply);
+        ingest(&ndb, &nested_reply);
+
+        let txn = Transaction::new(&ndb).expect("txn");
+        let mut note_cache = NoteCache::default();
+        let resolved =
+            root_note_id_from_selected_id(&ndb, &mut note_cache, &txn, nested_reply.id())
+                .expect("root id");
+
+        assert_eq!(resolved.bytes(), root.id());
+    }
+
+    #[test]
+    fn root_note_id_returns_note_not_found_for_unknown_id() {
+        let (_tmp, ndb) = setup_ndb();
+        let txn = Transaction::new(&ndb).expect("txn");
+        let mut note_cache = NoteCache::default();
+        let missing = [7u8; 32];
+
+        let err = root_note_id_from_selected_id(&ndb, &mut note_cache, &txn, &missing).unwrap_err();
+
+        assert!(matches!(err, RootIdError::NoteNotFound));
+    }
+}

--- a/crates/notedeck/src/oneshot_api.rs
+++ b/crates/notedeck/src/oneshot_api.rs
@@ -45,6 +45,7 @@ mod tests {
             None,
             vec![relay.to_owned()],
             FALLBACK_PUBKEY(),
+            crate::persist::DEFAULT_MAX_HASHTAGS_PER_NOTE,
             &mut ndb,
             &txn,
             &mut unknown_ids,

--- a/crates/notedeck/src/publish.rs
+++ b/crates/notedeck/src/publish.rs
@@ -92,6 +92,7 @@ mod tests {
             None,
             vec![relay.to_owned()],
             FALLBACK_PUBKEY(),
+            crate::persist::DEFAULT_MAX_HASHTAGS_PER_NOTE,
             &mut ndb,
             &txn,
             &mut unknown_ids,

--- a/crates/notedeck_columns/src/onboarding.rs
+++ b/crates/notedeck_columns/src/onboarding.rs
@@ -205,6 +205,7 @@ mod tests {
             None,
             vec!["wss://relay-onboarding.example.com".to_owned()],
             FALLBACK_PUBKEY(),
+            notedeck::DEFAULT_MAX_HASHTAGS_PER_NOTE,
             &mut ndb,
             &txn,
             &mut unknown_ids,

--- a/crates/notedeck_columns/src/post.rs
+++ b/crates/notedeck_columns/src/post.rs
@@ -751,7 +751,10 @@ pub struct MentionInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nostrdb::{Config, Ndb, Transaction};
     use pretty_assertions::assert_eq;
+    use std::time::{Duration, Instant};
+    use tempfile::TempDir;
 
     impl MentionInfo {
         pub fn bounds(&self) -> Range<usize> {
@@ -767,6 +770,59 @@ mod tests {
         Pubkey::from_hex("4a0510f26880d40e432f4865cb5714d9d3c200ca6ebb16b418ae6c555f574967")
             .unwrap()
     };
+
+    fn test_note(
+        account: &FullKeypair,
+        content: &str,
+        created_at: u64,
+        tags: &[&[&str]],
+    ) -> Note<'static> {
+        let mut builder = NoteBuilder::new()
+            .kind(1)
+            .content(content)
+            .created_at(created_at);
+
+        for tag in tags {
+            builder = builder.start_tag();
+            for component in *tag {
+                builder = builder.tag_str(component);
+            }
+        }
+
+        builder
+            .sign(&account.secret_key.secret_bytes())
+            .build()
+            .expect("note")
+    }
+
+    fn setup_ndb() -> (TempDir, Ndb) {
+        let tmp = TempDir::new().expect("tmpdir");
+        let ndb = Ndb::new(tmp.path().to_str().expect("db path"), &Config::new()).expect("ndb");
+        (tmp, ndb)
+    }
+
+    fn ingest(ndb: &Ndb, note: &Note<'_>) {
+        ndb.process_client_event(&note.json().expect("note json"))
+            .expect("ingest note");
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let txn = Transaction::new(ndb).expect("txn");
+            if ndb.get_note_by_id(&txn, note.id()).is_ok() {
+                break;
+            }
+
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for note import"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    fn stored_note<'a>(ndb: &'a Ndb, txn: &'a Transaction, id: &[u8; 32]) -> Note<'a> {
+        ndb.get_note_by_id(txn, id).expect("stored note")
+    }
 
     #[derive(PartialEq, Clone, Debug)]
     struct MentionExample {
@@ -877,6 +933,133 @@ mod tests {
             let expected: HashSet<String> = expected.into_iter().map(String::from).collect();
             assert_eq!(result, expected, "Failed for input: {}", input);
         }
+    }
+
+    #[test]
+    fn to_reply_writes_root_tag_for_top_level_reply() {
+        let (_tmp, ndb) = setup_ndb();
+        let author = FullKeypair::generate();
+        let reply_author = FullKeypair::generate();
+        let root = test_note(&author, "root", 1_700_000_000, &[]);
+        ingest(&ndb, &root);
+        let post = NewPost::new(
+            "reply".to_owned(),
+            reply_author.clone(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let (reply, expected_root_id, expected_root_pubkey) = {
+            let txn = Transaction::new(&ndb).expect("txn");
+            let root = stored_note(&ndb, &txn, root.id());
+            let reply = post.to_reply(&reply_author.secret_key.secret_bytes(), &root);
+            (reply, *root.id(), *root.pubkey())
+        };
+        ingest(&ndb, &reply);
+        let txn = Transaction::new(&ndb).expect("txn");
+        let reply = stored_note(&ndb, &txn, reply.id());
+        let note_reply = NoteReply::new(reply.tags());
+
+        assert!(note_reply.is_reply_to_root());
+        assert_eq!(note_reply.root().unwrap().id, &expected_root_id);
+        assert_eq!(note_reply.reply().unwrap().id, &expected_root_id);
+        assert_eq!(notedeck::get_p_tags(&reply), vec![&expected_root_pubkey]);
+    }
+
+    #[test]
+    fn to_reply_writes_root_and_reply_tags_for_nested_reply() {
+        let (_tmp, ndb) = setup_ndb();
+        let root_author = FullKeypair::generate();
+        let reply_author = FullKeypair::generate();
+        let nested_author = FullKeypair::generate();
+        let root = test_note(&root_author, "root", 1_700_000_000, &[]);
+        let root_hex = hex::encode(root.id());
+        let direct_reply = test_note(
+            &reply_author,
+            "direct reply",
+            1_700_000_001,
+            &[
+                &["e", root_hex.as_str(), "", "root"],
+                &["p", &root_author.pubkey.hex()],
+            ],
+        );
+        for note in [&root, &direct_reply] {
+            ingest(&ndb, note);
+        }
+        let post = NewPost::new(
+            "nested".to_owned(),
+            nested_author.clone(),
+            Vec::new(),
+            vec![reply_author.pubkey],
+        );
+        let (
+            nested,
+            expected_root_id,
+            expected_parent_id,
+            expected_root_pubkey,
+            expected_parent_pubkey,
+        ) = {
+            let txn = Transaction::new(&ndb).expect("txn");
+            let root = stored_note(&ndb, &txn, root.id());
+            let direct_reply = stored_note(&ndb, &txn, direct_reply.id());
+            let nested = post.to_reply(&nested_author.secret_key.secret_bytes(), &direct_reply);
+            (
+                nested,
+                *root.id(),
+                *direct_reply.id(),
+                *root.pubkey(),
+                *direct_reply.pubkey(),
+            )
+        };
+        ingest(&ndb, &nested);
+        let txn = Transaction::new(&ndb).expect("txn");
+        let nested = stored_note(&ndb, &txn, nested.id());
+        let note_reply = NoteReply::new(nested.tags());
+        let p_tags = notedeck::get_p_tags(&nested);
+
+        assert!(!note_reply.is_reply_to_root());
+        assert_eq!(note_reply.root().unwrap().id, &expected_root_id);
+        assert_eq!(note_reply.reply().unwrap().id, &expected_parent_id);
+        assert!(p_tags.contains(&&expected_parent_pubkey));
+        assert!(p_tags.contains(&&expected_root_pubkey));
+    }
+
+    #[test]
+    fn to_reply_uses_deprecated_single_e_tag_as_root_context() {
+        let (_tmp, ndb) = setup_ndb();
+        let root_author = FullKeypair::generate();
+        let reply_author = FullKeypair::generate();
+        let nested_author = FullKeypair::generate();
+        let root = test_note(&root_author, "root", 1_700_000_000, &[]);
+        let root_hex = hex::encode(root.id());
+        let direct_reply = test_note(
+            &reply_author,
+            "direct reply",
+            1_700_000_001,
+            &[&["e", root_hex.as_str()]],
+        );
+        for note in [&root, &direct_reply] {
+            ingest(&ndb, note);
+        }
+        let post = NewPost::new(
+            "nested".to_owned(),
+            nested_author.clone(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let (nested, expected_root_id, expected_parent_id) = {
+            let txn = Transaction::new(&ndb).expect("txn");
+            let root = stored_note(&ndb, &txn, root.id());
+            let direct_reply = stored_note(&ndb, &txn, direct_reply.id());
+            let nested = post.to_reply(&nested_author.secret_key.secret_bytes(), &direct_reply);
+            (nested, *root.id(), *direct_reply.id())
+        };
+        ingest(&ndb, &nested);
+        let txn = Transaction::new(&ndb).expect("txn");
+        let nested = stored_note(&ndb, &txn, nested.id());
+        let note_reply = NoteReply::new(nested.tags());
+
+        assert_eq!(note_reply.root().unwrap().id, &expected_root_id);
+        assert_eq!(note_reply.reply().unwrap().id, &expected_parent_id);
     }
 
     #[test]

--- a/crates/notedeck_columns/src/route.rs
+++ b/crates/notedeck_columns/src/route.rs
@@ -851,4 +851,26 @@ mod tests {
         assert_eq!(expected, parsed);
         assert_eq!(token_writer.str(), data_str);
     }
+
+    #[test]
+    fn test_thread_route_serialize_selected_reply() {
+        let root_hex = "1c54e5b0c386425f7e017d9e068ddef8962eb2ce1bb08ed27e24b93411c12e60";
+        let reply_hex = "7ac2f0c7792ff4b7f3bc3dbac6dc3ee85f02278698d50543607e7ea826988805";
+        let root = NoteId::from_hex(root_hex).unwrap();
+        let reply = NoteId::from_hex(reply_hex).unwrap();
+        let data_str = format!("thread:root:{root_hex}:reply:{reply_hex}");
+        let data = &data_str.split(':').collect::<Vec<&str>>();
+        let mut token_writer = TokenWriter::default();
+        let mut parser = TokenParser::new(data);
+        let parsed = Route::parse(&mut parser, &Pubkey::new(*root.bytes())).unwrap();
+        let expected = Route::Thread(ThreadSelection {
+            root_id: RootNoteIdBuf::new_unsafe(*root.bytes()),
+            selected_note: Some(reply),
+        });
+
+        parsed.serialize_tokens(&mut token_writer);
+
+        assert_eq!(expected, parsed);
+        assert_eq!(token_writer.str(), data_str);
+    }
 }

--- a/crates/notedeck_columns/src/timeline/kind.rs
+++ b/crates/notedeck_columns/src/timeline/kind.rs
@@ -234,6 +234,160 @@ impl FilterVec {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enostr::FullKeypair;
+    use nostrdb::{Config, NoteBuilder};
+    use std::time::{Duration, Instant};
+    use tempfile::TempDir;
+
+    fn test_note(
+        account: &FullKeypair,
+        content: &str,
+        created_at: u64,
+        tags: &[&[&str]],
+    ) -> nostrdb::Note<'static> {
+        let mut builder = NoteBuilder::new()
+            .kind(1)
+            .content(content)
+            .created_at(created_at);
+
+        for tag in tags {
+            builder = builder.start_tag();
+            for component in *tag {
+                builder = builder.tag_str(component);
+            }
+        }
+
+        builder
+            .sign(&account.secret_key.secret_bytes())
+            .build()
+            .expect("note")
+    }
+
+    fn setup_ndb() -> (TempDir, Ndb) {
+        let tmp = TempDir::new().expect("tmpdir");
+        let ndb = Ndb::new(tmp.path().to_str().expect("db path"), &Config::new()).expect("ndb");
+        (tmp, ndb)
+    }
+
+    fn ingest(ndb: &Ndb, note: &nostrdb::Note<'_>) {
+        ndb.process_client_event(&note.json().expect("note json"))
+            .expect("ingest note");
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let txn = Transaction::new(ndb).expect("txn");
+            if ndb.get_note_by_id(&txn, note.id()).is_ok() {
+                break;
+            }
+
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for note import"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[test]
+    fn thread_selection_from_note_id_returns_root_selection_for_root_note() {
+        let (_tmp, ndb) = setup_ndb();
+        let author = FullKeypair::generate();
+        let root = test_note(&author, "root", 1_700_000_000, &[]);
+        ingest(&ndb, &root);
+
+        let txn = Transaction::new(&ndb).expect("txn");
+        let mut note_cache = NoteCache::default();
+        let selection =
+            ThreadSelection::from_note_id(&ndb, &mut note_cache, &txn, NoteId::new(*root.id()))
+                .expect("thread selection");
+
+        assert_eq!(selection.root_id.bytes(), root.id());
+        assert_eq!(selection.selected_note, None);
+        assert_eq!(selection.selected_or_root(), root.id());
+    }
+
+    #[test]
+    fn thread_selection_from_note_id_preserves_selected_for_direct_root_reply() {
+        let (_tmp, ndb) = setup_ndb();
+        let root_author = FullKeypair::generate();
+        let reply_author = FullKeypair::generate();
+        let root = test_note(&root_author, "root", 1_700_000_000, &[]);
+        let root_hex = hex::encode(root.id());
+        let reply = test_note(
+            &reply_author,
+            "reply",
+            1_700_000_001,
+            &[&["e", root_hex.as_str(), "", "root"]],
+        );
+        ingest(&ndb, &root);
+        ingest(&ndb, &reply);
+
+        let txn = Transaction::new(&ndb).expect("txn");
+        let mut note_cache = NoteCache::default();
+        let selection =
+            ThreadSelection::from_note_id(&ndb, &mut note_cache, &txn, NoteId::new(*reply.id()))
+                .expect("thread selection");
+
+        assert_eq!(selection.root_id.bytes(), root.id());
+        assert_eq!(selection.selected_note, Some(NoteId::new(*reply.id())));
+        assert_eq!(selection.selected_or_root(), reply.id());
+    }
+
+    #[test]
+    fn thread_selection_from_note_id_preserves_selected_for_nested_reply() {
+        let (_tmp, ndb) = setup_ndb();
+        let root_author = FullKeypair::generate();
+        let reply_author = FullKeypair::generate();
+        let nested_author = FullKeypair::generate();
+        let root = test_note(&root_author, "root", 1_700_000_000, &[]);
+        let root_hex = hex::encode(root.id());
+        let reply = test_note(
+            &reply_author,
+            "reply",
+            1_700_000_001,
+            &[&["e", root_hex.as_str(), "", "root"]],
+        );
+        let reply_hex = hex::encode(reply.id());
+        let nested = test_note(
+            &nested_author,
+            "nested",
+            1_700_000_002,
+            &[
+                &["e", root_hex.as_str(), "", "root"],
+                &["e", reply_hex.as_str(), "", "reply"],
+            ],
+        );
+        ingest(&ndb, &root);
+        ingest(&ndb, &reply);
+        ingest(&ndb, &nested);
+
+        let txn = Transaction::new(&ndb).expect("txn");
+        let mut note_cache = NoteCache::default();
+        let selection =
+            ThreadSelection::from_note_id(&ndb, &mut note_cache, &txn, NoteId::new(*nested.id()))
+                .expect("thread selection");
+
+        assert_eq!(selection.root_id.bytes(), root.id());
+        assert_eq!(selection.selected_note, Some(NoteId::new(*nested.id())));
+        assert_eq!(selection.selected_or_root(), nested.id());
+    }
+
+    #[test]
+    fn thread_selection_from_note_id_returns_note_not_found() {
+        let (_tmp, ndb) = setup_ndb();
+        let txn = Transaction::new(&ndb).expect("txn");
+        let mut note_cache = NoteCache::default();
+        let missing = NoteId::new([3u8; 32]);
+
+        let err = ThreadSelection::from_note_id(&ndb, &mut note_cache, &txn, missing).unwrap_err();
+
+        assert!(matches!(err, RootIdError::NoteNotFound));
+    }
+}
+
 ///
 /// What kind of timeline is it?
 ///   - Follow List

--- a/crates/notedeck_columns/src/timeline/thread.rs
+++ b/crates/notedeck_columns/src/timeline/thread.rs
@@ -434,3 +434,274 @@ impl SingleNoteUnits {
         self.units.contains_key(&UnitKey::Single(*k))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enostr::FullKeypair;
+    use nostrdb::{Config, NoteBuilder};
+    use std::time::{Duration, Instant};
+    use tempfile::TempDir;
+
+    fn test_note(
+        account: &FullKeypair,
+        content: &str,
+        created_at: u64,
+        tags: &[&[&str]],
+    ) -> Note<'static> {
+        let mut builder = NoteBuilder::new()
+            .kind(1)
+            .content(content)
+            .created_at(created_at);
+
+        for tag in tags {
+            builder = builder.start_tag();
+            for component in *tag {
+                builder = builder.tag_str(component);
+            }
+        }
+
+        builder
+            .sign(&account.secret_key.secret_bytes())
+            .build()
+            .expect("note")
+    }
+
+    fn setup_ndb() -> (TempDir, Ndb) {
+        let tmp = TempDir::new().expect("tmpdir");
+        let ndb = Ndb::new(tmp.path().to_str().expect("db path"), &Config::new()).expect("ndb");
+        (tmp, ndb)
+    }
+
+    fn ingest(ndb: &Ndb, note: &Note<'_>) {
+        ndb.process_client_event(&note.json().expect("note json"))
+            .expect("ingest note");
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let txn = Transaction::new(ndb).expect("txn");
+            if ndb.get_note_by_id(&txn, note.id()).is_ok() {
+                break;
+            }
+
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for note import"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    fn stored_note<'a>(ndb: &'a Ndb, txn: &'a Transaction, id: &[u8; 32]) -> Note<'a> {
+        ndb.get_note_by_id(txn, id).expect("stored note")
+    }
+
+    #[test]
+    fn selected_has_at_least_n_replies_only_counts_direct_root_replies() {
+        let (_tmp, ndb) = setup_ndb();
+        let root_author = FullKeypair::generate();
+        let reply_author = FullKeypair::generate();
+        let nested_author = FullKeypair::generate();
+        let second_author = FullKeypair::generate();
+        let root = test_note(&root_author, "root", 1_700_000_000, &[]);
+        let root_hex = hex::encode(root.id());
+        let direct_reply = test_note(
+            &reply_author,
+            "direct reply",
+            1_700_000_001,
+            &[&["e", root_hex.as_str(), "", "root"]],
+        );
+        let direct_reply_hex = hex::encode(direct_reply.id());
+        let nested_reply = test_note(
+            &nested_author,
+            "nested reply",
+            1_700_000_002,
+            &[
+                &["e", root_hex.as_str(), "", "root"],
+                &["e", direct_reply_hex.as_str(), "", "reply"],
+            ],
+        );
+        let second_direct = test_note(
+            &second_author,
+            "second direct reply",
+            1_700_000_003,
+            &[&["e", root_hex.as_str(), "", "root"]],
+        );
+
+        for note in [&root, &direct_reply, &nested_reply, &second_direct] {
+            ingest(&ndb, note);
+        }
+
+        let txn = Transaction::new(&ndb).expect("txn");
+
+        assert!(selected_has_at_least_n_replies(
+            &ndb,
+            &txn,
+            None,
+            root.id(),
+            2
+        ));
+        assert!(!selected_has_at_least_n_replies(
+            &ndb,
+            &txn,
+            None,
+            root.id(),
+            3
+        ));
+    }
+
+    #[test]
+    fn selected_has_at_least_n_replies_only_counts_direct_children_of_selected_note() {
+        let (_tmp, ndb) = setup_ndb();
+        let root_author = FullKeypair::generate();
+        let reply_author = FullKeypair::generate();
+        let nested_author = FullKeypair::generate();
+        let unrelated_author = FullKeypair::generate();
+        let root = test_note(&root_author, "root", 1_700_000_000, &[]);
+        let root_hex = hex::encode(root.id());
+        let selected = test_note(
+            &reply_author,
+            "selected",
+            1_700_000_001,
+            &[&["e", root_hex.as_str(), "", "root"]],
+        );
+        let selected_hex = hex::encode(selected.id());
+        let nested = test_note(
+            &nested_author,
+            "nested",
+            1_700_000_002,
+            &[
+                &["e", root_hex.as_str(), "", "root"],
+                &["e", selected_hex.as_str(), "", "reply"],
+            ],
+        );
+        let unrelated = test_note(
+            &unrelated_author,
+            "unrelated direct root reply",
+            1_700_000_003,
+            &[&["e", root_hex.as_str(), "", "root"]],
+        );
+
+        for note in [&root, &selected, &nested, &unrelated] {
+            ingest(&ndb, note);
+        }
+
+        let txn = Transaction::new(&ndb).expect("txn");
+
+        assert!(selected_has_at_least_n_replies(
+            &ndb,
+            &txn,
+            Some(selected.id()),
+            root.id(),
+            1,
+        ));
+        assert!(!selected_has_at_least_n_replies(
+            &ndb,
+            &txn,
+            Some(selected.id()),
+            root.id(),
+            2,
+        ));
+    }
+
+    #[test]
+    fn fill_reply_chain_links_direct_root_reply_to_root() {
+        let (_tmp, ndb) = setup_ndb();
+        let root_author = FullKeypair::generate();
+        let reply_author = FullKeypair::generate();
+        let root = test_note(&root_author, "root", 1_700_000_000, &[]);
+        let root_hex = hex::encode(root.id());
+        let direct_reply = test_note(
+            &reply_author,
+            "direct reply",
+            1_700_000_001,
+            &[&["e", root_hex.as_str(), "", "root"]],
+        );
+
+        for note in [&root, &direct_reply] {
+            ingest(&ndb, note);
+        }
+
+        let txn = Transaction::new(&ndb).expect("txn");
+        let mut note_cache = NoteCache::default();
+        let mut threads = Threads::default();
+        let mut unknown_ids = UnknownIds::default();
+        let direct_reply = stored_note(&ndb, &txn, direct_reply.id());
+        let reply_key = direct_reply.key().expect("reply key");
+        let cached_reply = note_cache
+            .cached_note_or_insert_mut(reply_key, &direct_reply)
+            .reply;
+
+        let have_all_ancestors = threads.fill_reply_chain_recursive(
+            &direct_reply,
+            &cached_reply,
+            &mut note_cache,
+            &ndb,
+            &txn,
+            &mut unknown_ids,
+        );
+        let node = threads
+            .threads
+            .get(&NoteId::new(*direct_reply.id()))
+            .expect("thread node");
+        let root_node = threads
+            .threads
+            .get(&NoteId::new(*root.id()))
+            .expect("root node");
+
+        assert!(have_all_ancestors);
+        assert!(
+            matches!(node.prev, ParentState::Parent(parent) if parent == NoteId::new(*root.id()))
+        );
+        assert!(node.have_all_ancestors);
+        assert!(matches!(root_node.prev, ParentState::None));
+        assert!(root_node.have_all_ancestors);
+    }
+
+    #[test]
+    fn fill_reply_chain_links_deprecated_direct_reply_to_first_e_tag() {
+        let (_tmp, ndb) = setup_ndb();
+        let root_author = FullKeypair::generate();
+        let reply_author = FullKeypair::generate();
+        let root = test_note(&root_author, "root", 1_700_000_000, &[]);
+        let root_hex = hex::encode(root.id());
+        let direct_reply = test_note(
+            &reply_author,
+            "deprecated direct reply",
+            1_700_000_001,
+            &[&["e", root_hex.as_str()]],
+        );
+
+        for note in [&root, &direct_reply] {
+            ingest(&ndb, note);
+        }
+
+        let txn = Transaction::new(&ndb).expect("txn");
+        let mut note_cache = NoteCache::default();
+        let mut threads = Threads::default();
+        let mut unknown_ids = UnknownIds::default();
+        let direct_reply = stored_note(&ndb, &txn, direct_reply.id());
+        let reply_key = direct_reply.key().expect("reply key");
+        let cached_reply = note_cache
+            .cached_note_or_insert_mut(reply_key, &direct_reply)
+            .reply;
+
+        let have_all_ancestors = threads.fill_reply_chain_recursive(
+            &direct_reply,
+            &cached_reply,
+            &mut note_cache,
+            &ndb,
+            &txn,
+            &mut unknown_ids,
+        );
+        let node = threads
+            .threads
+            .get(&NoteId::new(*direct_reply.id()))
+            .expect("thread node");
+
+        assert!(have_all_ancestors);
+        assert!(
+            matches!(node.prev, ParentState::Parent(parent) if parent == NoteId::new(*root.id()))
+        );
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed hashtag limit settings to properly persist across account switches and app restarts
  * Improved note thread resolution and reply chain tracking for more accurate threading

* **Tests**
  * Added comprehensive test coverage for hashtag filtering behavior and settings persistence
  * Added integration tests for note threading, reply resolution, and reply chain handling
  * Enhanced test infrastructure with utilities for note creation and database operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->