### PR TITLE
dave: replace custom collapsing folder widget with egui CollapsingHeader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4940,7 +4940,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "android-activity",
  "base32",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck_chrome"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "android-keyring",
  "bitflags 2.11.0",
@@ -5054,7 +5054,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck_clndash"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "eframe",
  "egui",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck_columns"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck_dashboard"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -5153,7 +5153,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck_dave"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "arboard",
  "async-openai",
@@ -5198,7 +5198,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck_messages"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -5229,7 +5229,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck_nostrverse"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "bytemuck",
  "egui",
@@ -5252,7 +5252,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck_notebook"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "egui",
  "jsoncanvas",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck_release"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "hex",
  "nostr 0.37.0",
@@ -5275,7 +5275,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck_testing"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "eframe",
  "egui",
@@ -5293,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck_ui"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "bitflags 2.11.0",
  "eframe",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck_wasm"
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 dependencies = [
  "cc",
  "dirs",

--- a/crates/notedeck_dave/src/session.rs
+++ b/crates/notedeck_dave/src/session.rs
@@ -1211,7 +1211,11 @@ impl SessionManager {
                 continue;
             }
             for cwd_group in &host_group.cwd_groups {
-                if collapse.is_cwd_collapsed(&host_group.hostname, &cwd_group.cwd) {
+                // Single-session cwds render without a folder header (no UI to
+                // collapse), so they're always visible to keyboard nav too —
+                // ignore any stale `is_cwd_collapsed` state.
+                let collapsible = cwd_group.session_ids.len() > 1;
+                if collapsible && collapse.is_cwd_collapsed(&host_group.hostname, &cwd_group.cwd) {
                     continue;
                 }
                 ids.extend_from_slice(&cwd_group.session_ids);
@@ -2963,7 +2967,12 @@ mod tests {
     fn visual_order_skips_collapsed_hosts_and_cwds_but_keeps_chats() {
         let mut mgr = SessionManager::new();
 
-        let _local_a = create_grouped_session(&mut mgr, "", "/work/a", "Local A", AiMode::Agentic);
+        // Two sessions in /work/a so the cwd is collapsible (single-session
+        // cwds always stay visible regardless of collapse state).
+        let _local_a1 =
+            create_grouped_session(&mut mgr, "", "/work/a", "Local A1", AiMode::Agentic);
+        let _local_a2 =
+            create_grouped_session(&mut mgr, "", "/work/a", "Local A2", AiMode::Agentic);
         let local_b = create_grouped_session(&mut mgr, "", "/work/b", "Local B", AiMode::Agentic);
         let remote_a = create_grouped_session(
             &mut mgr,
@@ -2991,6 +3000,23 @@ mod tests {
             mgr.visual_order(&collapse),
             vec![local_b, remote_a, chat_id]
         );
+    }
+
+    #[test]
+    fn visual_order_keeps_single_session_cwd_visible_even_if_marked_collapsed() {
+        let mut mgr = SessionManager::new();
+
+        // Only one session in /work/solo — its cwd cannot be collapsed in the
+        // UI (no folder header is rendered), so a stale `is_cwd_collapsed`
+        // entry must not hide it from keyboard navigation.
+        let solo = create_grouped_session(&mut mgr, "", "/work/solo", "Solo", AiMode::Agentic);
+
+        mgr.rebuild_cwd_groups();
+
+        let mut collapse = CollapseState::new();
+        collapse.toggle_cwd("", std::path::Path::new("/work/solo"));
+
+        assert_eq!(mgr.visual_order(&collapse), vec![solo]);
     }
 
     // ---- compact_intent / take_compact_and_proceed tests ----

--- a/crates/notedeck_dave/src/ui/session_list.rs
+++ b/crates/notedeck_dave/src/ui/session_list.rs
@@ -108,66 +108,9 @@ impl<'a> SessionListUi<'a> {
 
         // Agents grouped by host → cwd (pre-computed, deterministically ordered)
         for host_group in &host_groups {
-            let host_label = if host_group.hostname.is_empty() {
-                "Local"
-            } else {
-                &host_group.hostname
-            };
-
-            let host_collapsed = self.collapse_state.is_host_collapsed(&host_group.hostname);
-
-            let host_response = host_header_ui(ui, host_label);
-            if host_response.clicked() {
-                action = Some(SessionListAction::ToggleHostCollapse(
-                    host_group.hostname.clone(),
-                ));
+            if let Some(a) = host_section_ui(ui, self, host_group, &mut visual_index, active_id) {
+                action = Some(a);
             }
-            ui.add_space(4.0);
-
-            if host_collapsed {
-                ui.add_space(6.0);
-                continue;
-            }
-
-            for cwd_group in &host_group.cwd_groups {
-                let collapsed = self
-                    .collapse_state
-                    .is_cwd_collapsed(&host_group.hostname, &cwd_group.cwd);
-
-                let header_response = cwd_folder_header(ui, &cwd_group.display_cwd, collapsed);
-                if header_response.clicked() {
-                    action = Some(SessionListAction::ToggleCwdCollapse(
-                        host_group.hostname.clone(),
-                        cwd_group.cwd.clone(),
-                    ));
-                }
-
-                notedeck_ui::context_menu::context_menu(&header_response, |ui| {
-                    if ui.button("New Session").clicked() {
-                        action = Some(SessionListAction::NewSessionInCwd(
-                            host_group.hostname.clone(),
-                            cwd_group.cwd.clone(),
-                        ));
-                        ui.close_menu();
-                    }
-                });
-
-                if !collapsed {
-                    ui.add_space(2.0);
-                    for &id in &cwd_group.session_ids {
-                        if let Some(session) = self.session_manager.get(id) {
-                            if let Some(a) =
-                                self.render_session_item(ui, session, visual_index, active_id)
-                            {
-                                action = Some(a);
-                            }
-                            visual_index += 1;
-                        }
-                    }
-                }
-                ui.add_space(2.0);
-            }
-            ui.add_space(6.0);
         }
 
         // Chats section (pre-computed IDs)
@@ -732,62 +675,131 @@ fn render_title(ui: &mut egui::Ui, title: &str, x: f32, y: f32, max_width: f32) 
     }
 }
 
-/// Render a collapsible host header. Truncates with ellipsis and shows
-/// full name on hover.
-fn host_header_ui(ui: &mut egui::Ui, label: &str) -> egui::Response {
-    let text = egui::RichText::new(label)
-        .size(14.0)
-        .color(ui.visuals().weak_text_color());
-    let widget = egui::Label::new(text).truncate().sense(Sense::click());
-    ui.add(widget)
-        .on_hover_cursor(egui::CursorIcon::PointingHand)
-}
-
-/// Render a collapsible cwd folder header with disclosure triangle and truncated path.
-fn cwd_folder_header(ui: &mut egui::Ui, cwd_display: &str, collapsed: bool) -> egui::Response {
-    let header_height = 24.0;
-    let desired_size = egui::vec2(ui.available_width(), header_height);
-    let (rect, response) = ui.allocate_exact_size(desired_size, Sense::click());
-    let response = response.on_hover_cursor(egui::CursorIcon::PointingHand);
-    response.widget_info(|| egui::WidgetInfo::labeled(egui::WidgetType::Button, true, cwd_display));
-
-    let triangle_size = 8.0;
-    let triangle_center = egui::pos2(rect.left() + 4.0 + triangle_size / 2.0, rect.center().y);
-    let weak_color = ui.visuals().weak_text_color();
-
-    let triangle_points = disclosure_triangle(triangle_center, collapsed);
-    ui.painter().add(egui::Shape::convex_polygon(
-        triangle_points,
-        weak_color,
-        egui::Stroke::NONE,
-    ));
-
-    let text_start = rect.left() + 4.0 + triangle_size + 4.0;
-    let max_text_width = rect.right() - text_start - 4.0;
-    let (text, _) = truncate_host_and_path(ui, "", cwd_display, max_text_width);
-    let font = egui::FontId::monospace(10.0);
-    let text_pos = egui::pos2(text_start, rect.center().y);
-    ui.painter()
-        .text(text_pos, egui::Align2::LEFT_CENTER, &text, font, weak_color);
-
-    response
-}
-
-/// Compute the three vertices for a disclosure triangle.
-fn disclosure_triangle(center: egui::Pos2, collapsed: bool) -> Vec<egui::Pos2> {
-    if collapsed {
-        vec![
-            center + egui::vec2(-3.0, -4.0),
-            center + egui::vec2(4.0, 0.0),
-            center + egui::vec2(-3.0, 4.0),
-        ]
+/// Render one host's collapsible section, including its nested cwd sections.
+///
+/// Egui's `CollapsingState` handles the disclosure triangle and animation;
+/// the open flag is forced from the external `CollapseState` each frame, so
+/// keyboard navigation and persistence keep their single source of truth.
+fn host_section_ui(
+    ui: &mut egui::Ui,
+    list_ui: &SessionListUi<'_>,
+    host_group: &crate::session::HostGroup,
+    visual_index: &mut usize,
+    active_id: Option<SessionId>,
+) -> Option<SessionListAction> {
+    let mut action = None;
+    let host_label = if host_group.hostname.is_empty() {
+        "Local"
     } else {
-        vec![
-            center + egui::vec2(-4.0, -3.0),
-            center + egui::vec2(4.0, -3.0),
-            center + egui::vec2(0.0, 4.0),
-        ]
+        host_group.hostname.as_str()
+    };
+    let host_collapsed = list_ui
+        .collapse_state
+        .is_host_collapsed(&host_group.hostname);
+    let host_id = ui.make_persistent_id(("dave_host_collapse", host_group.hostname.as_str()));
+    let mut host_state =
+        egui::collapsing_header::CollapsingState::load_with_default_open(ui.ctx(), host_id, true);
+    host_state.set_open(!host_collapsed);
+
+    let header = host_state.show_header(ui, |ui| {
+        let text = egui::RichText::new(host_label)
+            .size(14.0)
+            .color(ui.visuals().weak_text_color());
+        ui.add(egui::Label::new(text).truncate().sense(Sense::click()))
+            .on_hover_cursor(egui::CursorIcon::PointingHand)
+    });
+
+    let (toggle_resp, label_resp, _) = header.body_unindented(|ui| {
+        for cwd_group in &host_group.cwd_groups {
+            if let Some(a) = cwd_section_ui(
+                ui,
+                list_ui,
+                &host_group.hostname,
+                cwd_group,
+                visual_index,
+                active_id,
+            ) {
+                action = Some(a);
+            }
+        }
+    });
+
+    if toggle_resp.clicked() || label_resp.inner.clicked() {
+        action = Some(SessionListAction::ToggleHostCollapse(
+            host_group.hostname.clone(),
+        ));
     }
+
+    ui.add_space(6.0);
+    action
+}
+
+/// Render one (host, cwd) collapsible section, including its session rows.
+fn cwd_section_ui(
+    ui: &mut egui::Ui,
+    list_ui: &SessionListUi<'_>,
+    hostname: &str,
+    cwd_group: &crate::session::CwdGroup,
+    visual_index: &mut usize,
+    active_id: Option<SessionId>,
+) -> Option<SessionListAction> {
+    let mut action = None;
+    let cwd_collapsed = list_ui
+        .collapse_state
+        .is_cwd_collapsed(hostname, &cwd_group.cwd);
+    let cwd_id = ui.make_persistent_id(("dave_cwd_collapse", hostname, cwd_group.cwd.as_path()));
+    let mut cwd_state =
+        egui::collapsing_header::CollapsingState::load_with_default_open(ui.ctx(), cwd_id, true);
+    cwd_state.set_open(!cwd_collapsed);
+
+    let header = cwd_state.show_header(ui, |ui| cwd_folder_label_ui(ui, &cwd_group.display_cwd));
+
+    let (toggle_resp, label_resp, _) = header.body_unindented(|ui| {
+        ui.add_space(2.0);
+        for &id in &cwd_group.session_ids {
+            if let Some(session) = list_ui.session_manager.get(id) {
+                if let Some(a) = list_ui.render_session_item(ui, session, *visual_index, active_id)
+                {
+                    action = Some(a);
+                }
+                *visual_index += 1;
+            }
+        }
+    });
+
+    if toggle_resp.clicked() || label_resp.inner.clicked() {
+        action = Some(SessionListAction::ToggleCwdCollapse(
+            hostname.to_string(),
+            cwd_group.cwd.clone(),
+        ));
+    }
+
+    notedeck_ui::context_menu::context_menu(&label_resp.inner, |ui| {
+        if ui.button("New Session").clicked() {
+            action = Some(SessionListAction::NewSessionInCwd(
+                hostname.to_string(),
+                cwd_group.cwd.clone(),
+            ));
+            ui.close_menu();
+        }
+    });
+
+    ui.add_space(2.0);
+    action
+}
+
+/// Renders just the cwd label (monospace 10pt, weak color, truncated from the
+/// start) for use inside `CollapsingState::show_header`. egui draws the
+/// disclosure triangle separately.
+fn cwd_folder_label_ui(ui: &mut egui::Ui, cwd_display: &str) -> egui::Response {
+    let max_text_width = (ui.available_width() - 4.0).max(0.0);
+    let (text, _) = truncate_host_and_path(ui, "", cwd_display, max_text_width);
+    let weak_color = ui.visuals().weak_text_color();
+    let rich = egui::RichText::new(text)
+        .font(egui::FontId::monospace(10.0))
+        .color(weak_color);
+    ui.add(egui::Label::new(rich).sense(Sense::click()))
+        .on_hover_cursor(egui::CursorIcon::PointingHand)
 }
 
 /// Renders the "Delete worktree" context-menu item with an inline confirmation step.

--- a/crates/notedeck_dave/src/ui/session_list.rs
+++ b/crates/notedeck_dave/src/ui/session_list.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use egui::{Align, Color32, Layout, Sense};
+use egui::{Align, Color32, Layout, Pos2, Sense};
 use notedeck_ui::app_images;
 
 use crate::agent_status::AgentStatus;
@@ -124,7 +124,8 @@ impl<'a> SessionListUi<'a> {
             ui.add_space(4.0);
             for id in chat_ids {
                 if let Some(session) = self.session_manager.get(id) {
-                    if let Some(a) = self.render_session_item(ui, session, visual_index, active_id)
+                    if let Some(a) =
+                        self.render_session_item(ui, session, visual_index, active_id, None)
                     {
                         action = Some(a);
                     }
@@ -142,6 +143,7 @@ impl<'a> SessionListUi<'a> {
         session: &crate::session::ChatSession,
         index: usize,
         active_id: Option<SessionId>,
+        cwd_display: Option<&str>,
     ) -> Option<SessionListAction> {
         let is_active = Some(session.id) == active_id;
         let shortcut_hint = if self.ctrl_held && index < 9 {
@@ -169,6 +171,7 @@ impl<'a> SessionListUi<'a> {
                 ui,
                 session.id,
                 display_title,
+                cwd_display,
                 is_active,
                 shortcut_hint,
                 session.status(),
@@ -307,19 +310,25 @@ impl<'a> SessionListUi<'a> {
     }
 
     /// Render an agentic session row (status bar, backend icon, focus dot).
+    ///
+    /// When `cwd_display` is `Some`, the row is taller (48px) and shows the cwd
+    /// path in a second line below the title (used for sessions that are alone
+    /// in their cwd, where the surrounding folder header is suppressed).
     #[allow(clippy::too_many_arguments)]
     fn agent_row_ui(
         &self,
         ui: &mut egui::Ui,
         session_id: SessionId,
         title: &str,
+        cwd_display: Option<&str>,
         is_active: bool,
         shortcut_hint: Option<usize>,
         status: AgentStatus,
         queue_priority: Option<FocusPriority>,
         backend_type: BackendType,
     ) -> (egui::Response, Option<SessionListAction>) {
-        let desired_size = egui::vec2(ui.available_width(), 32.0);
+        let row_height = if cwd_display.is_some() { 48.0 } else { 32.0 };
+        let desired_size = egui::vec2(ui.available_width(), row_height);
         let (rect, response) = ui.allocate_exact_size(desired_size, Sense::click());
         let response = response.on_hover_cursor(egui::CursorIcon::PointingHand);
 
@@ -365,7 +374,11 @@ impl<'a> SessionListUi<'a> {
             .layout_no_wrap(title.to_string(), font_id, ui.visuals().text_color())
             .size()
             .y;
-        let title_top = rect.center().y - title_height / 2.0;
+        let title_top = if cwd_display.is_some() {
+            rect.top() + 6.0
+        } else {
+            rect.center().y - title_height / 2.0
+        };
         render_title(
             ui,
             title,
@@ -373,6 +386,11 @@ impl<'a> SessionListUi<'a> {
             title_top,
             max_text_width,
         );
+
+        if let Some(cwd) = cwd_display {
+            let cwd_pos = egui::pos2(rect.left() + text_start_x, title_top + title_height + 1.0);
+            cwd_inline_ui(ui, cwd, cwd_pos, max_text_width);
+        }
 
         (response, dot_action)
     }
@@ -734,7 +752,11 @@ fn host_section_ui(
     action
 }
 
-/// Render one (host, cwd) collapsible section, including its session rows.
+/// Render one (host, cwd) section, including its session rows.
+///
+/// When the cwd has a single session, the folder header is suppressed and the
+/// session is rendered inline with its cwd path embedded in the row. When the
+/// cwd has multiple sessions, a collapsible folder wraps them.
 fn cwd_section_ui(
     ui: &mut egui::Ui,
     list_ui: &SessionListUi<'_>,
@@ -744,6 +766,25 @@ fn cwd_section_ui(
     active_id: Option<SessionId>,
 ) -> Option<SessionListAction> {
     let mut action = None;
+
+    // Single-session cwd: render the row inline with the cwd path, no folder.
+    if cwd_group.session_ids.len() == 1 {
+        let id = cwd_group.session_ids[0];
+        if let Some(session) = list_ui.session_manager.get(id) {
+            if let Some(a) = list_ui.render_session_item(
+                ui,
+                session,
+                *visual_index,
+                active_id,
+                Some(cwd_group.display_cwd.as_str()),
+            ) {
+                action = Some(a);
+            }
+            *visual_index += 1;
+        }
+        return action;
+    }
+
     let cwd_collapsed = list_ui
         .collapse_state
         .is_cwd_collapsed(hostname, &cwd_group.cwd);
@@ -758,7 +799,8 @@ fn cwd_section_ui(
         ui.add_space(2.0);
         for &id in &cwd_group.session_ids {
             if let Some(session) = list_ui.session_manager.get(id) {
-                if let Some(a) = list_ui.render_session_item(ui, session, *visual_index, active_id)
+                if let Some(a) =
+                    list_ui.render_session_item(ui, session, *visual_index, active_id, None)
                 {
                     action = Some(a);
                 }
@@ -786,6 +828,17 @@ fn cwd_section_ui(
 
     ui.add_space(2.0);
     action
+}
+
+/// Draw the cwd path inline within an agent row (monospace 10pt, weak color,
+/// truncated from the start), for sessions that are alone in their cwd and so
+/// don't get a surrounding folder header.
+fn cwd_inline_ui(ui: &mut egui::Ui, cwd_display: &str, pos: Pos2, max_width: f32) {
+    let (text, _) = truncate_host_and_path(ui, "", cwd_display, max_width);
+    let cwd_font = egui::FontId::monospace(10.0);
+    let cwd_color = ui.visuals().weak_text_color();
+    ui.painter()
+        .text(pos, egui::Align2::LEFT_TOP, &text, cwd_font, cwd_color);
 }
 
 /// Renders just the cwd label (monospace 10pt, weak color, truncated from the
@@ -866,15 +919,22 @@ mod tests {
         fn new() -> Self {
             let cwd_path = PathBuf::from("/tmp/project");
             let mut session_manager = SessionManager::new();
-            let session_id =
-                session_manager.new_session(cwd_path.clone(), AiMode::Agentic, BackendType::Claude);
-            let session = session_manager
-                .get_mut(session_id)
-                .expect("session should exist");
-            session.details.hostname = "host-a".to_string();
-            session.details.title = "Workspace agent".to_string();
-            session.details.custom_title = None;
-            session.details.home_dir = String::new();
+            // Two sessions in the same cwd so the folder header is rendered
+            // (single-session cwds skip the header and inline the cwd path).
+            for title in ["Workspace agent A", "Workspace agent B"] {
+                let session_id = session_manager.new_session(
+                    cwd_path.clone(),
+                    AiMode::Agentic,
+                    BackendType::Claude,
+                );
+                let session = session_manager
+                    .get_mut(session_id)
+                    .expect("session should exist");
+                session.details.hostname = "host-a".to_string();
+                session.details.title = title.to_string();
+                session.details.custom_title = None;
+                session.details.home_dir = String::new();
+            }
             session_manager.rebuild_cwd_groups();
 
             let cwd_label = session_manager.host_cwd_groups()[0].cwd_groups[0]

--- a/crates/notedeck_dave/src/ui/session_list.rs
+++ b/crates/notedeck_dave/src/ui/session_list.rs
@@ -785,6 +785,38 @@ fn cwd_section_ui(
         return action;
     }
 
+    // Multi-session cwd: indent the folder under its host header so the
+    // visual hierarchy is obvious. Single-session rows above stay flush with
+    // the host since they're conceptually loose siblings, not a sub-group.
+    egui::Frame::new()
+        .inner_margin(egui::Margin {
+            left: 12,
+            ..Default::default()
+        })
+        .show(ui, |ui| {
+            if let Some(a) =
+                cwd_folder_ui(ui, list_ui, hostname, cwd_group, visual_index, active_id)
+            {
+                action = Some(a);
+            }
+        });
+
+    ui.add_space(2.0);
+    action
+}
+
+/// Render the collapsible folder for a multi-session cwd: header, body
+/// containing each session row, and the right-click "New Session" menu.
+/// Indentation is the caller's responsibility.
+fn cwd_folder_ui(
+    ui: &mut egui::Ui,
+    list_ui: &SessionListUi<'_>,
+    hostname: &str,
+    cwd_group: &crate::session::CwdGroup,
+    visual_index: &mut usize,
+    active_id: Option<SessionId>,
+) -> Option<SessionListAction> {
+    let mut action = None;
     let cwd_collapsed = list_ui
         .collapse_state
         .is_cwd_collapsed(hostname, &cwd_group.cwd);
@@ -826,7 +858,6 @@ fn cwd_section_ui(
         }
     });
 
-    ui.add_space(2.0);
     action
 }
 

--- a/crates/notedeck_dave/src/update.rs
+++ b/crates/notedeck_dave/src/update.rs
@@ -1638,9 +1638,21 @@ mod tests {
             "/srv/hidden",
             "Hidden",
         );
+        // Second session in /srv/hidden so its cwd is collapsible
+        // (single-session cwds skip the folder header and are always visible).
+        let _hidden_sibling = create_named_agent_session(
+            &mut sm,
+            &mut picker,
+            &mut scene,
+            "remote-a",
+            "/srv/hidden",
+            "Hidden sibling",
+        );
 
         let mut collapse = CollapseState::new();
         collapse.toggle_cwd("remote-a", std::path::Path::new("/srv/hidden"));
+
+        sm.switch_to(hidden_id);
 
         focus_queue.enqueue(hidden_id, FocusPriority::NeedsInput);
         focus_queue.enqueue(visible_id, FocusPriority::Error);


### PR DESCRIPTION
## Summary

Two related changes to the dave session-list sidebar.

### 1. Replace custom collapsing widget with `egui::CollapsingHeader` (Refs #1454)

- Replaces hand-rolled `cwd_folder_header` / `host_header_ui` / `disclosure_triangle` with `egui::collapsing_header::CollapsingState`.
- `CollapseState` stays as the external source of truth — keyboard navigation (Ctrl+Tab, Ctrl+1-9) and `collapse_state.json` persistence still need to query collapse state outside the UI render pass, so we force `set_open` from it every frame.
- Splits `sessions_list_ui` into smaller free `_ui` functions (`host_section_ui`, `cwd_section_ui`, `cwd_folder_label_ui`).

### 2. Skip the folder header for single-session cwds (Refs #1456)

- A cwd containing only one session no longer gets wrapped in a collapsible folder. The session is rendered inline with its cwd path drawn under the title (the pre-grouped-folder layout). Multi-session cwds still get the folder header.
- `SessionManager::visual_order` now ignores `is_cwd_collapsed` for single-session cwds, so a stale collapse-state entry can't desync keyboard navigation from what's actually visible.

## Notable behaviour changes

- The host row now has an egui-painted disclosure triangle where it previously had no triangle. Easy to revert if undesired.
- The clickable area of a folder row is now the triangle + label, not the whole row. Empty space to the right of a short path is no longer a click target.
- Triangle clicks have a one-frame visual mismatch (egui internal toggle, then forced back from `CollapseState` next frame). Imperceptible in practice.
- Single-session cwds lose the right-click "New Session in this cwd" affordance (there's no folder header to right-click). Same as the pre-#1454 behaviour.

## Test plan

- [ ] Open a few agent sessions across different cwds and a remote host; confirm host folders collapse/expand on click.
- [ ] Confirm a cwd with one session shows the session inline with its path, no folder/triangle.
- [ ] Add a second session to that same cwd → folder header appears and wraps both rows.
- [ ] Remove sessions until only one remains → folder header disappears, row shows inline path.
- [ ] Restart the app; confirm collapsed state persists (`collapse_state.json`).
- [ ] With a multi-session folder collapsed, hit Ctrl+Tab and Ctrl+1-9 — navigation should skip sessions inside collapsed folders.
- [ ] With a *single*-session cwd marked collapsed in stale state, navigation should still reach that session.
- [ ] Right-click a multi-session cwd folder header → "New Session" still spawns a session in that cwd.
- [ ] `cargo test -p notedeck_dave` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)