### PR TITLE
Zap receipt verification and grouped notifications

### DIFF
--- a/crates/notedeck/src/lib.rs
+++ b/crates/notedeck/src/lib.rs
@@ -97,7 +97,7 @@ pub use nip51_set::{create_nip51_set, Nip51Set, Nip51SetCache};
 pub use note::{
     builder_from_note, get_p_tags, send_mute_event, send_people_list_event, send_report_event,
     send_unmute_event, BroadcastContext, ContextSelection, NoteAction, NoteContext,
-    NoteContextSelection, NoteRef, ReportTarget, ReportType, RootIdError, RootNoteId,
+    NoteContextSelection, NoteDetail, NoteRef, ReportTarget, ReportType, RootIdError, RootNoteId,
     RootNoteIdBuf, ScrollInfo, ZapAction,
 };
 pub use notecache::{CachedNote, NoteCache};

--- a/crates/notedeck/src/note/action.rs
+++ b/crates/notedeck/src/note/action.rs
@@ -46,6 +46,17 @@ pub enum NoteAction {
 
     /// User scrolled the timeline
     Scroll(ScrollInfo),
+
+    /// User clicked a detailed count label (reactions, reposts, zaps)
+    Detail(NoteDetail),
+}
+
+/// Which detailed count label was clicked on a note
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum NoteDetail {
+    Reactions(NoteId),
+    Reposts(NoteId),
+    Zaps(NoteId),
 }
 
 impl NoteAction {

--- a/crates/notedeck/src/note/mod.rs
+++ b/crates/notedeck/src/note/mod.rs
@@ -2,7 +2,7 @@ mod action;
 mod context;
 pub mod publish;
 
-pub use action::{NoteAction, ReactAction, ScrollInfo, ZapAction, ZapTargetAmount};
+pub use action::{NoteAction, NoteDetail, ReactAction, ScrollInfo, ZapAction, ZapTargetAmount};
 pub use context::{BroadcastContext, ContextSelection, NoteContextSelection};
 pub use publish::{
     builder_from_note, send_mute_event, send_people_list_event, send_report_event,

--- a/crates/notedeck/src/zaps/zap.rs
+++ b/crates/notedeck/src/zaps/zap.rs
@@ -97,7 +97,7 @@ pub fn event_commitment(
 }
 
 // TODO(kernelkind): i think we may be able to validate just with the nostrdb::Note. Not exactly sure yet how though
-fn valid_zap_request(note: enostr::Note) -> bool {
+pub(crate) fn valid_zap_request(note: enostr::Note) -> bool {
     let sig = note.sig.clone();
 
     let commitment = event_commitment(

--- a/crates/notedeck_columns/src/actionbar.rs
+++ b/crates/notedeck_columns/src/actionbar.rs
@@ -240,6 +240,9 @@ fn execute_note_action(
 
             media_action.process_default_media_actions(images, jobs, ui.ctx())
         }
+        NoteAction::Detail(detail) => {
+            router_action = Some(RouterAction::route_to(Route::NoteDetails(detail)));
+        }
     }
 
     NoteActionResponse {

--- a/crates/notedeck_columns/src/app.rs
+++ b/crates/notedeck_columns/src/app.rs
@@ -838,6 +838,7 @@ fn should_show_compose_button(decks: &DecksCache, accounts: &Accounts) -> bool {
         Route::TosAcceptance => false,
         Route::Welcome => false,
         Route::Report(_) => false,
+        Route::NoteDetails(_) => false,
     }
 }
 

--- a/crates/notedeck_columns/src/nav.rs
+++ b/crates/notedeck_columns/src/nav.rs
@@ -37,7 +37,7 @@ use enostr::ProfileState;
 use nostrdb::{Filter, Ndb, Transaction};
 use notedeck::{
     get_current_default_msats, nav::DragResponse, tr, ui::is_narrow, Accounts, AppContext,
-    FilterState, NoteAction, NoteCache, NoteContext, RelayAction,
+    FilterState, NoteAction, NoteCache, NoteContext, NoteDetail, RelayAction,
 };
 use notedeck_ui::{ContactsListAction, ContactsListView, NoteOptions};
 use tracing::error;
@@ -659,6 +659,212 @@ fn process_render_nav_action(
     }
 }
 
+/// Extract the sender pubkey from a zap receipt (kind 9735).
+/// The sender is the author of the zap request (kind 9734) embedded
+/// in the receipt's "description" tag, not the receipt's own pubkey
+/// (which is the LNURL server).
+fn zap_sender_pubkey(zap_receipt: &nostrdb::Note<'_>) -> Option<enostr::Pubkey> {
+    for tag in zap_receipt.tags() {
+        if tag.count() >= 2 && tag.get_str(0) == Some("description") {
+            let desc = tag.get_str(1)?;
+            let zap_req = enostr::Note::from_json(desc).ok()?;
+            return Some(zap_req.pubkey);
+        }
+    }
+    None
+}
+
+/// Check if a zap receipt has been verified via nostrdb metadata flags.
+/// NDB_NOTE_META_FLAG_ZAP_VERIFIED = 4
+fn is_zap_verified(ndb: &Ndb, txn: &Transaction, note_id: &[u8; 32]) -> bool {
+    if let Ok(mut meta) = ndb.get_note_metadata(txn, note_id) {
+        *meta.flags() & 4 != 0
+    } else {
+        false
+    }
+}
+
+/// Cached zap detail list split by verification status.
+#[derive(Clone)]
+struct ZapDetailCache {
+    verified: Vec<enostr::Pubkey>,
+    unverified: Vec<enostr::Pubkey>,
+}
+
+fn note_detail_ui(
+    ui: &mut egui::Ui,
+    ndb: &Ndb,
+    detail: &NoteDetail,
+    note_context: &mut NoteContext<'_>,
+) -> DragResponse<RenderNavAction> {
+    let note_id = match detail {
+        NoteDetail::Reactions(id) => id,
+        NoteDetail::Reposts(id) => id,
+        NoteDetail::Zaps(id) => id,
+    };
+
+    if matches!(detail, NoteDetail::Zaps(_)) {
+        return zap_detail_ui(ui, ndb, note_id, note_context);
+    }
+
+    let cache_id = egui::Id::new((
+        "note_detail_cache",
+        note_id,
+        std::mem::discriminant(detail),
+    ));
+
+    let contacts = ui
+        .ctx()
+        .data_mut(|d| d.get_temp::<Vec<enostr::Pubkey>>(cache_id));
+
+    let (txn, contacts) = if let Some(cached) = contacts {
+        let txn = nostrdb::Transaction::new(ndb).expect("txn");
+        (txn, cached)
+    } else {
+        let txn = nostrdb::Transaction::new(ndb).expect("txn");
+
+        let kinds: &[u64] = match detail {
+            NoteDetail::Reactions(_) => &[7],
+            NoteDetail::Reposts(_) => &[6, 16],
+            NoteDetail::Zaps(_) => unreachable!(),
+        };
+
+        let filter = nostrdb::Filter::new()
+            .kinds(kinds.iter().copied())
+            .event(note_id.bytes())
+            .limit(500)
+            .build();
+
+        let mut seen = std::collections::HashSet::new();
+        let mut contacts = vec![];
+
+        if let Ok(results) = ndb.query(&txn, &[filter], 500) {
+            for result in &results {
+                let pk = enostr::Pubkey::new(*result.note.pubkey());
+                if seen.insert(pk) {
+                    contacts.push(pk);
+                }
+            }
+        }
+
+        ui.ctx()
+            .data_mut(|d| d.insert_temp(cache_id, contacts.clone()));
+        (txn, contacts)
+    };
+
+    ContactsListView::new(
+        &contacts,
+        note_context.jobs,
+        note_context.ndb,
+        note_context.img_cache,
+        &txn,
+        note_context.i18n,
+    )
+    .ui(ui)
+    .map_output(|action| match action {
+        ContactsListAction::Select(pk) => RenderNavAction::NoteAction(NoteAction::Profile(pk)),
+    })
+}
+
+fn zap_detail_ui(
+    ui: &mut egui::Ui,
+    ndb: &Ndb,
+    note_id: &enostr::NoteId,
+    note_context: &mut NoteContext<'_>,
+) -> DragResponse<RenderNavAction> {
+    let cache_id = egui::Id::new(("zap_detail_cache", note_id));
+
+    let cached = ui
+        .ctx()
+        .data_mut(|d| d.get_temp::<ZapDetailCache>(cache_id));
+
+    let (txn, zap_cache) = if let Some(cached) = cached {
+        let txn = nostrdb::Transaction::new(ndb).expect("txn");
+        (txn, cached)
+    } else {
+        let txn = nostrdb::Transaction::new(ndb).expect("txn");
+
+        let filter = nostrdb::Filter::new()
+            .kinds([9735])
+            .event(note_id.bytes())
+            .limit(500)
+            .build();
+
+        let mut seen = std::collections::HashSet::new();
+        let mut verified = vec![];
+        let mut unverified = vec![];
+
+        if let Ok(results) = ndb.query(&txn, &[filter], 500) {
+            for result in &results {
+                if let Some(pk) = zap_sender_pubkey(&result.note) {
+                    if seen.insert(pk) {
+                        if is_zap_verified(ndb, &txn, result.note.id()) {
+                            verified.push(pk);
+                        } else {
+                            unverified.push(pk);
+                        }
+                    }
+                }
+            }
+        }
+
+        let zap_cache = ZapDetailCache {
+            verified,
+            unverified,
+        };
+
+        ui.ctx()
+            .data_mut(|d| d.insert_temp(cache_id, zap_cache.clone()));
+        (txn, zap_cache)
+    };
+
+    let mut action = None;
+
+    egui::ScrollArea::vertical().show(ui, |ui| {
+        for pk in &zap_cache.verified {
+            let profile = ndb.get_profile_by_pubkey(&txn, pk.bytes()).ok();
+            if notedeck_ui::profile_row(
+                ui,
+                profile.as_ref(),
+                false,
+                note_context.img_cache,
+                note_context.jobs,
+                note_context.i18n,
+            ) {
+                action = Some(RenderNavAction::NoteAction(NoteAction::Profile(*pk)));
+            }
+        }
+
+        if !zap_cache.unverified.is_empty() {
+            ui.add_space(8.0);
+            ui.separator();
+            ui.add_space(4.0);
+            ui.label(
+                egui::RichText::new("Unverified")
+                    .size(13.0)
+                    .color(ui.visuals().weak_text_color()),
+            );
+            ui.add_space(4.0);
+
+            for pk in &zap_cache.unverified {
+                let profile = ndb.get_profile_by_pubkey(&txn, pk.bytes()).ok();
+                if notedeck_ui::profile_row(
+                    ui,
+                    profile.as_ref(),
+                    false,
+                    note_context.img_cache,
+                    note_context.jobs,
+                    note_context.i18n,
+                ) {
+                    action = Some(RenderNavAction::NoteAction(NoteAction::Profile(*pk)));
+                }
+            }
+        }
+    });
+
+    DragResponse::output(action)
+}
+
 fn render_nav_body(
     ui: &mut egui::Ui,
     app: &mut Damus,
@@ -1069,6 +1275,9 @@ fn render_nav_body(
             })
         }
         Route::FollowedBy(_pubkey) => DragResponse::none(),
+        Route::NoteDetails(detail) => {
+            note_detail_ui(ui, ctx.ndb, detail, &mut note_context)
+        }
         Route::TosAcceptance => {
             let resp = ui::tos::TosAcceptanceView::new(
                 ctx.i18n,

--- a/crates/notedeck_columns/src/route.rs
+++ b/crates/notedeck_columns/src/route.rs
@@ -2,8 +2,8 @@ use egui_nav::{Percent, ReturnType};
 use enostr::{NoteId, Pubkey};
 use nostrdb::Ndb;
 use notedeck::{
-    tr, Localization, NoteZapTargetOwned, ReplacementType, ReportTarget, RootNoteIdBuf, Router,
-    ScopedSubApi, WalletType,
+    tr, Localization, NoteDetail, NoteZapTargetOwned, ReplacementType, ReportTarget,
+    RootNoteIdBuf, Router, ScopedSubApi, WalletType,
 };
 use std::ops::Range;
 
@@ -43,6 +43,7 @@ pub enum Route {
     TosAcceptance,
     Welcome,
     Report(ReportTarget),
+    NoteDetails(NoteDetail),
 }
 
 impl Route {
@@ -169,6 +170,23 @@ impl Route {
                 writer.write_token(&target.pubkey.hex());
                 if let Some(note_id) = &target.note_id {
                     writer.write_token(&note_id.hex());
+                }
+            }
+            Route::NoteDetails(detail) => {
+                writer.write_token("note_detail");
+                match detail {
+                    NoteDetail::Reactions(id) => {
+                        writer.write_token("reactions");
+                        writer.write_token(&id.hex());
+                    }
+                    NoteDetail::Reposts(id) => {
+                        writer.write_token("reposts");
+                        writer.write_token(&id.hex());
+                    }
+                    NoteDetail::Zaps(id) => {
+                        writer.write_token("zaps");
+                        writer.write_token(&id.hex());
+                    }
                 }
             }
         }
@@ -329,6 +347,21 @@ impl Route {
                         Ok(Route::Report(ReportTarget { pubkey, note_id }))
                     })
                 },
+                |p| {
+                    p.parse_all(|p| {
+                        p.parse_token("note_detail")?;
+                        let kind = p.pull_token()?;
+                        let note_id = NoteId::from_hex(p.pull_token()?)
+                            .map_err(|_| ParseError::HexDecodeFailed)?;
+                        let detail = match kind {
+                            "reactions" => NoteDetail::Reactions(note_id),
+                            "reposts" => NoteDetail::Reposts(note_id),
+                            "zaps" => NoteDetail::Zaps(note_id),
+                            _ => return Err(ParseError::DecodeFailed),
+                        };
+                        Ok(Route::NoteDetails(detail))
+                    })
+                },
             ],
         )
     }
@@ -476,6 +509,23 @@ impl Route {
             Route::Report(_) => {
                 ColumnTitle::formatted(tr!(i18n, "Report", "Column title for report screen"))
             }
+            Route::NoteDetails(detail) => match detail {
+                NoteDetail::Reactions(_) => ColumnTitle::formatted(tr!(
+                    i18n,
+                    "Reactions",
+                    "Column title for note reactions list"
+                )),
+                NoteDetail::Reposts(_) => ColumnTitle::formatted(tr!(
+                    i18n,
+                    "Reposts",
+                    "Column title for note reposts list"
+                )),
+                NoteDetail::Zaps(_) => ColumnTitle::formatted(tr!(
+                    i18n,
+                    "Zaps",
+                    "Column title for note zaps list"
+                )),
+            },
         }
     }
 }

--- a/crates/notedeck_columns/src/ui/column/header.rs
+++ b/crates/notedeck_columns/src/ui/column/header.rs
@@ -537,6 +537,7 @@ impl<'a> NavTitle<'a> {
             Route::TosAcceptance => None,
             Route::Welcome => None,
             Route::Report(_) => None,
+            Route::NoteDetails(_) => None,
         }
     }
 

--- a/crates/notedeck_ui/src/note/mod.rs
+++ b/crates/notedeck_ui/src/note/mod.rs
@@ -25,7 +25,7 @@ use egui::{Id, Pos2, Rect, Response, Sense};
 use enostr::{KeypairUnowned, NoteId, Pubkey};
 use nostrdb::{Ndb, Note, NoteKey, NoteMetadataEntryVariant, ProfileRecord, Transaction};
 use notedeck::{
-    note::{NoteAction, NoteContext, ReactAction, ZapAction},
+    note::{NoteAction, NoteContext, NoteDetail, ReactAction, ZapAction},
     tr, AnyZapState, ContextSelection, NoteZapTarget, NoteZapTargetOwned, ZapTarget, Zaps,
 };
 
@@ -479,7 +479,8 @@ impl<'a, 'd> NoteView<'a, 'd> {
                     NoteStats::get(self.note_context.ndb, txn, self.note.id());
 
                 if show_detailed {
-                    detailed_counts_ui(ui, &stats);
+                    note_action = detailed_counts_ui(ui, self.note.id(), &stats)
+                        .or(note_action);
                 }
 
                 if show_actionbar {
@@ -580,7 +581,8 @@ impl<'a, 'd> NoteView<'a, 'd> {
                         NoteStats::get(self.note_context.ndb, txn, self.note.id());
 
                     if show_detailed {
-                        detailed_counts_ui(ui, &stats);
+                        note_action = detailed_counts_ui(ui, self.note.id(), &stats)
+                            .or(note_action);
                     }
 
                     if show_actionbar {
@@ -1038,7 +1040,12 @@ fn is_root_note(note: &Note) -> bool {
 
 /// Renders a detailed counts row showing reposts, reactions, zaps, etc.
 /// Styled like Damus iOS: "3 Reposts  11 Reactions  21K Sats"
-fn detailed_counts_ui(ui: &mut egui::Ui, stats: &NoteStats) {
+/// Each stat is clickable and navigates to a detail view.
+fn detailed_counts_ui(
+    ui: &mut egui::Ui,
+    note_id: &[u8; 32],
+    stats: &NoteStats,
+) -> Option<NoteAction> {
     let (reposts, reactions) = stats
         .counts
         .as_ref()
@@ -1048,57 +1055,85 @@ fn detailed_counts_ui(ui: &mut egui::Ui, stats: &NoteStats) {
 
     // Only show if there's something to display
     if reposts == 0 && reactions == 0 && zap_sats == 0 {
-        return;
+        return None;
     }
 
     ui.add_space(4.0);
     ui.separator();
 
-    ui.horizontal_wrapped(|ui| {
-        ui.spacing_mut().item_spacing.x = 2.0;
-        let text_color = ui.style().visuals.text_color();
-        let weak_color = ui.style().visuals.weak_text_color();
-        let font_size = 13.0;
-        let spacing = 12.0;
+    let action = ui
+        .horizontal_wrapped(|ui| {
+            ui.spacing_mut().item_spacing.x = 2.0;
+            let text_color = ui.style().visuals.text_color();
+            let weak_color = ui.style().visuals.weak_text_color();
+            let font_size = 13.0;
+            let spacing = 12.0;
 
-        let mut first = true;
+            let mut first = true;
+            let mut action: Option<NoteAction> = None;
 
-        let mut stat = |value: &str, label: &str, pluralize: bool| {
-            if !first {
-                ui.add_space(spacing);
-            }
-            first = false;
+            let mut stat = |ui: &mut egui::Ui, value: &str, label: &str, pluralize: bool| {
+                if !first {
+                    ui.add_space(spacing);
+                }
+                first = false;
 
-            ui.label(
-                egui::RichText::new(value)
-                    .size(font_size)
-                    .strong()
-                    .color(text_color),
-            );
-            ui.label(
-                egui::RichText::new(if pluralize {
+                let label_text = if pluralize {
                     format!("{label}s")
                 } else {
                     label.to_string()
-                })
-                .size(font_size)
-                .color(weak_color),
-            );
-        };
+                };
 
-        if reposts > 0 {
-            stat(&reposts.to_string(), "Repost", reposts != 1);
-        }
-        if reactions > 0 {
-            stat(&reactions.to_string(), "Reaction", reactions != 1);
-        }
-        if zap_sats > 0 {
-            stat(&format_sats_abbreviated(zap_sats), "Sat", zap_sats != 1);
-        }
-    });
+                let r1 = ui.label(
+                    egui::RichText::new(value)
+                        .size(font_size)
+                        .strong()
+                        .color(text_color),
+                );
+                let r2 = ui
+                    .label(
+                        egui::RichText::new(label_text)
+                            .size(font_size)
+                            .color(weak_color),
+                    )
+                    .on_hover_cursor(egui::CursorIcon::PointingHand);
+
+                r1.union(r2)
+            };
+
+            let nid = NoteId::new(*note_id);
+
+            if reposts > 0 {
+                if stat(ui, &reposts.to_string(), "Repost", reposts != 1).clicked() {
+                    action = Some(NoteAction::Detail(NoteDetail::Reposts(nid)));
+                }
+            }
+            if reactions > 0 {
+                if stat(ui, &reactions.to_string(), "Reaction", reactions != 1).clicked() {
+                    action = Some(NoteAction::Detail(NoteDetail::Reactions(nid)));
+                }
+            }
+            if zap_sats > 0 {
+                if stat(
+                    ui,
+                    &format_sats_abbreviated(zap_sats),
+                    "Sat",
+                    zap_sats != 1,
+                )
+                .clicked()
+                {
+                    action = Some(NoteAction::Detail(NoteDetail::Zaps(nid)));
+                }
+            }
+
+            action
+        })
+        .inner;
 
     ui.separator();
     ui.add_space(4.0);
+
+    action
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## Summary

- Add grouped zap notifications in the notification feed -- zap receipts (kind 9735) targeting the same note are clustered into a single unit showing total sats, zapper profile pictures, and descriptive text
- Add zap receipt verification by checking the recipient LNURL endpoint (lud16/lud06), verifying allow_nostr and matching nostr_pubkey
- Fix p-tag spoofing vulnerability on note zaps by resolving the actual author from the referenced note in nostrdb instead of trusting the p-tag
- Add --all-apps-active CLI option to keep all apps processing every frame

## Test plan

- [ ] Verify zap notifications appear grouped in the notification feed
- [ ] Verify zap amounts display correctly with abbreviation (e.g. "5.9K")
- [ ] Verify zap verification works for valid zap receipts
- [ ] Verify spoofed p-tag zap receipts are rejected
- [ ] Verify --all-apps-active flag keeps background apps updating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background verification of zap receipts via LNURL endpoints.
  * Zap receipts shown in timeline, notifications, and a new Note Details page (verified vs unverified senders).
  * New CLI flag to update all apps every frame.

* **Improvements**
  * Timeline groups show aggregated satoshi totals for zap clusters.
  * Note UI adds detailed counts row (clickable counts) and abbreviated sats labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->