### PR TITLE
messages: combine DM relay-list prefetch subscriptions

### DIFF
--- a/crates/md-stream/src/inline.rs
+++ b/crates/md-stream/src/inline.rs
@@ -138,39 +138,37 @@ pub fn parse_inline(text: &str, base_offset: usize) -> Vec<InlineElement> {
             }
 
             // Tilde - potential strikethrough
-            '~' => {
-                if chars.peek().map(|(_, c)| *c == '~').unwrap_or(false) {
-                    chars.next(); // consume second ~
+            '~' if chars.peek().map(|(_, c)| *c == '~').unwrap_or(false) => {
+                chars.next(); // consume second ~
 
-                    // Flush pending text
-                    if i > plain_start {
-                        result.push(InlineElement::Text(Span::new(
-                            base_offset + plain_start,
-                            base_offset + i,
-                        )));
+                // Flush pending text
+                if i > plain_start {
+                    result.push(InlineElement::Text(Span::new(
+                        base_offset + plain_start,
+                        base_offset + i,
+                    )));
+                }
+
+                let content_start = i + 2;
+
+                // Find closing ~~
+                if let Some(end_pos) = text[content_start..].find("~~") {
+                    result.push(InlineElement::Styled {
+                        style: InlineStyle::Strikethrough,
+                        content: Span::new(
+                            base_offset + content_start,
+                            base_offset + content_start + end_pos,
+                        ),
+                    });
+
+                    let skip_to = content_start + end_pos + 2;
+                    while chars.peek().map(|(idx, _)| *idx < skip_to).unwrap_or(false) {
+                        chars.next();
                     }
-
-                    let content_start = i + 2;
-
-                    // Find closing ~~
-                    if let Some(end_pos) = text[content_start..].find("~~") {
-                        result.push(InlineElement::Styled {
-                            style: InlineStyle::Strikethrough,
-                            content: Span::new(
-                                base_offset + content_start,
-                                base_offset + content_start + end_pos,
-                            ),
-                        });
-
-                        let skip_to = content_start + end_pos + 2;
-                        while chars.peek().map(|(idx, _)| *idx < skip_to).unwrap_or(false) {
-                            chars.next();
-                        }
-                        plain_start = skip_to;
-                    } else {
-                        // No closing, revert
-                        plain_start = i;
-                    }
+                    plain_start = skip_to;
+                } else {
+                    // No closing, revert
+                    plain_start = i;
                 }
             }
 
@@ -204,53 +202,53 @@ pub fn parse_inline(text: &str, base_offset: usize) -> Vec<InlineElement> {
             }
 
             // Exclamation - potential image
-            '!' => {
-                if chars.peek().map(|(_, c)| *c == '[').unwrap_or(false) {
-                    // Flush pending text
-                    if i > plain_start {
-                        result.push(InlineElement::Text(Span::new(
-                            base_offset + plain_start,
-                            base_offset + i,
-                        )));
+            '!' if chars.peek().map(|(_, c)| *c == '[').unwrap_or(false) => {
+                // Flush pending text
+                if i > plain_start {
+                    result.push(InlineElement::Text(Span::new(
+                        base_offset + plain_start,
+                        base_offset + i,
+                    )));
+                }
+
+                chars.next(); // consume [
+
+                if let Some((alt_span, url_span, link_len)) =
+                    parse_link(&text[i + 1..], base_offset + i + 1)
+                {
+                    result.push(InlineElement::Image {
+                        alt: alt_span,
+                        url: url_span,
+                    });
+
+                    let skip_to = i + 1 + link_len;
+                    while chars.peek().map(|(idx, _)| *idx < skip_to).unwrap_or(false) {
+                        chars.next();
                     }
-
-                    chars.next(); // consume [
-
-                    if let Some((alt_span, url_span, link_len)) =
-                        parse_link(&text[i + 1..], base_offset + i + 1)
-                    {
-                        result.push(InlineElement::Image {
-                            alt: alt_span,
-                            url: url_span,
-                        });
-
-                        let skip_to = i + 1 + link_len;
-                        while chars.peek().map(|(idx, _)| *idx < skip_to).unwrap_or(false) {
-                            chars.next();
-                        }
-                        plain_start = skip_to;
-                    } else {
-                        // Not a valid image
-                        plain_start = i;
-                    }
+                    plain_start = skip_to;
+                } else {
+                    // Not a valid image
+                    plain_start = i;
                 }
             }
 
             // Newline - could be hard break
-            '\n' => {
+            '\n' if i >= 2 && text[..i].ends_with("  ") => {
                 // Check for hard line break (two spaces before newline)
-                if i >= 2 && text[..i].ends_with("  ") {
-                    // Flush text without trailing spaces
-                    let text_end = i - 2;
-                    if text_end > plain_start {
-                        result.push(InlineElement::Text(Span::new(
-                            base_offset + plain_start,
-                            base_offset + text_end,
-                        )));
-                    }
-                    result.push(InlineElement::LineBreak);
-                    plain_start = i + 1;
+                // Flush text without trailing spaces
+                let text_end = i - 2;
+                if text_end > plain_start {
+                    result.push(InlineElement::Text(Span::new(
+                        base_offset + plain_start,
+                        base_offset + text_end,
+                    )));
                 }
+                result.push(InlineElement::LineBreak);
+                plain_start = i + 1;
+            }
+
+            // Newline - soft line break, keep in text
+            '\n' => {
                 // Otherwise soft line break, keep in text
             }
 

--- a/crates/notedeck/src/unknowns.rs
+++ b/crates/notedeck/src/unknowns.rs
@@ -295,21 +295,19 @@ pub fn get_unknown_note_ids<'a>(
         }
 
         match block.as_mention().unwrap() {
-            Mention::Pubkey(npub) => {
-                if ndb.get_profile_by_pubkey(txn, npub.pubkey()).is_err() {
-                    ids.entry(UnknownId::Pubkey(Pubkey::new(*npub.pubkey())))
-                        .or_default();
-                }
+            Mention::Pubkey(npub) if ndb.get_profile_by_pubkey(txn, npub.pubkey()).is_err() => {
+                ids.entry(UnknownId::Pubkey(Pubkey::new(*npub.pubkey())))
+                    .or_default();
             }
-            Mention::Profile(nprofile) => {
-                if ndb.get_profile_by_pubkey(txn, nprofile.pubkey()).is_err() {
-                    let id = UnknownId::Pubkey(Pubkey::new(*nprofile.pubkey()));
-                    let relays = nprofile
-                        .relays_iter()
-                        .filter_map(|s| RelayUrl::parse(s).ok())
-                        .collect::<HashSet<RelayUrl>>();
-                    ids.entry(id).or_default().extend(relays);
-                }
+            Mention::Profile(nprofile)
+                if ndb.get_profile_by_pubkey(txn, nprofile.pubkey()).is_err() =>
+            {
+                let id = UnknownId::Pubkey(Pubkey::new(*nprofile.pubkey()));
+                let relays = nprofile
+                    .relays_iter()
+                    .filter_map(|s| RelayUrl::parse(s).ok())
+                    .collect::<HashSet<RelayUrl>>();
+                ids.entry(id).or_default().extend(relays);
             }
             Mention::Event(ev) => {
                 let relays = ev

--- a/crates/notedeck_dashboard/src/lib.rs
+++ b/crates/notedeck_dashboard/src/lib.rs
@@ -661,7 +661,7 @@ pub(crate) fn top_kind1_authors_over(cache: &RollingCache, limit: usize) -> Vec<
         }
     }
     let mut v: Vec<_> = agg.into_iter().collect();
-    v.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    v.sort_unstable_by_key(|author| std::cmp::Reverse(author.1));
     v.truncate(limit);
     v
 }

--- a/crates/notedeck_dave/src/lib.rs
+++ b/crates/notedeck_dave/src/lib.rs
@@ -4301,10 +4301,8 @@ pub(crate) fn process_conversation_notes<'a>(
                     }
                 }
             }
-            Some("compaction_started") => {
-                if agentic.compact_intent.is_none() {
-                    agentic.compact_intent = Some(session::CompactIntent::Manual);
-                }
+            Some("compaction_started") if agentic.compact_intent.is_none() => {
+                agentic.compact_intent = Some(session::CompactIntent::Manual);
             }
             Some("compaction_complete") => {
                 let pre_tokens = content.parse::<u64>().unwrap_or(0);

--- a/crates/notedeck_dave/src/session_discovery.rs
+++ b/crates/notedeck_dave/src/session_discovery.rs
@@ -181,7 +181,7 @@ pub fn discover_sessions(cwd: &Path) -> Vec<ResumableSession> {
     }
 
     // Sort by most recent first
-    sessions.sort_by(|a, b| b.last_timestamp.cmp(&a.last_timestamp));
+    sessions.sort_by_key(|session| std::cmp::Reverse(session.last_timestamp));
 
     sessions
 }

--- a/crates/notedeck_dave/src/session_events.rs
+++ b/crates/notedeck_dave/src/session_events.rs
@@ -591,7 +591,7 @@ fn truncate_tool_input(tool_input: &serde_json::Value, max_bytes: usize) -> serd
         .iter()
         .filter_map(|(k, v)| v.as_str().map(|s| (k.as_str(), s.len())))
         .collect();
-    string_fields.sort_by(|a, b| b.1.cmp(&a.1));
+    string_fields.sort_by_key(|field| std::cmp::Reverse(field.1));
 
     if string_fields.is_empty() {
         return tool_input.clone();

--- a/crates/notedeck_dave/src/session_loader.rs
+++ b/crates/notedeck_dave/src/session_loader.rs
@@ -525,7 +525,7 @@ fn load_recent_paths_by_host_with_author(
     }
 
     // Sort by created_at descending (most recent first)
-    entries.sort_by(|a, b| b.2.cmp(&a.2));
+    entries.sort_by_key(|entry| std::cmp::Reverse(entry.2));
 
     // Group by hostname, dedup cwds, cap per host
     let mut result: HashMap<String, Vec<std::path::PathBuf>> = HashMap::new();

--- a/crates/notedeck_dave/src/ui/dave.rs
+++ b/crates/notedeck_dave/src/ui/dave.rs
@@ -628,10 +628,8 @@ impl<'a> DaveUi<'a> {
 
     fn tool_response_ui(tool_response: &ToolResponse, is_agentic: bool, ui: &mut egui::Ui) {
         match tool_response.responses() {
-            ToolResponses::ExecutedTool(result) => {
-                if is_agentic {
-                    Self::executed_tool_ui(result, ui);
-                }
+            ToolResponses::ExecutedTool(result) if is_agentic => {
+                Self::executed_tool_ui(result, ui);
             }
             _ => {
                 //ui.label(format!("tool_response: {:?}", tool_response));

--- a/crates/notedeck_messages/src/cache/conversation.rs
+++ b/crates/notedeck_messages/src/cache/conversation.rs
@@ -25,6 +25,7 @@ pub struct ConversationCache {
     order: Vec<ConversationOrder>,
     pub state: ConversationListState,
     dm_relay_list_ensure: DmListState,
+    dm_relay_list_prefetch: ParticipantRelayPrefetchState,
     pub active: Option<ConversationId>,
     selected_startup_pending: bool,
 }
@@ -114,12 +115,27 @@ impl ConversationCache {
             }
         }
 
-        participants.into_iter().collect()
+        let mut participants: Vec<Pubkey> = participants.into_iter().collect();
+        sort_pubkeys(&mut participants);
+        participants
     }
 
     /// Mutable access to the selected-account DM relay-list ensure state.
     pub fn dm_relay_list_ensure_mut(&mut self) -> &mut DmListState {
         &mut self.dm_relay_list_ensure
+    }
+
+    /// Accumulate participants for the selected-account DM relay-list prefetch declaration.
+    pub(crate) fn extend_dm_relay_list_prefetch_participants(
+        &mut self,
+        participants: &[Pubkey],
+    ) -> bool {
+        self.dm_relay_list_prefetch.extend(participants)
+    }
+
+    /// Deterministic participants for the selected-account DM relay-list prefetch declaration.
+    pub(crate) fn dm_relay_list_prefetch_participants(&self) -> &[Pubkey] {
+        self.dm_relay_list_prefetch.participants()
     }
 
     /// Mark selected-account startup side effects as pending after initial load.
@@ -270,6 +286,7 @@ impl Default for ConversationCache {
             order: Vec::new(),
             state: Default::default(),
             dm_relay_list_ensure: Default::default(),
+            dm_relay_list_prefetch: Default::default(),
             active: None,
             selected_startup_pending: false,
         }
@@ -297,6 +314,43 @@ impl ConversationMetadata {
     }
 }
 
+/// Account-local state for the single participant relay-list prefetch declaration.
+#[derive(Default)]
+struct ParticipantRelayPrefetchState {
+    participants: Vec<Pubkey>,
+    seen: HashSet<Pubkey>,
+}
+
+impl ParticipantRelayPrefetchState {
+    /// Insert new participants and keep the declaration order deterministic.
+    fn extend(&mut self, participants: &[Pubkey]) -> bool {
+        let mut changed = false;
+
+        for participant in participants {
+            if self.seen.insert(*participant) {
+                self.participants.push(*participant);
+                changed = true;
+            }
+        }
+
+        if changed {
+            sort_pubkeys(&mut self.participants);
+        }
+
+        changed
+    }
+
+    /// Return accumulated participants in deterministic order.
+    fn participants(&self) -> &[Pubkey] {
+        &self.participants
+    }
+}
+
+/// Sort pubkeys by raw bytes for stable filter/config serialization.
+fn sort_pubkeys(participants: &mut [Pubkey]) {
+    participants.sort_unstable_by(|a, b| a.bytes().cmp(b.bytes()));
+}
+
 /// Tracks the conversation list initialization and subscription lifecycle.
 #[derive(Default)]
 pub enum ConversationListState {
@@ -310,4 +364,36 @@ pub enum ConversationListState {
     },
     /// Initial load completed; subscription remains active if available.
     Initialized(Option<Subscription>), // conversation list filter
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verifies the account-local relay-list prefetch set accumulates instead of narrowing.
+    #[test]
+    fn relay_list_prefetch_participants_accumulate_after_conversation_subset() {
+        let participant_a = Pubkey::new([0x22; 32]);
+        let participant_b = Pubkey::new([0x11; 32]);
+        let participant_c = Pubkey::new([0x33; 32]);
+        let mut cache = ConversationCache::new();
+
+        assert!(cache.extend_dm_relay_list_prefetch_participants(&[participant_c, participant_a]));
+        assert_eq!(
+            cache.dm_relay_list_prefetch_participants(),
+            &[participant_a, participant_c]
+        );
+
+        assert!(cache.extend_dm_relay_list_prefetch_participants(&[participant_b]));
+        assert_eq!(
+            cache.dm_relay_list_prefetch_participants(),
+            &[participant_b, participant_a, participant_c]
+        );
+
+        assert!(!cache.extend_dm_relay_list_prefetch_participants(&[participant_a]));
+        assert_eq!(
+            cache.dm_relay_list_prefetch_participants(),
+            &[participant_b, participant_a, participant_c]
+        );
+    }
 }

--- a/crates/notedeck_messages/src/lib.rs
+++ b/crates/notedeck_messages/src/lib.rs
@@ -395,7 +395,12 @@ fn ensure_selected_startup(
 
     let account_pubkey = *ctx.accounts.selected_account_pubkey();
     let known_participants = startup_prefetch_participants(ctx.ndb, cache, &account_pubkey);
-    relay_prefetch::ensure_participant_prefetch(&mut ctx.remote, ctx.accounts, &known_participants);
+    relay_prefetch::ensure_participant_prefetch(
+        &mut ctx.remote,
+        ctx.accounts,
+        cache,
+        &known_participants,
+    );
 
     if cache.active.is_none() && !is_narrow {
         if let Some(first) = cache.first_convo_id() {
@@ -490,6 +495,13 @@ fn list_prefetch_owner_key(account_pk: Pubkey) -> SubOwnerKey {
 fn list_ensure_owner_key(account_pk: Pubkey) -> SubOwnerKey {
     SubOwnerKey::builder(RelayListOwner::Ensure)
         .with(account_pk)
+        .finish()
+}
+
+/// Stable account-level key for the participant DM relay-list prefetch stream.
+pub(crate) fn list_prefetch_sub_key() -> SubKey {
+    SubKey::builder(RELAY_LIST_KEY)
+        .with("participant_prefetch")
         .finish()
 }
 

--- a/crates/notedeck_messages/src/nip17/mod.rs
+++ b/crates/notedeck_messages/src/nip17/mod.rs
@@ -179,6 +179,18 @@ pub fn participant_dm_relay_list_filter(participant: &Pubkey) -> Filter {
         .build()
 }
 
+/// Builds one no-limit filter for fetching participants' kind `10050` DM relay lists.
+pub(crate) fn participant_dm_relay_list_prefetch_filter(participants: &[Pubkey]) -> Filter {
+    let mut participants = participants.to_vec();
+    participants.sort_unstable_by(|a, b| a.bytes().cmp(b.bytes()));
+    participants.dedup();
+
+    FilterBuilder::new()
+        .kinds([10050])
+        .authors(participants.iter().map(|participant| participant.bytes()))
+        .build()
+}
+
 /// Returns `true` when `note` is a kind `10050` DM relay-list authored by `participant`.
 pub fn is_participant_dm_relay_list(note: &Note<'_>, participant: &Pubkey) -> bool {
     note.kind() == 10050 && note.pubkey() == participant.bytes()
@@ -416,6 +428,24 @@ mod tests {
             .kinds([10050])
             .authors([participant.bytes()])
             .limit(1)
+            .build();
+
+        assert_eq!(
+            actual.json().expect("actual filter json"),
+            expected.json().expect("expected filter json")
+        );
+    }
+
+    /// Verifies participant relay-list prefetch uses one combined no-limit author filter.
+    #[test]
+    fn participant_dm_relay_list_prefetch_filter_combines_authors_without_limit() {
+        let participant_a = Pubkey::new([0x22; 32]);
+        let participant_b = Pubkey::new([0x33; 32]);
+        let participants = [participant_b, participant_a, participant_b];
+        let actual = participant_dm_relay_list_prefetch_filter(&participants);
+        let expected = FilterBuilder::new()
+            .kinds([10050])
+            .authors([participant_a.bytes(), participant_b.bytes()])
             .build();
 
         assert_eq!(

--- a/crates/notedeck_messages/src/relay_prefetch.rs
+++ b/crates/notedeck_messages/src/relay_prefetch.rs
@@ -1,15 +1,21 @@
 use enostr::Pubkey;
-use notedeck::{Accounts, RemoteApi, ScopedSubApi, ScopedSubIdentity, SubConfig, SubOwnerKey};
+use notedeck::{
+    Accounts, FullHistoryConfig, RemoteApi, ScopedSubApi, ScopedSubIdentity, SubConfig, SubOwnerKey,
+};
 
 use crate::{
     cache::{ConversationCache, ConversationId},
-    list_fetch_sub_key, list_prefetch_owner_key,
-    nip17::participant_dm_relay_list_filter,
+    list_prefetch_owner_key, list_prefetch_sub_key,
+    nip17::participant_dm_relay_list_prefetch_filter,
 };
 
-/// Pure builder for the scoped-sub spec used to prefetch one participant relay list.
-fn participant_relay_prefetch_spec(participant: &Pubkey) -> SubConfig {
-    SubConfig::live(vec![participant_dm_relay_list_filter(participant)]).build()
+/// Pure builder for the scoped-sub spec used to prefetch participant relay lists.
+fn participant_relay_prefetch_spec(participants: &[Pubkey]) -> SubConfig {
+    let filter = participant_dm_relay_list_prefetch_filter(participants);
+
+    SubConfig::live(vec![filter.clone()])
+        .full_history(FullHistoryConfig::new(vec![filter]))
+        .build()
 }
 
 /// Ensures remote prefetch subscriptions for one conversation's participants.
@@ -17,10 +23,13 @@ fn participant_relay_prefetch_spec(participant: &Pubkey) -> SubConfig {
 pub(crate) fn ensure_conversation_prefetch(
     remote: &mut RemoteApi<'_>,
     accounts: &Accounts,
-    cache: &ConversationCache,
+    cache: &mut ConversationCache,
     conversation_id: ConversationId,
 ) {
-    let Some(conversation) = cache.get(conversation_id) else {
+    let Some(participants) = cache
+        .get(conversation_id)
+        .map(|conversation| conversation.metadata.participants.clone())
+    else {
         tracing::debug!(
             "skipping participant relay-list prefetch for missing conversation {conversation_id}"
         );
@@ -29,9 +38,9 @@ pub(crate) fn ensure_conversation_prefetch(
 
     tracing::debug!(
         "ensuring participant relay-list prefetch for conversation {conversation_id} with {} participant(s)",
-        conversation.metadata.participants.len()
+        participants.len()
     );
-    ensure_participant_prefetch(remote, accounts, &conversation.metadata.participants);
+    ensure_participant_prefetch(remote, accounts, cache, &participants);
 }
 
 /// Ensures remote prefetch subscriptions for all provided participants.
@@ -39,13 +48,27 @@ pub(crate) fn ensure_conversation_prefetch(
 pub(crate) fn ensure_participant_prefetch(
     remote: &mut RemoteApi<'_>,
     accounts: &Accounts,
+    cache: &mut ConversationCache,
     participants: &[Pubkey],
 ) {
+    let participants =
+        participant_prefetch_candidates(accounts.selected_account_pubkey(), participants);
+
     if participants.is_empty() {
         tracing::debug!("skipping participant relay-list prefetch for empty participant set");
         return;
     }
 
+    if !cache.extend_dm_relay_list_prefetch_participants(&participants) {
+        tracing::trace!(
+            "skipping unchanged participant relay-list prefetch for selected_account={} participant_count={}",
+            accounts.selected_account_pubkey(),
+            cache.dm_relay_list_prefetch_participants().len()
+        );
+        return;
+    }
+
+    let participants = cache.dm_relay_list_prefetch_participants();
     let account_pk = *accounts.selected_account_pubkey();
     let owner = list_prefetch_owner_key(account_pk);
     tracing::debug!(
@@ -54,23 +77,75 @@ pub(crate) fn ensure_participant_prefetch(
         participants.len()
     );
     let mut scoped_subs = remote.scoped_subs(accounts);
-    ensure_participant_subs(&mut scoped_subs, owner, participants);
+    set_participant_prefetch_sub(&mut scoped_subs, owner, participants);
 }
 
+/// Returns relay-list prefetch candidates, excluding the selected account itself.
+fn participant_prefetch_candidates(
+    selected_account: &Pubkey,
+    participants: &[Pubkey],
+) -> Vec<Pubkey> {
+    let mut candidates: Vec<Pubkey> = participants
+        .iter()
+        .copied()
+        .filter(|participant| participant != selected_account)
+        .collect();
+
+    candidates.sort_unstable_by(|a, b| a.bytes().cmp(b.bytes()));
+    candidates.dedup();
+    candidates
+}
+
+/// Sets the single account-scoped relay-list prefetch declaration.
 #[profiling::function]
-fn ensure_participant_subs(
+fn set_participant_prefetch_sub(
     scoped_subs: &mut ScopedSubApi<'_, '_>,
     owner: SubOwnerKey,
     participants: &[Pubkey],
 ) {
-    for participant in participants {
-        let key = list_fetch_sub_key(participant);
-        let spec = participant_relay_prefetch_spec(participant);
-        let identity = ScopedSubIdentity::account(owner, key);
-        tracing::trace!(
-            "ensuring participant relay-list prefetch sub owner={owner:?} participant={} sub_key={key:?}",
-            participant
+    let key = list_prefetch_sub_key();
+    let spec = participant_relay_prefetch_spec(participants);
+    let identity = ScopedSubIdentity::account(owner, key);
+    tracing::trace!(
+        "setting participant relay-list prefetch sub owner={owner:?} participant_count={} sub_key={key:?}",
+        participants.len()
+    );
+    let _ = scoped_subs.set_sub(identity, spec);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verifies participant relay-list prefetch uses one account-level key.
+    #[test]
+    fn participant_relay_prefetch_sub_key_is_stable_account_level_key() {
+        let participant_a = Pubkey::new([0x22; 32]);
+        let participant_b = Pubkey::new([0x33; 32]);
+
+        assert_eq!(list_prefetch_sub_key(), list_prefetch_sub_key());
+        assert_ne!(
+            list_prefetch_sub_key(),
+            crate::list_fetch_sub_key(&participant_a)
         );
-        let _ = scoped_subs.ensure_sub(identity, spec);
+        assert_ne!(
+            list_prefetch_sub_key(),
+            crate::list_fetch_sub_key(&participant_b)
+        );
+    }
+
+    /// Verifies relay-list prefetch does not request the selected account's own kind `10050`.
+    #[test]
+    fn participant_prefetch_candidates_exclude_selected_account() {
+        let selected = Pubkey::new([0x11; 32]);
+        let participant_a = Pubkey::new([0x33; 32]);
+        let participant_b = Pubkey::new([0x22; 32]);
+
+        let candidates = participant_prefetch_candidates(
+            &selected,
+            &[participant_a, selected, participant_b, participant_a],
+        );
+
+        assert_eq!(candidates, vec![participant_b, participant_a]);
     }
 }

--- a/crates/protoverse/src/parser.rs
+++ b/crates/protoverse/src/parser.rs
@@ -244,13 +244,10 @@ impl<'a> Parser<'a> {
         };
 
         match result {
-            Some(attr) => {
-                if self.eat_close() {
-                    Some(attr)
-                } else {
-                    self.restore(cp);
-                    None
-                }
+            Some(attr) if self.eat_close() => Some(attr),
+            Some(_) => {
+                self.restore(cp);
+                None
             }
             None => {
                 self.restore(cp);
@@ -418,13 +415,10 @@ impl<'a> Parser<'a> {
             .or_else(|| self.try_parse_object());
 
         match id {
-            Some(id) => {
-                if self.eat_close() {
-                    Some(id)
-                } else {
-                    self.restore(cp);
-                    None
-                }
+            Some(id) if self.eat_close() => Some(id),
+            Some(_) => {
+                self.restore(cp);
+                None
             }
             None => {
                 self.restore(cp);


### PR DESCRIPTION
Accumulate known conversation participants per account and update one live/full-history relay-list prefetch subscription instead of declaring one scoped sub per participant.

Changelog-Fixed: Avoid per-participant DM relay-list prefetch subscriptions in Messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved direct-message relay-list prefetching for more efficient, deterministic conversation loading and reduced duplicate work.
* **Improvements**
  * More stable/consistent participant selection and subscription behavior for conversation prefetching.
  * Tighter, more predictable markdown rendering (strikethrough, images, and line-break handling).
  * More consistent sorting for session lists, truncation behavior, and aggregated author rankings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/damus-io/notedeck/pull/1461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->