### PR TITLE
chrome: browser-style app tab strip with notification badges

### DIFF
--- a/crates/notedeck/src/app.rs
+++ b/crates/notedeck/src/app.rs
@@ -32,12 +32,39 @@ pub enum AppAction {
     ToggleChrome,
 }
 
+/// Notification badge state for an app's chrome tab.
+///
+/// Apps report this via [`App::tab_notifications`] so the chrome tab strip can
+/// render a badge (e.g. unread DMs on Messages, items needing input on Dave).
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TabNotifications {
+    /// A count to display in the badge. Zero means no badge.
+    pub count: u32,
+}
+
+impl TabNotifications {
+    /// A badge showing `count`. A count of zero renders no badge.
+    pub fn count(count: u32) -> Self {
+        Self { count }
+    }
+
+    /// Whether there's anything to show.
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+}
+
 pub trait App {
     /// Background processing — called every frame for ALL apps.
     fn update(&mut self, _ctx: &mut AppContext<'_>, _egui_ctx: &egui::Context) {}
 
     /// UI rendering — called only for the active/visible app.
     fn render(&mut self, ctx: &mut AppContext<'_>, ui: &mut egui::Ui) -> AppResponse;
+
+    /// Notification badge state for this app's chrome tab. Defaults to none.
+    fn tab_notifications(&self, _ctx: &AppContext<'_>) -> TabNotifications {
+        TabNotifications::default()
+    }
 }
 
 #[derive(Default)]

--- a/crates/notedeck/src/lib.rs
+++ b/crates/notedeck/src/lib.rs
@@ -67,7 +67,7 @@ pub use account::accounts::{giftwrap_sub_identity, AccountData, Accounts};
 pub use account::contacts::{ContactState, IsFollowing};
 pub use account::relay::{construct_nip65_relays_note, RelayAction};
 pub use account::FALLBACK_PUBKEY;
-pub use app::{App, AppAction, AppResponse, Notedeck};
+pub use app::{App, AppAction, AppResponse, Notedeck, TabNotifications};
 pub use args::Args;
 pub use async_loader::{worker_count, AsyncLoader};
 pub use context::{AppContext, SoftKeyboardContext};

--- a/crates/notedeck_chrome/src/app.rs
+++ b/crates/notedeck_chrome/src/app.rs
@@ -90,4 +90,28 @@ impl notedeck::App for NotedeckApp {
             NotedeckApp::Other(_name, other) => other.render(ctx, ui),
         }
     }
+
+    fn tab_notifications(&self, ctx: &AppContext<'_>) -> notedeck::TabNotifications {
+        match self {
+            NotedeckApp::Dave(dave) => dave.tab_notifications(ctx),
+            NotedeckApp::Columns(columns) => columns.tab_notifications(ctx),
+
+            #[cfg(feature = "notebook")]
+            NotedeckApp::Notebook(notebook) => notebook.tab_notifications(ctx),
+
+            #[cfg(feature = "clndash")]
+            NotedeckApp::ClnDash(clndash) => clndash.tab_notifications(ctx),
+
+            #[cfg(feature = "messages")]
+            NotedeckApp::Messages(dms) => dms.tab_notifications(ctx),
+
+            #[cfg(feature = "dashboard")]
+            NotedeckApp::Dashboard(db) => db.tab_notifications(ctx),
+
+            #[cfg(feature = "nostrverse")]
+            NotedeckApp::Nostrverse(nostrverse) => nostrverse.tab_notifications(ctx),
+
+            NotedeckApp::Other(_name, other) => other.tab_notifications(ctx),
+        }
+    }
 }

--- a/crates/notedeck_chrome/src/chrome.rs
+++ b/crates/notedeck_chrome/src/chrome.rs
@@ -1060,6 +1060,28 @@ fn nth_opened(opened: &[bool], n: usize) -> Option<usize> {
 /// Chrome-browser-style tab strip across the top of the chrome frame. Shows one
 /// tab per *opened* app (`Chrome::opened`); clicking a tab switches the active
 /// app. New apps are opened from the left sidebar.
+/// A subtle separator beneath the tab strip: a faint line that softens into a
+/// short gradient fading up into the tab strip, instead of a hard hairline.
+fn tab_strip_fade(ui: &egui::Ui) {
+    let rect = ui.available_rect_before_wrap();
+    let top = rect.top();
+    let fade_height = 6.0;
+    let (left, right) = (rect.left(), rect.right());
+
+    let base = ui.visuals().widgets.noninteractive.bg_stroke.color;
+    let line = base.gamma_multiply(0.6);
+    let transparent = Color32::TRANSPARENT;
+
+    let mut mesh = egui::Mesh::default();
+    mesh.colored_vertex(egui::pos2(left, top), line);
+    mesh.colored_vertex(egui::pos2(right, top), line);
+    mesh.colored_vertex(egui::pos2(right, top - fade_height), transparent);
+    mesh.colored_vertex(egui::pos2(left, top - fade_height), transparent);
+    mesh.add_triangle(0, 1, 2);
+    mesh.add_triangle(0, 2, 3);
+    ui.painter().add(egui::Shape::mesh(mesh));
+}
+
 fn chrome_app_tabs(chrome: &mut Chrome, loc: &mut Localization, ui: &mut egui::Ui) {
     // disjoint field borrows so the tab closure can read opened flags while
     // mutably rendering app icons (e.g. Dave's avatar)
@@ -1109,7 +1131,7 @@ fn chrome_app_tabs(chrome: &mut Chrome, loc: &mut Localization, ui: &mut egui::U
             });
         });
 
-    notedeck_ui::hline(ui);
+    tab_strip_fade(ui);
 
     // switch active app if a different tab was selected
     let new_sel = tab_res.selected().unwrap_or(sel as i32) as usize;

--- a/crates/notedeck_chrome/src/chrome.rs
+++ b/crates/notedeck_chrome/src/chrome.rs
@@ -450,6 +450,25 @@ impl Chrome {
         }
     }
 
+    /// Cycle the active app to the next (`forward`) or previous opened app,
+    /// wrapping around. Used by Ctrl+Tab / Ctrl+Shift+Tab.
+    fn cycle_app(&mut self, forward: bool) {
+        let n = self.opened.len();
+        if n == 0 {
+            return;
+        }
+        let active = self.active.clamp(0, n as i32 - 1) as usize;
+        let step = if forward { 1 } else { n - 1 };
+        // walk opened slots starting from the one after active, wrapping
+        for offset in 1..=n {
+            let idx = (active + step * offset) % n;
+            if self.opened[idx] {
+                self.set_active(idx as i32);
+                return;
+            }
+        }
+    }
+
     /// The chrome side panel
     #[profiling::function]
     fn panel(
@@ -557,6 +576,23 @@ impl Chrome {
 
         // chrome-style app tab strip, desktop/wide only
         let show_app_tabs = !is_narrow && ctx.settings.welcome_completed();
+
+        // Ctrl+Tab / Ctrl+Shift+Tab cycle through opened app tabs
+        if show_app_tabs {
+            let (mut next, mut prev) = (false, false);
+            ui.input_mut(|i| {
+                prev = i.consume_key(
+                    egui::Modifiers::CTRL | egui::Modifiers::SHIFT,
+                    egui::Key::Tab,
+                );
+                next = i.consume_key(egui::Modifiers::CTRL, egui::Key::Tab);
+            });
+            if prev {
+                self.cycle_app(false);
+            } else if next {
+                self.cycle_app(true);
+            }
+        }
 
         let (unseen_notifications, active_toolbar_tab) = if is_narrow {
             let unseen = self

--- a/crates/notedeck_chrome/src/chrome.rs
+++ b/crates/notedeck_chrome/src/chrome.rs
@@ -22,7 +22,7 @@ use notedeck::Error;
 use notedeck::SoftKeyboardContext;
 use notedeck::{
     tr, App, AppAction, AppContext, Localization, Notedeck, NotedeckOptions, NotedeckTextStyle,
-    UserAccount, WalletType,
+    TabNotifications, UserAccount, WalletType,
 };
 use notedeck_columns::{timeline::TimelineKind, Damus};
 use notedeck_dave::{Dave, DaveAvatar};
@@ -620,7 +620,7 @@ impl Chrome {
                 strip.cell(|ui| {
                     ui.spacing_mut().item_spacing = prev_spacing;
                     if show_app_tabs {
-                        chrome_app_tabs(self, ctx.i18n, ui);
+                        chrome_app_tabs(self, ctx, ui);
                     }
                     action = self.panel(ctx, ui, keyboard_height);
                 });
@@ -1093,9 +1093,6 @@ fn nth_opened(opened: &[bool], n: usize) -> Option<usize> {
         .map(|(i, _)| i)
 }
 
-/// Chrome-browser-style tab strip across the top of the chrome frame. Shows one
-/// tab per *opened* app (`Chrome::opened`); clicking a tab switches the active
-/// app. New apps are opened from the left sidebar.
 /// A subtle separator beneath the tab strip: a faint line that softens into a
 /// short gradient fading up into the tab strip, instead of a hard hairline.
 fn tab_strip_fade(ui: &egui::Ui) {
@@ -1118,7 +1115,62 @@ fn tab_strip_fade(ui: &egui::Ui) {
     ui.painter().add(egui::Shape::mesh(mesh));
 }
 
-fn chrome_app_tabs(chrome: &mut Chrome, loc: &mut Localization, ui: &mut egui::Ui) {
+/// A single tab in the chrome app tab strip: the app it represents, whether
+/// it's the active tab, and any notification badge it wants to show.
+struct ChromeTab<'a> {
+    app: &'a mut NotedeckApp,
+    selected: bool,
+    notifications: TabNotifications,
+}
+
+impl ChromeTab<'_> {
+    fn show(&mut self, loc: &mut Localization, ui: &mut egui::Ui) {
+        ui.horizontal_centered(|ui| {
+            ui.spacing_mut().item_spacing.x = 6.0;
+            tab_app_icon(ui, self.app, 18.0);
+
+            let txt = RichText::new(app_label(loc, self.app));
+            let txt = if self.selected {
+                txt
+            } else {
+                txt.color(ui.visuals().weak_text_color())
+            };
+            ui.add(Label::new(txt).selectable(false));
+
+            tab_notification_badge(ui, self.notifications);
+        });
+    }
+}
+
+/// Render a small pill badge with the notification count, if any.
+fn tab_notification_badge(ui: &mut egui::Ui, notifs: TabNotifications) {
+    if notifs.is_empty() {
+        return;
+    }
+
+    let label = if notifs.count > 99 {
+        "99+".to_owned()
+    } else {
+        notifs.count.to_string()
+    };
+
+    let galley =
+        ui.painter()
+            .layout_no_wrap(label, egui::FontId::proportional(11.0), Color32::WHITE);
+
+    let padding = vec2(5.0, 1.0);
+    let size = galley.size() + padding * 2.0;
+    let (rect, _) = ui.allocate_exact_size(size, Sense::hover());
+    ui.painter()
+        .rect_filled(rect, rect.height() / 2.0, notedeck_ui::colors::PINK);
+    ui.painter()
+        .galley(rect.center() - galley.size() / 2.0, galley, Color32::WHITE);
+}
+
+/// Chrome-browser-style tab strip across the top of the chrome frame. Shows one
+/// tab per *opened* app (`Chrome::opened`); clicking a tab switches the active
+/// app. New apps are opened from the left sidebar.
+fn chrome_app_tabs(chrome: &mut Chrome, ctx: &mut AppContext, ui: &mut egui::Ui) {
     // disjoint field borrows so the tab closure can read opened flags while
     // mutably rendering app icons (e.g. Dave's avatar)
     let opened = &chrome.opened;
@@ -1154,17 +1206,13 @@ fn chrome_app_tabs(chrome: &mut Chrome, loc: &mut Localization, ui: &mut egui::U
                 return;
             };
 
-            ui.horizontal_centered(|ui| {
-                ui.spacing_mut().item_spacing.x = 6.0;
-                tab_app_icon(ui, &mut apps[app_idx], 18.0);
-                let txt = RichText::new(app_label(loc, &apps[app_idx]));
-                let txt = if state.is_selected() {
-                    txt
-                } else {
-                    txt.color(ui.visuals().weak_text_color())
-                };
-                ui.add(Label::new(txt).selectable(false));
-            });
+            let notifications = apps[app_idx].tab_notifications(ctx);
+            ChromeTab {
+                app: &mut apps[app_idx],
+                selected: state.is_selected(),
+                notifications,
+            }
+            .show(ctx.i18n, ui);
         });
 
     tab_strip_fade(ui);

--- a/crates/notedeck_chrome/src/chrome.rs
+++ b/crates/notedeck_chrome/src/chrome.rs
@@ -555,6 +555,9 @@ impl Chrome {
             0.0
         };
 
+        // chrome-style app tab strip, desktop/wide only
+        let show_app_tabs = !is_narrow && ctx.settings.welcome_completed();
+
         let (unseen_notifications, active_toolbar_tab) = if is_narrow {
             let unseen = self
                 .get_columns_app()
@@ -580,6 +583,9 @@ impl Chrome {
                 // the actual content, shifted up because of the soft keyboard
                 strip.cell(|ui| {
                     ui.spacing_mut().item_spacing = prev_spacing;
+                    if show_app_tabs {
+                        chrome_app_tabs(self, ctx.i18n, ui);
+                    }
                     action = self.panel(ctx, ui, keyboard_height);
                 });
 
@@ -964,6 +970,156 @@ fn dave_button(avatar: Option<&mut DaveAvatar>, ui: &mut egui::Ui, rect: Rect) -
     }
 }
 
+/// The localized display name for a notedeck app, used in the sidebar and the
+/// chrome tab strip.
+fn app_label(loc: &mut Localization, app: &NotedeckApp) -> String {
+    match app {
+        NotedeckApp::Dave(_) => tr!(loc, "Dave", "Button to go to the Dave app"),
+        NotedeckApp::Columns(_) => tr!(loc, "Columns", "Button to go to the Columns app"),
+
+        #[cfg(feature = "messages")]
+        NotedeckApp::Messages(_) => tr!(loc, "Messaging", "Button to go to the messaging app"),
+
+        #[cfg(feature = "dashboard")]
+        NotedeckApp::Dashboard(_) => tr!(loc, "Dashboard", "Button to go to the dashboard app"),
+
+        #[cfg(feature = "notebook")]
+        NotedeckApp::Notebook(_) => tr!(loc, "Notebook", "Button to go to the Notebook app"),
+
+        #[cfg(feature = "clndash")]
+        NotedeckApp::ClnDash(_) => tr!(loc, "ClnDash", "Button to go to the ClnDash app"),
+
+        #[cfg(feature = "nostrverse")]
+        NotedeckApp::Nostrverse(_) => tr!(loc, "Nostrverse", "Button to go to the Nostrverse app"),
+
+        NotedeckApp::Other(name, _) => tr!(loc, name.as_str(), "Button to go to a WASM app"),
+    }
+}
+
+/// Render a small (`size` square) app icon for the chrome tab strip.
+fn tab_app_icon(ui: &mut egui::Ui, app: &mut NotedeckApp, size: f32) {
+    match app {
+        NotedeckApp::Columns(_) => {
+            ui.add(app_images::columns_image().max_width(size).max_height(size));
+        }
+
+        NotedeckApp::Dave(dave) => {
+            let (rect, _) = ui.allocate_exact_size(vec2(size, size), Sense::hover());
+            dave_button(dave.avatar_mut(), ui, rect);
+        }
+
+        #[cfg(feature = "dashboard")]
+        NotedeckApp::Dashboard(_) => {
+            ui.add(app_images::algo_image().max_width(size).max_height(size));
+        }
+
+        #[cfg(feature = "messages")]
+        NotedeckApp::Messages(_) => {
+            ui.add(
+                app_images::new_message_image()
+                    .max_width(size)
+                    .max_height(size),
+            );
+        }
+
+        #[cfg(feature = "clndash")]
+        NotedeckApp::ClnDash(_) => {
+            ui.add(app_images::cln_image().max_width(size).max_height(size));
+        }
+
+        #[cfg(feature = "notebook")]
+        NotedeckApp::Notebook(_) => {
+            ui.add(app_images::algo_image().max_width(size).max_height(size));
+        }
+
+        #[cfg(feature = "nostrverse")]
+        NotedeckApp::Nostrverse(_) => {
+            ui.add(
+                app_images::universe_image()
+                    .max_width(size)
+                    .max_height(size),
+            );
+        }
+
+        NotedeckApp::Other(_name, _) => {
+            ui.label("W");
+        }
+    }
+}
+
+/// The app index of the `n`th opened app (the app backing the `n`th tab).
+fn nth_opened(opened: &[bool], n: usize) -> Option<usize> {
+    opened
+        .iter()
+        .enumerate()
+        .filter(|(_, o)| **o)
+        .nth(n)
+        .map(|(i, _)| i)
+}
+
+/// Chrome-browser-style tab strip across the top of the chrome frame. Shows one
+/// tab per *opened* app (`Chrome::opened`); clicking a tab switches the active
+/// app. New apps are opened from the left sidebar.
+fn chrome_app_tabs(chrome: &mut Chrome, loc: &mut Localization, ui: &mut egui::Ui) {
+    // disjoint field borrows so the tab closure can read opened flags while
+    // mutably rendering app icons (e.g. Dave's avatar)
+    let opened = &chrome.opened;
+    let apps = &mut chrome.apps;
+
+    // the active app is always opened, so there is always at least one tab
+    let n_tabs = opened.iter().filter(|o| **o).count();
+    if n_tabs == 0 {
+        return;
+    }
+
+    // the selected tab is the number of opened apps before the active app
+    let active = chrome.active.max(0) as usize;
+    let sel = opened.iter().take(active).filter(|o| **o).count();
+
+    ui.spacing_mut().item_spacing.y = 0.0;
+
+    // egui_tabs keys its selection on `ui.id().with("tabs")` and prefers temp
+    // data over `.selected()`, so overwrite it each frame to stay in sync with
+    // app switches that happen elsewhere (e.g. the sidebar).
+    let tabs_id = ui.id().with("tabs");
+    ui.ctx().data_mut(|d| d.insert_temp(tabs_id, sel as i32));
+
+    let tab_res = egui_tabs::Tabs::new(n_tabs as i32)
+        .selected(sel as i32)
+        .hover_bg(egui_tabs::TabColor::none())
+        .selected_fg(egui_tabs::TabColor::none())
+        .selected_bg(egui_tabs::TabColor::none())
+        .height(30.0)
+        .layout(Layout::centered_and_justified(egui::Direction::TopDown))
+        .show(ui, |ui, state| {
+            let Some(app_idx) = nth_opened(opened, state.index() as usize) else {
+                return;
+            };
+
+            ui.horizontal_centered(|ui| {
+                ui.spacing_mut().item_spacing.x = 6.0;
+                tab_app_icon(ui, &mut apps[app_idx], 18.0);
+                let txt = RichText::new(app_label(loc, &apps[app_idx]));
+                let txt = if state.is_selected() {
+                    txt
+                } else {
+                    txt.color(ui.visuals().weak_text_color())
+                };
+                ui.add(Label::new(txt).selectable(false));
+            });
+        });
+
+    notedeck_ui::hline(ui);
+
+    // switch active app if a different tab was selected
+    let new_sel = tab_res.selected().unwrap_or(sel as i32) as usize;
+    if let Some(app_idx) = nth_opened(&chrome.opened, new_sel) {
+        if app_idx as i32 != chrome.active {
+            chrome.set_active(app_idx as i32);
+        }
+    }
+}
+
 pub fn get_profile_url_owned(profile: Option<ProfileRecord<'_>>) -> &str {
     if let Some(url) = profile.and_then(|pr| pr.record().profile().and_then(|p| p.picture())) {
         url
@@ -1323,37 +1479,7 @@ fn topdown_sidebar(
             continue;
         }
 
-        let text = match &app {
-            NotedeckApp::Dave(_) => tr!(loc, "Dave", "Button to go to the Dave app"),
-            NotedeckApp::Columns(_) => tr!(loc, "Columns", "Button to go to the Columns app"),
-
-            #[cfg(feature = "messages")]
-            NotedeckApp::Messages(_) => {
-                tr!(loc, "Messaging", "Button to go to the messaging app")
-            }
-
-            #[cfg(feature = "dashboard")]
-            NotedeckApp::Dashboard(_) => {
-                tr!(loc, "Dashboard", "Button to go to the dashboard app")
-            }
-
-            #[cfg(feature = "notebook")]
-            NotedeckApp::Notebook(_) => {
-                tr!(loc, "Notebook", "Button to go to the Notebook app")
-            }
-
-            #[cfg(feature = "clndash")]
-            NotedeckApp::ClnDash(_) => tr!(loc, "ClnDash", "Button to go to the ClnDash app"),
-
-            #[cfg(feature = "nostrverse")]
-            NotedeckApp::Nostrverse(_) => {
-                tr!(loc, "Nostrverse", "Button to go to the Nostrverse app")
-            }
-
-            NotedeckApp::Other(name, _) => {
-                tr!(loc, name.as_str(), "Button to go to a WASM app")
-            }
-        };
+        let text = app_label(loc, app);
 
         StripBuilder::new(ui)
             .size(Size::exact(40.0))

--- a/crates/notedeck_dave/src/focus_queue.rs
+++ b/crates/notedeck_dave/src/focus_queue.rs
@@ -249,6 +249,14 @@ impl FocusQueue {
             .any(|e| e.priority == FocusPriority::NeedsInput)
     }
 
+    /// Count the entries with NeedsInput priority
+    pub fn needs_input_count(&self) -> usize {
+        self.entries
+            .iter()
+            .filter(|e| e.priority == FocusPriority::NeedsInput)
+            .count()
+    }
+
     /// Find the first entry with Done priority and return its index
     pub fn first_done_index(&self) -> Option<usize> {
         self.entries

--- a/crates/notedeck_dave/src/lib.rs
+++ b/crates/notedeck_dave/src/lib.rs
@@ -3975,6 +3975,10 @@ impl notedeck::App for Dave {
 
         AppResponse::action(app_action)
     }
+
+    fn tab_notifications(&self, _ctx: &AppContext<'_>) -> notedeck::TabNotifications {
+        notedeck::TabNotifications::count(self.focus_queue.needs_input_count() as u32)
+    }
 }
 
 /// Bring the application to the front.

--- a/crates/notedeck_messages/src/cache/conversation.rs
+++ b/crates/notedeck_messages/src/cache/conversation.rs
@@ -47,6 +47,11 @@ impl ConversationCache {
         self.conversations.get(&id)
     }
 
+    /// Iterate over conversations by id.
+    pub fn iter(&self) -> impl Iterator<Item = (&ConversationId, &Conversation)> {
+        self.conversations.iter()
+    }
+
     pub fn get_id_by_index(&self, i: usize) -> Option<&ConversationId> {
         Some(&self.order.get(i)?.id)
     }

--- a/crates/notedeck_messages/src/lib.rs
+++ b/crates/notedeck_messages/src/lib.rs
@@ -13,6 +13,7 @@ use nav::{process_messages_ui_response, Route};
 use nostrdb::{Ndb, Subscription, Transaction};
 use notedeck::{
     ui::is_narrow, Accounts, App, AppContext, AppResponse, RemoteApi, Router, SubKey, SubOwnerKey,
+    TabNotifications,
 };
 
 use crate::{
@@ -165,6 +166,25 @@ impl App for MessagesApp {
 
         AppResponse::action(processed.app_action)
     }
+
+    fn tab_notifications(&self, ctx: &AppContext<'_>) -> TabNotifications {
+        let Some(cache) = self.messages.get_current(ctx.accounts) else {
+            return TabNotifications::default();
+        };
+        let states = self
+            .states
+            .for_account(ctx.accounts.selected_account_pubkey());
+        let unread = cache
+            .iter()
+            .filter(|(id, convo)| {
+                let last_read = states
+                    .and_then(|s| s.cache.get(id))
+                    .and_then(|s| s.last_read);
+                crate::ui::ConversationSummary::new(convo, last_read).unread
+            })
+            .count();
+        TabNotifications::count(unread as u32)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -190,6 +210,10 @@ struct ConversationStatesByAccount {
 impl ConversationStatesByAccount {
     fn for_account_mut(&mut self, account: &Pubkey) -> &mut ConversationStates {
         self.states.entry(*account).or_default()
+    }
+
+    fn for_account(&self, account: &Pubkey) -> Option<&ConversationStates> {
+        self.states.get(account)
     }
 }
 
@@ -558,6 +582,12 @@ impl ConversationsCtx {
     /// Get an existing conversation cache for an account-addressed async result.
     pub fn get_mut(&mut self, account: &Pubkey) -> Option<&mut ConversationCache> {
         self.convos_per_acc.get_mut(account)
+    }
+
+    /// Read-only conversation cache for the selected account, if one exists.
+    pub fn get_current(&self, accounts: &Accounts) -> Option<&ConversationCache> {
+        accounts.get_selected_account().keypair().secret_key?;
+        self.convos_per_acc.get(accounts.selected_account_pubkey())
     }
 }
 


### PR DESCRIPTION
Adds a Chrome-browser-style tab strip across the top of the notedeck chrome for switching between opened apps, plus notification badges.

Closes #1475

## What's here

- **Top tab strip** (desktop/wide only): one tab per *opened* app (built from `Chrome::opened`), the active app shown in default text color and the rest weak-colored. Clicking a tab switches the active app. The left sidebar remains the launcher for not-yet-opened apps. Reuses the existing `egui_tabs` widget (equal-width split for now).
- **Soft separator**: the strip's bottom edge is a faint line that fades up into the tabs rather than a hard hairline.
- **Keyboard cycling**: `Ctrl+Tab` / `Ctrl+Shift+Tab` cycle to the next/previous opened app, wrapping around and skipping unopened apps. Keys are consumed so egui focus navigation doesn't also grab them.
- **Notification badges**: a new `TabNotifications` type and `App::tab_notifications` trait method let apps report a count for their tab. Messages reports unread conversations; Dave reports sessions awaiting input; other apps default to none. Counts are rendered as a small pill badge (`99+` cap), computed per-frame with no per-frame Vec allocation.

## Notes

- Mobile keeps its existing bottom toolbar; the tab strip is `!is_narrow` only.
- No close (×) buttons in this pass.
- Constrained (non-full-width) tab widths are left for a later change to the `egui-tabs` crate.

## Testing

- `./scripts/ci.py lint` passes (fmt + clippy).
- `cargo check` clean across all chrome features (`messages,notebook,dashboard,clndash,nostrverse`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notification badges to app tabs displaying activity counts (unread messages, sessions needing input, etc.)
  * Introduced a desktop app tab strip for easy visual navigation between apps
  * Added keyboard shortcuts (Ctrl+Tab / Ctrl+Shift+Tab) to cycle through apps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->