### PR TITLE
enostr: enable TLS for the tokio websocket backend

### DIFF
--- a/crates/enostr/Cargo.toml
+++ b/crates/enostr/Cargo.toml
@@ -7,10 +7,14 @@ edition = "2021"
 
 [features]
 default = ["tokio-websocket"]
-tokio-websocket = ["ewebsock/tokio"]
+# ewebsock/tls only enables TLS for ewebsock's blocking tungstenite backend.
+# The tokio backend connects via tokio-tungstenite, which needs its own TLS
+# feature, otherwise wss:// fails with "TLS support not compiled in".
+tokio-websocket = ["ewebsock/tokio", "tokio-tungstenite/rustls-tls-webpki-roots"]
 
 [dependencies]
 ewebsock = { version = "0.8.0", features = ["tls"] }
+tokio-tungstenite = { workspace = true, optional = true }
 serde_derive = { workspace = true }
 serde = { workspace = true, features = ["derive"] } # You only need this if you want app persistence
 serde_json = { workspace = true }

--- a/crates/notedeck_columns/src/ui/repost.rs
+++ b/crates/notedeck_columns/src/ui/repost.rs
@@ -117,7 +117,7 @@ fn repost_item_text(text: &str) -> impl egui::Widget + use<'_> {
 
 pub fn quote_icon() -> impl egui::Widget {
     move |ui: &mut egui::Ui| -> egui::Response {
-        let h = 32.0; // scaling constant
+        let h = 32.0_f32; // scaling constant
         let color = ui.visuals().strong_text_color();
         let r = h * 0.12; // dot radius
         let arc_r = r * 2.0; // larger so it protrudes above


### PR DESCRIPTION
## Problem

After switching enostr's default to ewebsock's **tokio** websocket backend (commit c726f46f, "chore(deps): pin negentropy transport prerequisites"), all `wss://` relay connections fail:

```
ERROR enostr::relay::coordinator: relay wss://relay.damus.io/ error: "URL error: TLS support not compiled in"
```

`ewebsock`'s `tls` feature only enables TLS for its **blocking** tungstenite backend (`tungstenite/rustls-tls-webpki-roots`). The tokio backend connects via `tokio-tungstenite`, and no crate in the workspace enables a TLS feature on it — so the tokio path has no TLS connector and every secure relay is rejected at connect time. (NIP-11 metadata fetches still work because they use a separate HTTP client, which can mask the issue.)

## Fix

Enable `tokio-tungstenite`'s `rustls-tls-webpki-roots` feature as part of the `tokio-websocket` feature. This matches the rustls + webpki-roots stack `ewebsock` already pulls in for its blocking backend, so no additional TLS stack is introduced. `ewebsock` pins `tokio-tungstenite` to 0.24 (same as the workspace), so Cargo feature unification applies the TLS connector to ewebsock's tokio backend.

## Verification

Before: every `wss://` relay → `"TLS support not compiled in"`, blank timelines.
After: TLS errors gone, relays connect (e.g. nos.lol, relay.coinos.io, relay.primal.net). Remaining failures are purely relay-side (nostr.wine 403 paid-relay auth, transient 502/503s).

## Note

Also includes a small unrelated build fix: `columns: fix ambiguous float type in repost icon` — `let h = 32.0;` was ambiguous and broke `.max()` on newer rustc (E0689 via the `float_literal_f32_fallback` future-compat change). Happy to split this into its own PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS support for websocket connections, helping secure connections work more reliably in the Tokio backend.
  * Added a small rendering type fix in the repost UI to keep drawing behavior consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->