### PR TITLE
test(ci): isolate notedeck_notebook snapshot tests on Windows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,12 @@ jobs:
         run: ${{ inputs.additional-setup }}
 
       - name: Run Tests (Native Only)
-        run: cargo test --workspace --exclude notedeck_columns --exclude notedeck_dave --exclude notedeck_messages
+        run: cargo test --workspace --exclude notedeck_columns --exclude notedeck_dave --exclude notedeck_messages --exclude notedeck_notebook
+        env:
+          CI: true
+
+      - name: Run notedeck_notebook Tests
+        run: cargo test -p notedeck_notebook -- --test-threads=1
         env:
           CI: true
 


### PR DESCRIPTION
## Problem

The `Test (Windows) / run` job crashed with `snapshot_tests-*.exe (exit code: 0xc0000005, STATUS_ACCESS_VIOLATION)` — a native process death, **not** a test panic: no assertion failed and no per-test result was printed. Linux and macOS were green (this is why PR #1497 was merged with Windows red — it's a non-required check).

## Root cause

Concurrent execution inside the parallel `cargo test --workspace` step. `notedeck_notebook`'s non-ignored `snapshot_tests` are heavyweight interactive `egui_kittest` e2e cases (drag, connect edges, create/edit longform, rename, delete) that each spin up a full `Notedeck` + `Harness` and loop `run_ok` + 25ms sleeps over asynchronous PNS-crypto nostrdb ingest.

That is the **same class of suite already isolated** for the other heavyweight harness crates, each fixed the same way:

- `notedeck_dave` — c29f2d58c09d ("test(ci): isolate Dave tests on Windows")
- `notedeck_columns` e2e — 36eb6b4d0e08 ("test(ci): isolate Columns e2e on Windows")
- `notedeck_messages` e2e — fd311b265de9 ("Run messages E2E serially in CI")

`notedeck_notebook` was the last such suite still running inside the parallel workspace step. The lighter single-snapshot harness suites (chrome/dashboard/headway/horizon) finish in ms and don't hit the race window.

## Fix

Exclude `notedeck_notebook` from the broad workspace test step and run it in its own `--test-threads=1` step, matching the established Dave/Columns/Messages model. Coverage is unchanged — the lavapipe snapshot cases stay ignored.

Verified green locally on Linux: 28 lib + 7 non-ignored snapshot tests pass, 7 lavapipe tests ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated testing to run the `notedeck_notebook` package separately and sequentially.
  * Adjusted workspace test coverage to prevent duplicate execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->