### PR TITLE
feat: Add outbox support for threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5283,7 +5283,7 @@ dependencies = [
 [[package]]
 name = "nostrdb"
 version = "0.10.0"
-source = "git+https://github.com/damus-io/nostrdb-rs?rev=c23591d5edaa#c23591d5edaa6094dc5da080c94f3c930d074aa8"
+source = "git+https://github.com/kernelkind/nostrdb-rs?rev=3df041f92670#3df041f9267006858aa737740467d30575c150b5"
 dependencies = [
  "bindgen 0.69.5",
  "cc",
@@ -5299,7 +5299,7 @@ dependencies = [
 [[package]]
 name = "nostrdb_net"
 version = "0.1.0"
-source = "git+https://github.com/damus-io/nostrdb-rs?rev=c23591d5edaa#c23591d5edaa6094dc5da080c94f3c930d074aa8"
+source = "git+https://github.com/kernelkind/nostrdb-rs?rev=3df041f92670#3df041f9267006858aa737740467d30575c150b5"
 dependencies = [
  "base64 0.22.1",
  "bech32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,9 +83,9 @@ md5 = "0.7.0"
 nostr = { version = "0.37.0", default-features = false, features = ["std", "nip44", "nip49"] }
 nwc = "0.39.0"
 mio = { version = "1.0.3", features = ["os-poll", "net"] }
-nostrdb = { git = "https://github.com/damus-io/nostrdb-rs", rev = "c23591d5edaa" }
+nostrdb = { git = "https://github.com/kernelkind/nostrdb-rs", rev = "3df041f92670" }
 #nostrdb = "0.6.1"
-nostrdb_net = { git = "https://github.com/damus-io/nostrdb-rs", rev = "c23591d5edaa" }
+nostrdb_net = { git = "https://github.com/kernelkind/nostrdb-rs", rev = "3df041f92670" }
 notedeck = { path = "crates/notedeck" }
 notedeck_chrome = { path = "crates/notedeck_chrome" }
 notedeck_clndash = { path = "crates/notedeck_clndash" }

--- a/crates/enostr/src/relay/identity.rs
+++ b/crates/enostr/src/relay/identity.rs
@@ -512,6 +512,47 @@ fn valid_dns_label(label: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
 }
 
+/// Remote relay hints may identify a websocket endpoint below the domain root.
+/// Percent-encoded bytes and strings resembling another URL remain path data;
+/// for example, `nostramsterdam.vpx.moewss` remains the parsed authority below.
+#[test]
+fn remote_advertised_policy_allows_bounded_websocket_paths() {
+    for endpoint in [
+        "wss://basspistol.org/inbox".to_owned(),
+        "wss://relay.example.com/path".to_owned(),
+        "wss://relay.example.com/path%0b".to_owned(),
+        "wss://relay.example.com/path%20with-space".to_owned(),
+        "wss://nostramsterdam.vpx.moewss//nostr.primz.org".to_owned(),
+        "wss://rsslay.wss//relay.nostr.info%0b%20nostr.net".to_owned(),
+        format!("wss://relay.example.com/{}", "a".repeat(2048 - 24)),
+    ] {
+        let relay = NormRelayUrl::new(&endpoint).expect("valid websocket endpoint");
+        assert!(
+            relay.allowed_for_source(RelayUrlSource::RemoteAdvertised),
+            "remote-advertised websocket endpoint should be allowed: {endpoint}"
+        );
+    }
+}
+
+/// Accepting endpoint paths must preserve relay URL credentials and host checks.
+#[test]
+fn remote_advertised_paths_preserve_url_restrictions() {
+    for endpoint in [
+        "wss://user:pass@relay.example.com/inbox".to_owned(),
+        "wss://relay.example.com/inbox?token=secret".to_owned(),
+        "wss://relay.example.com/inbox#fragment".to_owned(),
+        "ws://127.0.0.1:7777/inbox".to_owned(),
+        "ws://relay.local/inbox".to_owned(),
+        format!("wss://relay.example.com/{}", "a".repeat(2049 - 24)),
+    ] {
+        let relay = NormRelayUrl::new(&endpoint).expect("syntactically valid endpoint");
+        assert!(
+            !relay.allowed_for_source(RelayUrlSource::RemoteAdvertised),
+            "remote-advertised websocket endpoint should be rejected: {endpoint}"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -601,13 +642,8 @@ mod tests {
             "wss://user@relay.example.com",
             "wss://user:pass@relay.example.com",
             "wss://relay.example.com/#fragment",
-            "wss://relay.example.com/path",
             "wss://relay.example.com/?q=relay",
-            "wss://relay.example.com/path%0b",
-            "wss://relay.example.com/path%20with-space",
             "wss://relay.example.com/?q=%7f",
-            "wss://nostramsterdam.vpx.moewss//nostr.primz.org",
-            "wss://rsslay.wss//relay.nostr.info%0b%20nostr.net",
         ] {
             let relay = NormRelayUrl::new(url).expect("syntactically valid relay URL");
             assert!(

--- a/crates/enostr/src/relay/identity.rs
+++ b/crates/enostr/src/relay/identity.rs
@@ -461,8 +461,12 @@ fn canonicalize_url(url: String) -> String {
     }
 }
 
+/// Accept bounded WebSocket endpoint paths without changing URL authority.
+/// Credentials, fragments, and queries retain the remote-advertised restrictions;
+/// host eligibility is checked separately after normal URL parsing.
 fn remote_advertised_url_parts_allowed(url: &Url) -> bool {
-    if !url.username().is_empty()
+    if url.as_str().len() > 2048
+        || !url.username().is_empty()
         || url.password().is_some()
         || url.fragment().is_some()
         || url.query().is_some()
@@ -470,7 +474,7 @@ fn remote_advertised_url_parts_allowed(url: &Url) -> bool {
         return false;
     }
 
-    url.path() == "/"
+    true
 }
 
 fn public_domain_host_allowed(domain: &str) -> bool {

--- a/crates/enostr/src/relay/ws.rs
+++ b/crates/enostr/src/relay/ws.rs
@@ -20,6 +20,7 @@ use tokio::net::TcpStream;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::handshake::client::Request;
+use tokio_tungstenite::tungstenite::http::{header::USER_AGENT, HeaderValue};
 use tokio_tungstenite::tungstenite::Message as TMessage;
 use tokio_tungstenite::{client_async_tls, MaybeTlsStream, WebSocketStream};
 
@@ -37,6 +38,8 @@ const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(2);
 /// A vanished *route* is caught instantly by the interface watcher instead;
 /// this backstops the rarer "peer silently dead, route still up" case.
 const KEEPALIVE_RETRIES: u32 = 2;
+/// Stable client identity sent during relay websocket handshakes.
+const ENOSTR_USER_AGENT: &str = "enostr";
 
 /// A websocket data frame exchanged with a relay.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -103,11 +106,14 @@ where
 {
     // Validate the request synchronously so a malformed URL fails on the
     // spot, matching the previous connect contract.
-    let request = url.into_client_request().map_err(|err| {
+    let mut request = url.into_client_request().map_err(|err| {
         Error::WebSocket(WebSocketError::new(format!(
             "invalid relay url {url}: {err}"
         )))
     })?;
+    request
+        .headers_mut()
+        .insert(USER_AGENT, HeaderValue::from_static(ENOSTR_USER_AGENT));
 
     let (out_tx, out_rx) = tokio::sync::mpsc::unbounded_channel::<WsEvent>();
     let (in_tx, in_rx) = tokio::sync::mpsc::unbounded_channel::<WsMessage>();

--- a/crates/notedeck/Cargo.toml
+++ b/crates/notedeck/Cargo.toml
@@ -24,6 +24,7 @@ eframe = { workspace = true }
 image = { workspace = true }
 base32 = { workspace = true }
 poll-promise = { workspace = true }
+futures-util = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 serde_json = { workspace = true }
@@ -82,7 +83,6 @@ tempfile = { workspace = true }
 tokio = { workspace = true, features = ["net", "sync", "time"] }
 nostr-relay-builder = "0.37"
 tokio-tungstenite = { workspace = true }
-futures-util = { workspace = true }
 
 [dependencies.egui_kittest]
 workspace = true

--- a/crates/notedeck/DEVELOPER.md
+++ b/crates/notedeck/DEVELOPER.md
@@ -115,6 +115,12 @@ Read/setup failures back off from 100 ms, doubling up to 60 seconds; a successfu
 snapshot with subscription coverage resets the delay.
 Relay-list discovery uses the existing `RelayListDiscovery` requests and remains
 alive while ancestry changes. Usable routes do not wait for discovery EOSE.
+Both author-filter and thread discovery query the selected read relays plus the
+configured bootstrap set. Missing ancestors without a claimed author also get
+exact-ID one-shots on bootstrap relays outside the selected read set. These
+are explicit configured-relay requests, not remote-advertised hints; ordinary
+account reads stay unchanged. Forced-relay configuration disables the additional
+bootstrap coverage, and an injected empty bootstrap set remains empty.
 NDB does not notify when an already-stored note gains another observed relay;
 that metadata is picked up on the next snapshot rebuild.
 

--- a/crates/notedeck/DEVELOPER.md
+++ b/crates/notedeck/DEVELOPER.md
@@ -75,6 +75,54 @@ pub enum FilterState {
 }
 ```
 
+#### Thread outbox subscriptions
+
+Columns declares a thread with the existing scoped subscription API:
+
+```rust,ignore
+SubConfig::builder(root_filters)
+    .accounts_read_important()
+    .with_author_outbox_augmentation()
+    .for_thread(root_id, selected_note_ids)
+    .build()
+```
+
+The filters still request replies to the root and the root itself. The selected
+IDs are additional planning inputs, not an `authors` restriction. Owners of the
+same thread share their selected IDs under the existing account-scoped key.
+
+`AuthorOutboxPlanRuntime` uses the existing background job runner to walk available
+NIP-10 ancestry. `RelayDirectorySnapshot` resolves the authors' write relays, just
+as it does for author-filter subscriptions. Observed relays and relay hints add
+coverage. Missing ancestors are requested by exact event ID; a tag's claimed
+author only helps find relays and cannot exclude the actual event author.
+
+Author-filter and thread jobs have distinct input variants. A thread job reads
+one ancestry snapshot and returns its routes and encountered IDs/authors; it
+does not create subscriptions or reread ancestry to catch up with ingestion.
+
+After completion, `AuthorOutboxPlanRuntime` subscribes to those IDs and authors'
+kind-10002 events. Installing new or expanded subscription coverage schedules
+another job to catch arrivals that preceded subscription setup. The completed
+plan remains usable while that job runs. With unchanged coverage, the runtime
+retains the same subscription and its queued arrivals.
+
+An NDB `SubscriptionStream` wakes the bridge when relevant data arrives; healthy
+threads have no polling timer. Notifications remain queued while a job runs,
+then can cause the next job to be scheduled. Timers are used only for failed
+planning/subscription attempts and existing relay-list discovery retries.
+Read/setup failures back off from 100 ms, doubling up to 60 seconds; a successful
+snapshot with subscription coverage resets the delay.
+Relay-list discovery uses the existing `RelayListDiscovery` requests and remains
+alive while ancestry changes. Usable routes do not wait for discovery EOSE.
+NDB does not notify when an already-stored note gains another observed relay;
+that metadata is picked up on the next snapshot rebuild.
+
+Closing the last owner or switching away from the account releases the watch,
+ancestor fetch, and unfinished relay-list discovery. Disabling outbox replaces
+the declaration with ordinary selected-account coverage. `UnknownIds` and the
+bridge's selected-account one-shot API are unchanged.
+
 ## Development Workflow
 
 ### Setting Up Your Environment

--- a/crates/notedeck/DEVELOPER.md
+++ b/crates/notedeck/DEVELOPER.md
@@ -123,6 +123,10 @@ ancestor fetch, and unfinished relay-list discovery. Disabling outbox replaces
 the declaration with ordinary selected-account coverage. `UnknownIds` and the
 bridge's selected-account one-shot API are unchanged.
 
+The regression tests in `columns_e2e.rs` run the real host, scoped subscriptions,
+relay transport, and NDB against local WebSocket relays, including late ancestor
+and relay-list arrival. They are not interactive GUI verification.
+
 ## Development Workflow
 
 ### Setting Up Your Environment

--- a/crates/notedeck/src/account/accounts.rs
+++ b/crates/notedeck/src/account/accounts.rs
@@ -479,6 +479,19 @@ impl Accounts {
         )
     }
 
+    /// Additional bootstrap coverage for relay lists and authorless missing events.
+    /// Forced relays override this coverage; an injected empty set stays empty.
+    pub(crate) fn discovery_bootstrap_relays(&self) -> HashSet<NormRelayUrl> {
+        if !self.relay_defaults.forced_relays.is_empty() {
+            return HashSet::new();
+        }
+        self.relay_defaults
+            .bootstrap_relays
+            .iter()
+            .map(|relay| relay.url.clone())
+            .collect()
+    }
+
     /// Return the selected account's advertised NIP-65 relays with marker metadata.
     pub fn selected_account_advertised_relays(
         &self,

--- a/crates/notedeck/src/account/accounts.rs
+++ b/crates/notedeck/src/account/accounts.rs
@@ -826,6 +826,69 @@ mod tests {
         _job_pool: JobPool,
     }
 
+    /// Injected metadata defaults respect forced relays without changing account reads.
+    #[test]
+    fn discovery_bootstrap_respects_overrides_and_preserves_account_reads() {
+        let read = NormRelayUrl::new("wss://account-read.example.com").expect("read relay");
+        let bootstrap =
+            NormRelayUrl::new("wss://injected-bootstrap.example.com").expect("bootstrap relay");
+        let forced = NormRelayUrl::new("wss://forced.example.com").expect("forced relay");
+        for (force, inject_bootstrap, configure_read) in [
+            (false, true, true),
+            (true, true, true),
+            (false, false, true),
+            (false, false, false),
+        ] {
+            let tmp = TempDir::new().expect("temp dir");
+            let mut ndb =
+                Ndb::new(tmp.path().to_str().expect("path"), &Config::new()).expect("ndb");
+            let txn = Transaction::new(&ndb).expect("transaction");
+            let forced_relays = if force {
+                vec![forced.to_string()]
+            } else {
+                Vec::new()
+            };
+            let bootstrap_relays = if inject_bootstrap {
+                vec![bootstrap.to_string()]
+            } else {
+                Vec::new()
+            };
+            let mut accounts = Accounts::new(
+                None,
+                forced_relays,
+                bootstrap_relays,
+                FALLBACK_PUBKEY(),
+                &mut ndb,
+                &txn,
+                &mut UnknownIds::default(),
+            );
+            if configure_read {
+                accounts
+                    .cache
+                    .selected_mut()
+                    .data
+                    .relay
+                    .advertised
+                    .insert(RelaySpec::new(read.clone(), true, false));
+            }
+            let expected_reads = if force {
+                HashSet::from([forced.clone()])
+            } else if configure_read {
+                HashSet::from([read.clone()])
+            } else {
+                HashSet::new()
+            };
+            let expected_bootstrap = if inject_bootstrap && !force {
+                HashSet::from([bootstrap.clone()])
+            } else {
+                HashSet::new()
+            };
+            assert_eq!(accounts.selected_account_read_relays(), expected_reads);
+            assert_eq!(accounts.discovery_bootstrap_relays(), expected_bootstrap);
+            assert_eq!(accounts.selected_account_read_relays(), expected_reads);
+        }
+    }
+
     impl AccountRemoteHarness {
         fn new() -> Self {
             Self::with_forced_relays(Vec::new())

--- a/crates/notedeck/src/author_outbox/mod.rs
+++ b/crates/notedeck/src/author_outbox/mod.rs
@@ -1,6 +1,7 @@
 mod directory;
 mod planner;
 mod routing;
+pub(crate) mod thread;
 
 pub(crate) use directory::{RelayDirectoryRead, RelayDirectorySnapshot, RelayDirectoryState};
 pub(crate) use planner::{

--- a/crates/notedeck/src/author_outbox/thread.rs
+++ b/crates/notedeck/src/author_outbox/thread.rs
@@ -1,0 +1,78 @@
+use enostr::{NormRelayUrl, NoteId, Pubkey, RelayUrlSource};
+use hashbrown::HashSet;
+use nostrdb::{Error, Ndb, NoteReply, Transaction};
+
+/// Thread ancestry and routing information read in one NostrDB transaction.
+///
+/// Missing references remain in `note_ids` so a subscription can observe their
+/// later arrival. Authors named by root/reply tags are routing hints only; they
+/// do not restrict the authors of events requested from relays.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ThreadSnapshot {
+    /// Every selected note, root, and reply parent encountered during traversal.
+    pub(crate) note_ids: HashSet<NoteId>,
+    /// Authors of available notes and authors claimed by their root/reply tags.
+    pub(crate) authors: HashSet<Pubkey>,
+    /// Referenced notes absent from this database snapshot.
+    pub(crate) missing_ids: HashSet<NoteId>,
+    /// Allowed observed relays and NIP-10 root/reply relay hints.
+    pub(crate) relays: HashSet<NormRelayUrl>,
+}
+
+impl ThreadSnapshot {
+    /// Traverse available root/reply ancestry without recursion or UI work.
+    ///
+    /// Each ID is visited once, including missing IDs and cyclic references.
+    /// Mentions and other unrelated tags do not contribute routing information.
+    #[profiling::function]
+    pub(crate) fn load(ndb: &Ndb, seeds: &HashSet<NoteId>) -> Result<Self, Error> {
+        let txn = Transaction::new(ndb)?;
+        let mut snapshot = Self::default();
+        let mut pending = seeds.iter().copied().collect::<Vec<_>>();
+        while let Some(id) = pending.pop() {
+            if !snapshot.note_ids.insert(id) {
+                continue;
+            }
+
+            let note = match ndb.get_note_by_id(&txn, id.bytes()) {
+                Ok(note) => note,
+                Err(Error::NotFound) => {
+                    snapshot.missing_ids.insert(id);
+                    continue;
+                }
+                Err(err) => return Err(err),
+            };
+            snapshot.authors.insert(Pubkey::new(*note.pubkey()));
+            for relay in note.relays(&txn) {
+                snapshot.retain_relay(relay);
+            }
+
+            let reply = NoteReply::new(note.tags());
+            for reference in [reply.root(), reply.reply()].into_iter().flatten() {
+                pending.push(NoteId::new(*reference.id));
+                if let Some(relay) = reference.relay {
+                    snapshot.retain_relay(relay);
+                }
+                if let Some(author) = note
+                    .tags()
+                    .into_iter()
+                    .nth(usize::from(reference.index))
+                    .and_then(|tag| tag.get_id(4))
+                {
+                    snapshot.authors.insert(Pubkey::new(*author));
+                }
+            }
+        }
+        Ok(snapshot)
+    }
+
+    /// Keep normalized relay hints under the existing remote-advertised policy.
+    fn retain_relay(&mut self, relay: &str) {
+        let Ok(relay) = NormRelayUrl::new(relay) else {
+            return;
+        };
+        if relay.allowed_for_source(RelayUrlSource::RemoteAdvertised) {
+            self.relays.insert(relay);
+        }
+    }
+}

--- a/crates/notedeck/src/author_outbox/thread.rs
+++ b/crates/notedeck/src/author_outbox/thread.rs
@@ -76,3 +76,73 @@ impl ThreadSnapshot {
         }
     }
 }
+
+#[test]
+fn thread_snapshot_retains_missing_parents_and_their_routing_hints() {
+    use enostr::{NormRelayUrl, NoteId, Pubkey};
+    use hashbrown::HashSet;
+    use nostrdb::{Config, IngestMetadata, Ndb, NoteBuilder, Transaction};
+    use std::time::{Duration, Instant};
+
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let ndb = Ndb::new(tmp.path().to_str().expect("path"), &Config::new()).expect("ndb");
+    let root_id = NoteId::new([11; 32]);
+    let parent_id = NoteId::new([12; 32]);
+    let root_author = Pubkey::new([2; 32]);
+    let parent_author = Pubkey::new([3; 32]);
+    let selected = NoteBuilder::new()
+        .kind(1)
+        .created_at(1)
+        .content("selected reply")
+        .start_tag()
+        .tag_str("e")
+        .tag_id(root_id.bytes())
+        .tag_str("wss://root.example.com")
+        .tag_str("root")
+        .tag_id(root_author.bytes())
+        .start_tag()
+        .tag_str("e")
+        .tag_id(parent_id.bytes())
+        .tag_str("wss://parent.example.com")
+        .tag_str("reply")
+        .tag_id(parent_author.bytes())
+        .sign(&[1; 32])
+        .build()
+        .expect("selected note");
+    ndb.process_event_with(
+        &selected.json().expect("json"),
+        IngestMetadata::new()
+            .client(true)
+            .relay("wss://observed.example.com"),
+    )
+    .expect("ingest selected note");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let txn = Transaction::new(&ndb).expect("txn");
+        if ndb.get_note_by_id(&txn, selected.id()).is_ok() {
+            break;
+        }
+        assert!(Instant::now() < deadline, "selected note was not ingested");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    let selected_id = NoteId::new(*selected.id());
+    let snapshot = ThreadSnapshot::load(&ndb, &HashSet::from([selected_id])).expect("snapshot");
+    assert_eq!(
+        snapshot.note_ids,
+        HashSet::from([selected_id, root_id, parent_id])
+    );
+    assert_eq!(snapshot.missing_ids, HashSet::from([root_id, parent_id]));
+    assert_eq!(
+        snapshot.authors,
+        HashSet::from([Pubkey::new(*selected.pubkey()), root_author, parent_author])
+    );
+    assert_eq!(
+        snapshot.relays,
+        HashSet::from([
+            NormRelayUrl::new("wss://root.example.com").expect("relay"),
+            NormRelayUrl::new("wss://parent.example.com").expect("relay"),
+            NormRelayUrl::new("wss://observed.example.com").expect("relay"),
+        ])
+    );
+}

--- a/crates/notedeck/src/author_outbox/thread.rs
+++ b/crates/notedeck/src/author_outbox/thread.rs
@@ -88,6 +88,90 @@ impl ThreadSnapshot {
 }
 
 #[test]
+fn thread_snapshot_uses_all_references_to_identify_missing_ids_without_authors() {
+    use nostrdb::{Config, NoteBuilder};
+    use std::time::{Duration, Instant};
+
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let ndb = Ndb::new(tmp.path().to_str().expect("path"), &Config::new()).expect("ndb");
+    let first = NoteId::new([11; 32]);
+    let second = NoteId::new([12; 32]);
+    let unclaimed = NoteId::new([13; 32]);
+    let missing_seed = NoteId::new([14; 32]);
+    let claimed_author = Pubkey::new([2; 32]);
+    let mut seeds = HashSet::from([missing_seed]);
+    let mut inserted = Vec::new();
+    for (created_at, root_author, reply_author) in [(1, true, false), (2, false, true)] {
+        let mut builder = NoteBuilder::new()
+            .kind(1)
+            .created_at(created_at)
+            .content("references share missing ancestors")
+            .start_tag()
+            .tag_str("e")
+            .tag_id(first.bytes())
+            .tag_str("")
+            .tag_str("root");
+        if root_author {
+            builder = builder.tag_id(claimed_author.bytes());
+        }
+        builder = builder
+            .start_tag()
+            .tag_str("e")
+            .tag_id(second.bytes())
+            .tag_str("")
+            .tag_str("reply");
+        if reply_author {
+            builder = builder.tag_id(claimed_author.bytes());
+        }
+        let note = builder.sign(&[1; 32]).build().expect("note");
+        let id = NoteId::new(*note.id());
+        seeds.insert(id);
+        inserted.push(id);
+        ndb.process_client_event(&note.json().expect("json"))
+            .expect("ingest note");
+    }
+    let unclaimed_ref = NoteBuilder::new()
+        .kind(1)
+        .created_at(3)
+        .content("ancestor without claimed author")
+        .start_tag()
+        .tag_str("e")
+        .tag_id(unclaimed.bytes())
+        .tag_str("")
+        .tag_str("reply")
+        .sign(&[1; 32])
+        .build()
+        .expect("note");
+    let unclaimed_ref_id = NoteId::new(*unclaimed_ref.id());
+    seeds.insert(unclaimed_ref_id);
+    inserted.push(unclaimed_ref_id);
+    ndb.process_client_event(&unclaimed_ref.json().expect("json"))
+        .expect("ingest note");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let txn = Transaction::new(&ndb).expect("txn");
+        if inserted
+            .iter()
+            .all(|id| ndb.get_note_by_id(&txn, id.bytes()).is_ok())
+        {
+            break;
+        }
+        assert!(Instant::now() < deadline, "notes were not ingested");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    let snapshot = ThreadSnapshot::load(&ndb, &seeds).expect("snapshot");
+    assert_eq!(
+        snapshot.missing_ids,
+        HashSet::from([first, second, unclaimed, missing_seed])
+    );
+    assert_eq!(
+        snapshot.missing_ids_without_author,
+        HashSet::from([unclaimed, missing_seed])
+    );
+}
+
+#[test]
 fn thread_snapshot_retains_missing_parents_and_their_routing_hints() {
     use enostr::{NormRelayUrl, NoteId, Pubkey};
     use hashbrown::HashSet;

--- a/crates/notedeck/src/author_outbox/thread.rs
+++ b/crates/notedeck/src/author_outbox/thread.rs
@@ -15,6 +15,8 @@ pub(crate) struct ThreadSnapshot {
     pub(crate) authors: HashSet<Pubkey>,
     /// Referenced notes absent from this database snapshot.
     pub(crate) missing_ids: HashSet<NoteId>,
+    /// Missing IDs with no claimed author on any encountered root/reply reference.
+    pub(crate) missing_ids_without_author: HashSet<NoteId>,
     /// Allowed observed relays and NIP-10 root/reply relay hints.
     pub(crate) relays: HashSet<NormRelayUrl>,
 }
@@ -28,6 +30,7 @@ impl ThreadSnapshot {
     pub(crate) fn load(ndb: &Ndb, seeds: &HashSet<NoteId>) -> Result<Self, Error> {
         let txn = Transaction::new(ndb)?;
         let mut snapshot = Self::default();
+        let mut ids_with_claimed_authors = HashSet::new();
         let mut pending = seeds.iter().copied().collect::<Vec<_>>();
         while let Some(id) = pending.pop() {
             if !snapshot.note_ids.insert(id) {
@@ -60,9 +63,16 @@ impl ThreadSnapshot {
                     .and_then(|tag| tag.get_id(4))
                 {
                     snapshot.authors.insert(Pubkey::new(*author));
+                    ids_with_claimed_authors.insert(NoteId::new(*reference.id));
                 }
             }
         }
+        // Another reference may name an author after this missing ID was visited.
+        snapshot.missing_ids_without_author = snapshot
+            .missing_ids
+            .difference(&ids_with_claimed_authors)
+            .copied()
+            .collect();
         Ok(snapshot)
     }
 

--- a/crates/notedeck/src/network.rs
+++ b/crates/notedeck/src/network.rs
@@ -13,6 +13,8 @@ use hyper_util::{
 use url::Url;
 
 const MAX_BODY_BYTES: usize = 20 * 1024 * 1024;
+/// Stable client identity sent with outbound HTTP requests.
+const NOTEDECK_USER_AGENT: &str = "notedeck";
 
 type HyperClient = Client<HttpsConnector<HttpConnector>, Empty<Bytes>>;
 
@@ -102,7 +104,8 @@ async fn http_req_with_client(
         // Fetch the url...
         let mut req_builder = Request::builder()
             .uri(current_uri.clone())
-            .header(hyper::header::HOST, authority.as_str());
+            .header(hyper::header::HOST, authority.as_str())
+            .header(hyper::header::USER_AGENT, NOTEDECK_USER_AGENT);
         if let Some(accept) = accept {
             req_builder = req_builder.header(hyper::header::ACCEPT, accept);
         }

--- a/crates/notedeck/src/remote_api.rs
+++ b/crates/notedeck/src/remote_api.rs
@@ -134,6 +134,7 @@ impl<'a> RemoteApi<'a> {
             accounts.selected_account_read_relays(),
             accounts.selected_account_write_relays(),
         )
+        .with_bootstrap_relays(accounts.discovery_bootstrap_relays())
     }
 }
 

--- a/crates/notedeck/src/remote_data/remote_bridge.rs
+++ b/crates/notedeck/src/remote_data/remote_bridge.rs
@@ -300,6 +300,8 @@ pub(crate) struct BridgeAccountState {
     selected_pubkey: Pubkey,
     read_relays: HashSet<NormRelayUrl>,
     write_relays: Vec<RelayId>,
+    /// Configured discovery coverage, already restricted by forced-relay policy.
+    bootstrap_relays: HashSet<NormRelayUrl>,
 }
 
 impl BridgeAccountState {
@@ -312,7 +314,14 @@ impl BridgeAccountState {
             selected_pubkey,
             read_relays,
             write_relays,
+            bootstrap_relays: HashSet::new(),
         }
+    }
+
+    /// Add host-configured discovery relays without changing account reads or writes.
+    pub(crate) fn with_bootstrap_relays(mut self, relays: HashSet<NormRelayUrl>) -> Self {
+        self.bootstrap_relays = relays;
+        self
     }
 
     fn selected_pubkey(&self) -> Pubkey {
@@ -1135,6 +1144,9 @@ impl<'a> RemoteBridge<'a> {
     }
 
     fn apply_account_changed(&mut self, account: BridgeAccountState) -> ScopedSubDelta {
+        self.settlement
+            .scoped
+            .set_bootstrap_relays(&account.bootstrap_relays);
         let previous = self.accounts.replace(account);
         let new_pubkey = self.account_state().selected_pubkey();
         let new_read_relays = self.account_state().read_relays().clone();
@@ -1142,7 +1154,10 @@ impl<'a> RemoteBridge<'a> {
             Some(previous) if previous.selected_pubkey() != new_pubkey => {
                 self.apply_scoped_account_switched(previous.selected_pubkey(), new_pubkey)
             }
-            Some(previous) if previous.read_relays() != &new_read_relays => {
+            Some(previous)
+                if previous.read_relays() != &new_read_relays
+                    || previous.bootstrap_relays != self.account_state().bootstrap_relays =>
+            {
                 self.apply_scoped_account_read_relays_changed(new_pubkey)
             }
             None => self.apply_scoped_account_initialized(new_pubkey),

--- a/crates/notedeck/src/remote_data/remote_bridge.rs
+++ b/crates/notedeck/src/remote_data/remote_bridge.rs
@@ -363,7 +363,7 @@ pub(crate) enum RemotePublishCommand {
 enum BridgeActorInput {
     Ui(RemoteIntentBatch),
     SetMaxWebsocketConnections(Option<usize>),
-    AuthorOutboxPlanCompleted(AuthorOutboxPlanJobCompletion),
+    AuthorOutboxPlanCompleted(Box<AuthorOutboxPlanJobCompletion>),
     AuthorOutboxDiscoveryRetryDue,
     Shutdown,
 }
@@ -392,7 +392,9 @@ impl AuthorOutboxEffectRunner {
             move || request.run(ndb),
             move |completion| {
                 if inputs
-                    .send(BridgeActorInput::AuthorOutboxPlanCompleted(completion))
+                    .send(BridgeActorInput::AuthorOutboxPlanCompleted(Box::new(
+                        completion,
+                    )))
                     .is_err()
                 {
                     tracing::debug!(
@@ -780,8 +782,7 @@ async fn run_remote_bridge(
             input = inputs.recv() => {
                 input.unwrap_or(BridgeActorInput::Shutdown)
             }
-            output = actor.settlement.next() => {
-                let actions = actor.settlement.settle_outbox_output(output);
+            actions = actor.settlement.next() => {
                 actor.run_settlement_actions(actions);
                 continue;
             }
@@ -810,8 +811,16 @@ impl BridgeOutboxSettlement {
         self.scoped.next_author_outbox_retry_deadline()
     }
 
-    fn next(&mut self) -> impl Future<Output = OutboxServiceOutput> + '_ {
-        self.outbox.next()
+    /// Settle the next network output or matching NDB arrival without a timer.
+    /// Cancelling this wait leaves both services and their subscriptions owned.
+    async fn next(&mut self) -> Vec<BridgeSettlementAction> {
+        tokio::select! {
+            output = self.outbox.next() => self.settle_outbox_output(output),
+            slot_id = self.scoped.next_author_outbox_thread_change() => {
+                let delta = self.scoped.apply_author_outbox_thread_change(slot_id);
+                self.settle_scoped_delta(delta)
+            }
+        }
     }
 
     fn apply_scoped_account_initialized(&mut self, pubkey: Pubkey) -> ScopedSubDelta {
@@ -852,11 +861,13 @@ impl BridgeOutboxSettlement {
         selected_account_pubkey: Pubkey,
         account_read_relays: &HashSet<NormRelayUrl>,
         completion: AuthorOutboxPlanJobCompletion,
+        ndb: &Ndb,
     ) -> Vec<BridgeSettlementAction> {
         let delta = self.scoped.apply_author_outbox_plan_completed(
             selected_account_pubkey,
             account_read_relays,
             completion,
+            ndb,
         );
         self.settle_scoped_delta(delta)
     }
@@ -1004,6 +1015,8 @@ impl BridgeOutboxSettlement {
 struct RemoteBridge<'a> {
     settlement: BridgeOutboxSettlement,
     author_outbox_effects: AuthorOutboxEffectRunner,
+    /// Database used to install watches after background plan completion.
+    ndb: &'a Ndb,
     events: &'a RemoteBridgeEventSink,
     accounts: Option<BridgeAccountState>,
 }
@@ -1029,6 +1042,7 @@ impl<'a> RemoteBridge<'a> {
         Self {
             settlement,
             author_outbox_effects,
+            ndb,
             events,
             accounts: None,
         }
@@ -1045,7 +1059,7 @@ impl<'a> RemoteBridge<'a> {
                 .settlement
                 .apply_max_websocket_connections(max_connections),
             BridgeActorInput::AuthorOutboxPlanCompleted(completion) => {
-                self.apply_author_outbox_plan_completed(completion)
+                self.apply_author_outbox_plan_completed(*completion)
             }
             BridgeActorInput::AuthorOutboxDiscoveryRetryDue => {
                 self.settlement.apply_author_outbox_discovery_retry_due()
@@ -1183,6 +1197,7 @@ impl<'a> RemoteBridge<'a> {
             selected_account_pubkey,
             &account_read_relays,
             completion,
+            self.ndb,
         )
     }
 }

--- a/crates/notedeck/src/remote_data/tests.rs
+++ b/crates/notedeck/src/remote_data/tests.rs
@@ -637,6 +637,377 @@ async fn publish_accounts_write_broadcasts_to_selected_account_write_relays() {
     assert!(frame.contains("publish account-write"));
 }
 
+/// Missing author metadata is fetched from bootstrap before the parent is
+/// requested by exact ID from that author's advertised write relay.
+#[tokio::test]
+async fn bridge_thread_discovers_author_on_bootstrap_then_fetches_parent_from_write_relay() {
+    use serde_json::{json, Value};
+
+    // Each relay serves its one event only for the exact filter under test.
+    let handler = |expected: Value, event: Value| {
+        move || {
+            let expected = expected.clone();
+            let event = event.clone();
+            move |text: &str| {
+                let Ok(Value::Array(request)) = serde_json::from_str::<Value>(text) else {
+                    return CaptureRelayResponse::none();
+                };
+                if request.first().and_then(Value::as_str) != Some("REQ") {
+                    return CaptureRelayResponse::none();
+                }
+                let Some(sub_id) = request.get(1).and_then(Value::as_str) else {
+                    return CaptureRelayResponse::none();
+                };
+                let mut response = Vec::new();
+                if request[2..].contains(&expected) {
+                    response.push(json!(["EVENT", sub_id, event]).to_string());
+                }
+                response.push(json!(["EOSE", sub_id]).to_string());
+                CaptureRelayResponse {
+                    send_text: response,
+                    close: false,
+                }
+            }
+        }
+    };
+    let user = FullKeypair::generate();
+    let author = FullKeypair::generate();
+    let parent = NoteBuilder::new()
+        .kind(1)
+        .content("parent only on write relay")
+        .created_at(1)
+        .sign(&author.secret_key.secret_bytes())
+        .build()
+        .expect("parent");
+    let parent_filter = json!({"ids": [hex::encode(parent.id())]});
+    let (_write_task, write_relay, write_frames, write_notify) =
+        create_filtered_capture_relay_with_handler(
+            |_| true,
+            handler(
+                parent_filter.clone(),
+                serde_json::from_str(&parent.json().expect("json")).expect("event"),
+            ),
+        )
+        .await;
+    // Match the existing Columns local-relay setup without relaxing URL policy.
+    let mut write_url = url::Url::parse(write_relay.as_str()).expect("write URL");
+    write_url
+        .set_host(Some("localhost.localdomain"))
+        .expect("local hostname");
+    let advertised_write = NormRelayUrl::new(write_url.as_str()).expect("advertised relay");
+    assert!(advertised_write.allowed_for_source(enostr::RelayUrlSource::RemoteAdvertised));
+    let write_spec = crate::RelaySpec::new(advertised_write, false, true);
+    let author_list = crate::construct_nip65_relays_note([&write_spec])
+        .created_at(2)
+        .sign(&author.secret_key.secret_bytes())
+        .build()
+        .expect("author list");
+    let list_filter = json!({"authors": [author.pubkey.hex()], "kinds": [10002]});
+    let (_bootstrap_task, bootstrap, bootstrap_frames, bootstrap_notify) =
+        create_filtered_capture_relay_with_handler(
+            |_| true,
+            handler(
+                list_filter.clone(),
+                serde_json::from_str(&author_list.json().expect("json")).expect("event"),
+            ),
+        )
+        .await;
+    let (read_url, _, _) = create_text_capture_relay().await;
+    let read = NormRelayUrl::new(&read_url).expect("read relay");
+    let read_spec = crate::RelaySpec::new(read.clone(), true, false);
+    let account_list = crate::construct_nip65_relays_note([&read_spec])
+        .created_at(2)
+        .sign(&user.secret_key.secret_bytes())
+        .build()
+        .expect("account list");
+    let child = NoteBuilder::new()
+        .kind(1)
+        .content("selected child")
+        .created_at(3)
+        .start_tag()
+        .tag_str("e")
+        .tag_id(parent.id())
+        .tag_str("")
+        .tag_str("reply")
+        .tag_id(author.pubkey.bytes())
+        .sign(&user.secret_key.secret_bytes())
+        .build()
+        .expect("child");
+    let (_tmp, mut ndb) = test_ndb();
+    let job_pool = JobPool::new(1);
+    let mut remote = test_remote_state(&ndb, &job_pool);
+    for note in [&account_list, &child] {
+        ndb.process_client_event(&note.json().expect("json"))
+            .expect("seed local context");
+    }
+    wait_for_condition(
+        &mut remote,
+        Duration::from_secs(2),
+        None,
+        "local context",
+        |_| {
+            let txn = Transaction::new(&ndb).ok()?;
+            [&account_list, &child]
+                .iter()
+                .all(|note| ndb.get_note_by_id(&txn, note.id()).is_ok())
+                .then_some(())
+        },
+    )
+    .await;
+    let accounts = {
+        let txn = Transaction::new(&ndb).expect("txn");
+        assert!(ndb.get_note_by_id(&txn, parent.id()).is_err());
+        assert!(ndb.get_note_by_id(&txn, author_list.id()).is_err());
+        Accounts::new(
+            None,
+            Vec::new(),
+            vec![bootstrap.to_string()],
+            user.pubkey,
+            &mut ndb,
+            &txn,
+            &mut UnknownIds::default(),
+        )
+    };
+    assert_eq!(
+        accounts.selected_account_read_relays(),
+        hashbrown::HashSet::from([read])
+    );
+    assert_eq!(
+        accounts.discovery_bootstrap_relays(),
+        hashbrown::HashSet::from([bootstrap])
+    );
+    let identity = ScopedSubIdentity::global(
+        SubOwnerKey::new("bridge/bootstrap-author"),
+        SubKey::new("thread"),
+    );
+    let config = SubConfig::builder(vec![Filter::new()
+        .kinds([1])
+        .event(parent.id())
+        .limit(250)
+        .build()])
+    .accounts_read_important()
+    .with_author_outbox_augmentation()
+    .for_thread(NoteId::new(*parent.id()), [NoteId::new(*child.id())])
+    .build();
+    {
+        let mut api = remote.api();
+        api.on_selected_account_changed(&accounts);
+        assert_eq!(
+            api.scoped_subs(&accounts).ensure_sub(identity, config),
+            EnsureSubResult::Created
+        );
+        api.flush();
+    }
+    let list_request = wait_for_frame(
+        &mut remote,
+        &bootstrap_frames,
+        &bootstrap_notify,
+        "author relay-list REQ on bootstrap",
+        |text| {
+            let Ok(Value::Array(request)) = serde_json::from_str::<Value>(text) else {
+                return false;
+            };
+            request.first().and_then(Value::as_str) == Some("REQ")
+                && request.get(2) == Some(&list_filter)
+        },
+    )
+    .await;
+    let list_request: Value = serde_json::from_str(&list_request).expect("request");
+    assert_eq!(list_request.as_array().expect("request").len(), 3);
+    let _ = wait_for_frame(
+        &mut remote,
+        &write_frames,
+        &write_notify,
+        "parent exact-ID REQ on discovered write relay",
+        |text| {
+            let Ok(Value::Array(request)) = serde_json::from_str::<Value>(text) else {
+                return false;
+            };
+            request.first().and_then(Value::as_str) == Some("REQ")
+                && request[2..].contains(&parent_filter)
+        },
+    )
+    .await;
+    wait_for_condition(
+        &mut remote,
+        Duration::from_secs(3),
+        None,
+        "network parent ingestion",
+        |_| {
+            let txn = Transaction::new(&ndb).ok()?;
+            ndb.get_note_by_id(&txn, author_list.id()).ok()?;
+            ndb.get_note_by_id(&txn, parent.id()).ok().map(|_| ())
+        },
+    )
+    .await;
+    assert!(
+        bootstrap_frames.lock().expect("frames").iter().all(|text| {
+            let Ok(Value::Array(request)) = serde_json::from_str::<Value>(text) else {
+                return true;
+            };
+            request.first().and_then(Value::as_str) != Some("REQ")
+                || request[2..] == [list_filter.clone()]
+        }),
+        "known-author parent must not be fetched from metadata-only bootstrap"
+    );
+}
+
+/// An explicit bootstrap relay can supply an authorless missing parent, without
+/// receiving the thread's root/reply filters in the parent request.
+#[tokio::test]
+async fn bridge_thread_fetches_authorless_parent_from_bootstrap_by_exact_id() {
+    use serde_json::{json, Value};
+
+    let parent = signed_text_note("parent only on bootstrap", 1);
+    let parent_filter = json!({"ids": [hex::encode(parent.id())]});
+    let event: Value = serde_json::from_str(&parent.json().expect("json")).expect("event");
+    let expected = parent_filter.clone();
+    let (_bootstrap_task, bootstrap, captured, notify) =
+        create_filtered_capture_relay_with_handler(
+            |_| true,
+            move || {
+                let expected = expected.clone();
+                let event = event.clone();
+                move |text: &str| {
+                    let Ok(Value::Array(request)) = serde_json::from_str::<Value>(text) else {
+                        return CaptureRelayResponse::none();
+                    };
+                    if request.first().and_then(Value::as_str) != Some("REQ") {
+                        return CaptureRelayResponse::none();
+                    }
+                    let Some(sub_id) = request.get(1).and_then(Value::as_str) else {
+                        return CaptureRelayResponse::none();
+                    };
+                    // No broad request, relay-list request, or extra filter can obtain the parent.
+                    let mut response = Vec::new();
+                    if request[2..] == [expected.clone()] {
+                        response.push(json!(["EVENT", sub_id, event]).to_string());
+                    }
+                    response.push(json!(["EOSE", sub_id]).to_string());
+                    CaptureRelayResponse {
+                        send_text: response,
+                        close: false,
+                    }
+                }
+            },
+        )
+        .await;
+    let (read_url, _, _) = create_text_capture_relay().await;
+    let read = NormRelayUrl::new(&read_url).expect("read relay");
+    let user = FullKeypair::generate();
+    let read_spec = crate::RelaySpec::new(read.clone(), true, false);
+    let account_list = crate::construct_nip65_relays_note([&read_spec])
+        .created_at(2)
+        .sign(&user.secret_key.secret_bytes())
+        .build()
+        .expect("account list");
+    let child = NoteBuilder::new()
+        .kind(1)
+        .content("child without a parent-author hint")
+        .created_at(3)
+        .start_tag()
+        .tag_str("e")
+        .tag_id(parent.id())
+        .tag_str("")
+        .tag_str("reply")
+        .sign(&user.secret_key.secret_bytes())
+        .build()
+        .expect("child");
+    let (_tmp, mut ndb) = test_ndb();
+    let job_pool = JobPool::new(1);
+    let mut remote = test_remote_state(&ndb, &job_pool);
+    for note in [&account_list, &child] {
+        ndb.process_client_event(&note.json().expect("json"))
+            .expect("seed local context");
+    }
+    wait_for_condition(
+        &mut remote,
+        Duration::from_secs(2),
+        None,
+        "local context",
+        |_| {
+            let txn = Transaction::new(&ndb).ok()?;
+            [&account_list, &child]
+                .iter()
+                .all(|note| ndb.get_note_by_id(&txn, note.id()).is_ok())
+                .then_some(())
+        },
+    )
+    .await;
+    let accounts = {
+        let txn = Transaction::new(&ndb).expect("txn");
+        assert!(ndb.get_note_by_id(&txn, parent.id()).is_err());
+        Accounts::new(
+            None,
+            Vec::new(),
+            vec![bootstrap.to_string()],
+            user.pubkey,
+            &mut ndb,
+            &txn,
+            &mut UnknownIds::default(),
+        )
+    };
+    assert_eq!(
+        accounts.selected_account_read_relays(),
+        hashbrown::HashSet::from([read])
+    );
+    assert_eq!(
+        accounts.discovery_bootstrap_relays(),
+        hashbrown::HashSet::from([bootstrap.clone()])
+    );
+    assert!(!bootstrap.allowed_for_source(enostr::RelayUrlSource::RemoteAdvertised));
+    let identity = ScopedSubIdentity::global(
+        SubOwnerKey::new("bridge/bootstrap-authorless"),
+        SubKey::new("thread"),
+    );
+    let config = SubConfig::builder(vec![Filter::new()
+        .kinds([1])
+        .event(parent.id())
+        .limit(250)
+        .build()])
+    .accounts_read_important()
+    .with_author_outbox_augmentation()
+    .for_thread(NoteId::new(*parent.id()), [NoteId::new(*child.id())])
+    .build();
+    {
+        let mut api = remote.api();
+        api.on_selected_account_changed(&accounts);
+        assert_eq!(
+            api.scoped_subs(&accounts).ensure_sub(identity, config),
+            EnsureSubResult::Created
+        );
+        api.flush();
+    }
+    let frame = wait_for_frame(
+        &mut remote,
+        &captured,
+        &notify,
+        "bootstrap exact-ID REQ",
+        |text| {
+            let Ok(Value::Array(request)) = serde_json::from_str::<Value>(text) else {
+                return false;
+            };
+            request.first().and_then(Value::as_str) == Some("REQ")
+                && request[2..] == [parent_filter.clone()]
+        },
+    )
+    .await;
+    let frame: Value = serde_json::from_str(&frame).expect("request");
+    assert_eq!(frame.as_array().expect("request").len(), 3);
+    assert_eq!(frame[2], parent_filter);
+    wait_for_condition(
+        &mut remote,
+        Duration::from_secs(3),
+        None,
+        "bootstrap parent ingestion",
+        |_| {
+            let txn = Transaction::new(&ndb).ok()?;
+            ndb.get_note_by_id(&txn, parent.id()).ok().map(|_| ())
+        },
+    )
+    .await;
+}
+
 #[tokio::test]
 async fn oneshot_uses_selected_account_read_relays() {
     let (relay_url, captured, notify) = create_text_capture_relay().await;

--- a/crates/notedeck/src/scoped_subs/author_plan/mod.rs
+++ b/crates/notedeck/src/scoped_subs/author_plan/mod.rs
@@ -1264,6 +1264,209 @@ fn planned_routed_relay_from_send(route: SendPlannedRoutedRelay) -> PlannedRoute
     }
 }
 
+#[test]
+fn thread_plan_job_only_builds_a_snapshot_without_subscribing() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let ndb = Ndb::new(tmp.path().to_str().expect("path"), &nostrdb::Config::new()).expect("ndb");
+    let missing = NoteId::new([42; 32]);
+    let spec = SubConfig::builder(vec![nostrdb::Filter::new().ids([missing.bytes()]).build()])
+        .accounts_read_important()
+        .with_author_outbox_augmentation()
+        .for_thread(missing, [])
+        .build();
+    let inputs = AuthorOutboxPlanInputs::new(&HashSet::new(), &spec);
+    let job = AuthorOutboxPlanJobRequest::new(
+        AuthorOutboxPlanSlotId(1),
+        AuthorOutboxBuildStage::Initial,
+        &inputs,
+    );
+
+    let completion = job.run(ndb.clone());
+
+    assert_eq!(
+        ndb.subscription_count(),
+        0,
+        "a planning job must return its snapshot without creating a subscription"
+    );
+    assert_eq!(
+        completion
+            .result
+            .thread
+            .expect("thread result")
+            .expect("thread snapshot")
+            .missing_ids,
+        HashSet::from([missing])
+    );
+}
+
+#[test]
+fn thread_plan_reuses_partial_routes_rebuilds_on_ingestion_and_cleans_up_owners() {
+    use super::config::{ResolvedSubScope, SubKey};
+    use super::ScopedSubOutboxOp;
+    use crate::test_utils::{nip65_write_relay_note_for_test, wait_for_nip65_for_test};
+    use enostr::FullKeypair;
+    use futures_util::FutureExt;
+    use nostrdb::{Config, NoteBuilder, Transaction};
+
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let ndb = Ndb::new(tmp.path().to_str().unwrap(), &Config::new()).expect("ndb");
+    let author = FullKeypair::generate();
+    let parent = NoteId::new([12; 32]);
+    let selected = NoteBuilder::new()
+        .kind(1)
+        .created_at(1)
+        .content("reply")
+        .start_tag()
+        .tag_str("e")
+        .tag_id(parent.bytes())
+        .tag_str("wss://hint.example.com/inbox")
+        .tag_str("reply")
+        .sign(&author.secret_key.secret_bytes())
+        .build()
+        .expect("note");
+    ndb.process_client_event(&selected.json().unwrap())
+        .expect("ingest");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let txn = Transaction::new(&ndb).unwrap();
+        if ndb.get_note_by_id(&txn, selected.id()).is_ok() {
+            break;
+        }
+        assert!(Instant::now() < deadline, "note not ingested");
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    let selected_id = NoteId::new(*selected.id());
+    let spec = SubConfig::builder(vec![Filter::new().ids([selected.id()]).build()])
+        .accounts_read_important()
+        .with_author_outbox_augmentation()
+        .for_thread(selected_id, [])
+        .build();
+    let reads = HashSet::from([NormRelayUrl::new("wss://account.example.com").unwrap()]);
+    let scoped = ScopedSubKey {
+        scope: ResolvedSubScope::Global,
+        key: SubKey::new("thread"),
+    };
+    let second = ScopedSubKey {
+        scope: ResolvedSubScope::Global,
+        key: SubKey::new("second"),
+    };
+    let account = Pubkey::new([1; 32]);
+    let ids = OutboxIdRegistry::new();
+    let mut runtime = AuthorOutboxPlanRuntime::default();
+    let request = |scoped| AuthorOutboxPlanAdvanceRequest {
+        account_pubkey: account,
+        scoped,
+        account_read_relays: &reads,
+        spec: &spec,
+    };
+    let initial = runtime.advance(request(scoped.clone()));
+    assert!(matches!(initial.advance, AuthorOutboxPlanAdvance::Pending));
+    let mut jobs = initial.effects.into_effects();
+    assert_eq!(jobs.len(), 1);
+    let ScopedSubEffect::StartAuthorOutboxPlanJob(job) = jobs.pop().unwrap();
+    let completion = job.run(ndb.clone());
+    assert_eq!(ndb.subscription_count(), 0);
+    let (owners, ops, effects) = runtime.apply_plan_slot_ready(&ids, completion, &reads, &ndb);
+    assert_eq!(ndb.subscription_count(), 1);
+    assert_eq!(
+        owners,
+        vec![scoped.clone()],
+        "hint route is ready before relay-list EOSE"
+    );
+    assert!(ops.into_ops().iter().any(|op| matches!(op, ScopedSubOutboxOp::StartFetch { filters, .. }
+        if filters.iter().any(|filter| filter.same_canonical_attributes(&Filter::new().ids([parent.bytes()]).build())))));
+    assert!(runtime
+        .slots
+        .values()
+        .next()
+        .unwrap()
+        .thread
+        .as_ref()
+        .unwrap()
+        .discovery
+        .is_some());
+    let mut jobs = effects.into_effects();
+    assert_eq!(jobs.len(), 1, "first subscription requires a catch-up job");
+    let ScopedSubEffect::StartAuthorOutboxPlanJob(job) = jobs.pop().unwrap();
+    let (_, ops, effects) = runtime.apply_plan_slot_ready(&ids, job.run(ndb.clone()), &reads, &ndb);
+    assert!(ops.is_empty(), "catch-up retains the baseline fetch");
+    assert!(
+        effects.into_effects().is_empty(),
+        "unchanged coverage is ready"
+    );
+    let shared = runtime.advance(request(second.clone()));
+    assert!(matches!(
+        shared.advance,
+        AuthorOutboxPlanAdvance::Ready { .. }
+    ));
+    assert!(shared.effects.into_effects().is_empty());
+    assert_eq!(runtime.slots.len(), 1);
+    assert!(runtime.remove_scoped(&scoped).is_empty());
+    assert_eq!(ndb.subscription_count(), 1, "other owner retains the watch");
+    assert!(runtime.next_thread_change().now_or_never().is_none());
+
+    let list = nip65_write_relay_note_for_test(&author, &["wss://author.example.com"]);
+    ndb.process_client_event(&list.json().unwrap())
+        .expect("relay list ingestion");
+    wait_for_nip65_for_test(&ndb, &author.pubkey);
+    let changed = runtime
+        .next_thread_change()
+        .now_or_never()
+        .expect("relay-list notification");
+    let effects = runtime.apply_thread_change(changed);
+    let mut jobs = effects.into_effects();
+    assert_eq!(jobs.len(), 1, "new relay list rebuilds without EOSE");
+    assert!(
+        runtime
+            .apply_thread_change(changed)
+            .into_effects()
+            .is_empty(),
+        "one snapshot job at a time"
+    );
+    let ScopedSubEffect::StartAuthorOutboxPlanJob(job) = jobs.pop().unwrap();
+    let (owners, ops, effects) =
+        runtime.apply_plan_slot_ready(&ids, job.run(ndb.clone()), &reads, &ndb);
+    assert!(effects.into_effects().is_empty());
+    assert_eq!(owners, vec![second.clone()]);
+    assert!(
+        ops.is_empty(),
+        "unchanged missing IDs do not restart the baseline fetch"
+    );
+    assert_eq!(
+        ndb.subscription_count(),
+        1,
+        "unchanged coverage retains the existing watch"
+    );
+    let slot = runtime.slots.values().next().unwrap();
+    let routes = &slot.ready_plan().unwrap().routes.live_routed_relays;
+    assert!(routes
+        .iter()
+        .any(|route| route.relay.as_str() == "wss://author.example.com/"));
+    assert!(routes
+        .iter()
+        .any(|route| route.relay.as_str() == "wss://hint.example.com/inbox"));
+    let cleanup = runtime.deactivate_account(account).into_ops();
+    assert!(cleanup
+        .iter()
+        .any(|op| matches!(op, ScopedSubOutboxOp::ClearFetch { .. })));
+    assert!(runtime.slots.is_empty());
+    assert_eq!(ndb.subscription_count(), 0);
+
+    // A job finishing after the last owner closes cannot resurrect subscriptions.
+    let mut jobs = runtime
+        .advance(request(second.clone()))
+        .effects
+        .into_effects();
+    let ScopedSubEffect::StartAuthorOutboxPlanJob(job) = jobs.pop().unwrap();
+    let completion = job.run(ndb.clone());
+    runtime.remove_scoped(&second);
+    assert!(runtime
+        .apply_plan_slot_ready(&ids, completion, &reads, &ndb)
+        .0
+        .is_empty());
+    assert_eq!(ndb.subscription_count(), 0);
+}
+
 #[cfg(test)]
 mod tests {
     use super::discovery::{
@@ -1383,11 +1586,22 @@ mod tests {
             match effect {
                 ScopedSubEffect::StartAuthorOutboxPlanJob(request) => {
                     let completion = request.run(ndb.clone());
-                    bridge.with_returned_outbox(|ids| {
-                        let (_, outbox_ops) =
-                            runtime.apply_plan_slot_ready(ids, completion, account_read_relays);
-                        outbox_ops
+                    let next_effects = bridge.with_returned_outbox(|ids| {
+                        let (_, outbox_ops, next_effects) = runtime.apply_plan_slot_ready(
+                            ids,
+                            completion,
+                            account_read_relays,
+                            ndb,
+                        );
+                        (next_effects, outbox_ops)
                     });
+                    apply_author_outbox_effects_for_test(
+                        runtime,
+                        bridge,
+                        account_read_relays,
+                        ndb,
+                        next_effects,
+                    );
                 }
             }
         }
@@ -1503,11 +1717,11 @@ mod tests {
             .kinds([1])
             .build();
         let filter = SendFilter::try_from_filter(filter).expect("sendable test filter");
-        let input = SendAuthorOutboxPlanJobInput {
+        let input = SendAuthorOutboxPlanJobInput::AuthorFilters(SendAuthorOutboxPlanConfig {
             account_read_relays: HashSet::new(),
             live_filters: send_plan_filters(&[filter]),
             full_history_filters: Vec::new(),
-        };
+        });
 
         let result = build_author_outbox_plan(ndb, input);
 
@@ -1839,6 +2053,7 @@ mod tests {
             ready_slot_id,
             AuthorOutboxPlanSlot {
                 inputs: AuthorOutboxPlanInputs::new(&account_read_relays, &spec),
+                thread: None,
                 owners: HashSet::from([ready_owner.clone()]),
                 state: AuthorOutboxPlanState::Ready(CachedAuthorOutboxPlan {
                     generation: 42,
@@ -1929,6 +2144,7 @@ mod tests {
             .build();
         let send_filter = SendFilter::try_from_filter(filter).expect("send filter");
         let result = SendAuthorOutboxPlanJobResult {
+            thread: None,
             live_routed_relays: vec![SendPlannedRoutedRelay {
                 relay: relay.clone(),
                 relay_priority: RoutedRelayPriority::default(),
@@ -1963,6 +2179,7 @@ mod tests {
         let send_filter = SendFilter::try_from_filter(filter).expect("send filter");
         let route_count = 20;
         let result = SendAuthorOutboxPlanJobResult {
+            thread: None,
             live_routed_relays: (0..route_count)
                 .map(|index| SendPlannedRoutedRelay {
                     relay: NormRelayUrl::new(&format!(

--- a/crates/notedeck/src/scoped_subs/author_plan/mod.rs
+++ b/crates/notedeck/src/scoped_subs/author_plan/mod.rs
@@ -1,6 +1,11 @@
-use enostr::{NormRelayUrl, OutboxIdRegistry, OutboxSubId, Pubkey, RelayReqStatus};
+use enostr::{
+    NormRelayUrl, NoteId, OutboxIdRegistry, OutboxSubId, Pubkey, RelayReqStatus, RelayUrlPkgs,
+    RelayUrlPolicy,
+};
+use futures_util::{future::poll_fn, StreamExt};
 use hashbrown::{HashMap, HashSet};
-use nostrdb::{Ndb, SendFilter};
+use nostrdb::{Filter, Ndb, SendFilter};
+use std::task::Poll;
 use std::time::{Duration, Instant};
 
 use super::config::{ScopedSubKey, SubConfig};
@@ -12,8 +17,13 @@ use crate::author_outbox::{
 };
 
 mod discovery;
+mod thread;
 
 use discovery::{start_relay_list_discovery, RelayListDiscovery, RelayListDiscoveryAdvance};
+use thread::{build_thread_plan, ThreadPlanSnapshot, ThreadWatch};
+
+const THREAD_PLAN_RETRY_DELAY: Duration = Duration::from_millis(100);
+const THREAD_PLAN_RETRY_MAX: Duration = Duration::from_secs(60);
 
 const RELAY_LIST_INGESTION_WAIT_DELAYS: [Duration; 6] = [
     Duration::from_millis(50),
@@ -32,7 +42,7 @@ struct AuthorOutboxPlanOwner {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub(super) struct AuthorOutboxPlanSlotId(u64);
+pub(crate) struct AuthorOutboxPlanSlotId(u64);
 
 /// Input snapshot that must still match before a cached plan can be reused.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -105,7 +115,18 @@ pub(crate) struct AuthorOutboxPlanJobCompletion {
 }
 
 /// Owned sendable data needed by one background author-outbox plan job.
-struct SendAuthorOutboxPlanJobInput {
+enum SendAuthorOutboxPlanJobInput {
+    /// Route authors named by the configured filters.
+    AuthorFilters(SendAuthorOutboxPlanConfig),
+    /// Route the ancestry of the required thread note IDs.
+    Thread {
+        config: SendAuthorOutboxPlanConfig,
+        note_ids: HashSet<NoteId>,
+    },
+}
+
+/// Relay coverage and filters shared by both background plan kinds.
+struct SendAuthorOutboxPlanConfig {
     account_read_relays: HashSet<NormRelayUrl>,
     live_filters: Vec<SendPlanFilter>,
     full_history_filters: Vec<SendPlanFilter>,
@@ -124,6 +145,7 @@ struct SendAuthorOutboxPlanJobResult {
     live_routed_relays: Vec<SendPlannedRoutedRelay>,
     full_history_routed_relays: Vec<SendPlannedRoutedRelay>,
     missing_authors: HashSet<Pubkey>,
+    thread: Option<Result<ThreadPlanSnapshot, nostrdb::Error>>,
 }
 
 /// Current shared author-outbox plan lifecycle for one input snapshot.
@@ -131,10 +153,118 @@ struct AuthorOutboxPlanSlot {
     inputs: AuthorOutboxPlanInputs,
     owners: HashSet<AuthorOutboxPlanOwner>,
     state: AuthorOutboxPlanState,
+    thread: Option<ThreadPlanState>,
+}
+
+/// Dynamic thread inputs and the last usable routes while a replacement builds.
+/// Owned by the same plan slot as relay-list discovery, never by the UI.
+struct ThreadPlanState {
+    watch: Option<ThreadWatch>,
+    /// Only failed reads or subscription setup use a timer; arrivals wake the stream.
+    retry_after: Option<Instant>,
+    /// Next failure's delay, doubled up to the cap and reset after recovery.
+    retry_delay: Duration,
+    available_plan: Option<CachedAuthorOutboxPlan>,
+    missing_ids: HashSet<NoteId>,
+    baseline_fetch: Option<OutboxSubId>,
+    /// Shared discovery implementation, kept alive across ancestry snapshots.
+    discovery: Option<RelayListDiscovery>,
+    requested_authors: HashSet<Pubkey>,
+}
+
+impl Default for ThreadPlanState {
+    fn default() -> Self {
+        Self {
+            watch: None,
+            retry_after: None,
+            retry_delay: THREAD_PLAN_RETRY_DELAY,
+            available_plan: None,
+            missing_ids: HashSet::new(),
+            baseline_fetch: None,
+            discovery: None,
+            requested_authors: HashSet::new(),
+        }
+    }
+}
+
+impl ThreadPlanState {
+    /// Back off consecutive read/setup failures, including across planning jobs.
+    fn record_failed_attempt(&mut self) {
+        self.retry_after = Some(Instant::now() + self.retry_delay);
+        self.retry_delay = self
+            .retry_delay
+            .saturating_mul(2)
+            .min(THREAD_PLAN_RETRY_MAX);
+    }
+
+    /// Discover each newly encountered author once per thread plan lifetime.
+    /// Existing discovery legs retain their normal EOSE/retry policy while
+    /// arriving ancestors extend the set of authors being discovered.
+    fn discover_authors(
+        &mut self,
+        ids: &OutboxIdRegistry,
+        missing: HashSet<Pubkey>,
+        reads: &HashSet<NormRelayUrl>,
+    ) -> ScopedSubOutboxOps {
+        if reads.is_empty() {
+            return ScopedSubOutboxOps::default();
+        }
+        let new_authors = missing
+            .into_iter()
+            .filter(|author| self.requested_authors.insert(*author))
+            .collect::<HashSet<_>>();
+        if new_authors.is_empty() {
+            return ScopedSubOutboxOps::default();
+        }
+        let (discovery, ops) = start_relay_list_discovery(ids, new_authors, reads.clone());
+        if let Some(existing) = &mut self.discovery {
+            existing.chunks.extend(discovery.chunks);
+        } else {
+            self.discovery = Some(discovery);
+        }
+        ops
+    }
+
+    /// Keep selected-account coverage for missing ancestors independent of
+    /// author relay-list availability. Replace the fetch only when IDs change.
+    fn request_missing_ids(
+        &mut self,
+        missing_ids: HashSet<NoteId>,
+        ids: &OutboxIdRegistry,
+        inputs: &AuthorOutboxPlanInputs,
+    ) -> ScopedSubOutboxOps {
+        let mut ops = ScopedSubOutboxOps::default();
+        if self.missing_ids == missing_ids {
+            return ops;
+        }
+        self.missing_ids = missing_ids;
+        if let Some(id) = self.baseline_fetch.take() {
+            ops.clear_fetch(id);
+        }
+        if self.missing_ids.is_empty() || inputs.account_read_relays.is_empty() {
+            return ops;
+        }
+        let mut missing = self.missing_ids.iter().copied().collect::<Vec<_>>();
+        missing.sort_unstable_by_key(|id| *id.bytes());
+        let id = ids.next_sub_id();
+        let policy = inputs.spec.baseline_policy();
+        ops.start_fetch(
+            id,
+            vec![Filter::new().ids(missing.iter().map(NoteId::bytes)).build()],
+            RelayUrlPkgs::new(
+                inputs.account_read_relays.clone(),
+                RelayUrlPolicy::explicit(policy.demand_priority(), policy.routing_preference()),
+            ),
+        );
+        self.baseline_fetch = Some(id);
+        ops
+    }
 }
 
 enum AuthorOutboxPlanState {
     BuildingInitial,
+    /// No successful initial thread snapshot yet; retry at the error deadline.
+    WaitingForThreadRetry,
     DiscoveringRelays {
         discovery: RelayListDiscovery,
         original_missing_author_count: usize,
@@ -200,7 +330,8 @@ pub(super) struct AuthorOutboxPlanAdvanceResult<'a> {
     pub(super) effects: ScopedSubEffects,
 }
 
-/// Retained frozen author-outbox plans and in-flight relay-list discovery.
+/// Shared author-outbox planner. Author-filter plans remain frozen; thread
+/// plans rebuild on NDB ingestion while retaining their relay-list discovery.
 pub(super) struct AuthorOutboxPlanRuntime {
     owner_slots: HashMap<AuthorOutboxPlanOwner, AuthorOutboxPlanSlotId>,
     slots: HashMap<AuthorOutboxPlanSlotId, AuthorOutboxPlanSlot>,
@@ -220,12 +351,73 @@ impl Default for AuthorOutboxPlanRuntime {
 }
 
 impl AuthorOutboxPlanRuntime {
-    /// Return the next relay-list discovery retry deadline.
+    /// Return the next discovery or failed-thread-plan retry deadline.
     pub(super) fn next_deadline(&self) -> Option<Instant> {
         self.slots
             .values()
             .filter_map(AuthorOutboxPlanSlot::next_deadline)
             .min()
+    }
+
+    /// Await a relevant NDB arrival without a timer or a task per thread.
+    ///
+    /// Do not consume notifications while a job is running: the subscription's
+    /// queue retains them for a subsequent job. Cancelling this wait keeps the
+    /// streams in their slots, so other bridge activity cannot lose arrivals.
+    pub(super) async fn next_thread_change(&mut self) -> AuthorOutboxPlanSlotId {
+        poll_fn(|cx| {
+            for (slot_id, slot) in &mut self.slots {
+                if slot.state.is_building() {
+                    continue;
+                }
+                let Some(thread) = &mut slot.thread else {
+                    continue;
+                };
+                let Some(watch) = &mut thread.watch else {
+                    continue;
+                };
+                match watch.poll_next_unpin(cx) {
+                    Poll::Ready(Some(())) => return Poll::Ready(*slot_id),
+                    Poll::Ready(None) => {
+                        // An ended stream must be replaced, never selected repeatedly.
+                        thread.watch = None;
+                        return Poll::Ready(*slot_id);
+                    }
+                    Poll::Pending => {}
+                }
+            }
+            Poll::Pending
+        })
+        .await
+    }
+
+    /// Schedule one new thread plan while preserving the last completed routes.
+    /// Used by NDB notifications, expanded subscription coverage, and failed-job retries.
+    pub(super) fn apply_thread_change(
+        &mut self,
+        slot_id: AuthorOutboxPlanSlotId,
+    ) -> ScopedSubEffects {
+        let mut effects = ScopedSubEffects::default();
+        let Some(slot) = self.slots.get_mut(&slot_id) else {
+            return effects;
+        };
+        if slot.state.is_building() {
+            return effects;
+        }
+        let Some(thread) = &mut slot.thread else {
+            return effects;
+        };
+        thread.retry_after = None;
+        let previous = std::mem::replace(&mut slot.state, AuthorOutboxPlanState::BuildingInitial);
+        if let AuthorOutboxPlanState::Ready(plan) = previous {
+            thread.available_plan = Some(plan);
+        }
+        effects.push(ScopedSubEffect::from(AuthorOutboxPlanJobRequest::new(
+            slot_id,
+            AuthorOutboxBuildStage::Initial,
+            &slot.inputs,
+        )));
+        effects
     }
 
     /// Drop every cached or in-flight owner binding for one scoped subscription.
@@ -259,7 +451,8 @@ impl AuthorOutboxPlanRuntime {
     }
 
     /// Drop in-flight ownership tied to an inactive account while retaining
-    /// completed frozen plans for fast switch-back.
+    /// completed frozen author-filter plans for fast switch-back. Thread watches
+    /// belong only to the active account and are rebuilt on switch-back.
     pub(super) fn deactivate_account(&mut self, account_pubkey: Pubkey) -> ScopedSubOutboxOps {
         let owners = self
             .owner_slots
@@ -268,11 +461,11 @@ impl AuthorOutboxPlanRuntime {
                 if owner.account_pubkey != account_pubkey {
                     return None;
                 }
-                let is_ready = self
+                let retain = self
                     .slots
                     .get(slot_id)
-                    .is_some_and(AuthorOutboxPlanSlot::is_ready);
-                (!is_ready).then_some(owner.clone())
+                    .is_some_and(|slot| slot.thread.is_none() && slot.is_ready());
+                (!retain).then_some(owner.clone())
             })
             .collect::<Vec<_>>();
         let mut outbox_ops = ScopedSubOutboxOps::default();
@@ -321,7 +514,7 @@ impl AuthorOutboxPlanRuntime {
         };
 
         if let Some(slot) = self.slots.get(&slot_id) {
-            if let AuthorOutboxPlanState::Ready(plan) = &slot.state {
+            if let Some(plan) = slot.ready_plan() {
                 return AuthorOutboxPlanAdvanceResult {
                     advance: AuthorOutboxPlanAdvance::Ready {
                         routes: &plan.routes,
@@ -382,6 +575,10 @@ impl AuthorOutboxPlanRuntime {
         self.slots.insert(
             slot_id,
             AuthorOutboxPlanSlot {
+                thread: inputs
+                    .spec
+                    .thread_notes()
+                    .map(|_| ThreadPlanState::default()),
                 inputs,
                 owners: HashSet::from([owner]),
                 state: Self::building_state(AuthorOutboxBuildStage::Initial),
@@ -404,10 +601,19 @@ impl AuthorOutboxPlanRuntime {
         let Some(slot) = self.slots.remove(&slot_id) else {
             return ScopedSubOutboxOps::default();
         };
-        if let AuthorOutboxPlanState::DiscoveringRelays { discovery, .. } = slot.state {
-            return discovery.unsubscribe_all();
+        let mut ops = ScopedSubOutboxOps::default();
+        if let Some(thread) = slot.thread {
+            if let Some(id) = thread.baseline_fetch {
+                ops.clear_fetch(id);
+            }
+            if let Some(discovery) = thread.discovery {
+                ops.extend(discovery.unsubscribe_all());
+            }
         }
-        ScopedSubOutboxOps::default()
+        if let AuthorOutboxPlanState::DiscoveringRelays { discovery, .. } = slot.state {
+            ops.extend(discovery.unsubscribe_all());
+        }
+        ops
     }
 
     /// Apply one relay request status fact to discovery slots that own the
@@ -422,8 +628,12 @@ impl AuthorOutboxPlanRuntime {
             .slots
             .iter()
             .filter_map(|(slot_id, slot)| {
-                matches!(slot.state, AuthorOutboxPlanState::DiscoveringRelays { .. })
-                    .then_some(*slot_id)
+                (matches!(slot.state, AuthorOutboxPlanState::DiscoveringRelays { .. })
+                    || slot
+                        .thread
+                        .as_ref()
+                        .is_some_and(|thread| thread.discovery.is_some()))
+                .then_some(*slot_id)
             })
             .collect::<Vec<_>>();
 
@@ -445,17 +655,19 @@ impl AuthorOutboxPlanRuntime {
         ids: &OutboxIdRegistry,
         completion: AuthorOutboxPlanJobCompletion,
         account_read_relays: &HashSet<NormRelayUrl>,
-    ) -> (Vec<ScopedSubKey>, ScopedSubOutboxOps) {
+        ndb: &Ndb,
+    ) -> (Vec<ScopedSubKey>, ScopedSubOutboxOps, ScopedSubEffects) {
         let slot_id = completion.slot_id;
-        let outbox_ops = self.apply_build_result(ids, completion, account_read_relays);
+        let (outbox_ops, effects) =
+            self.apply_build_result(ids, completion, account_read_relays, ndb);
         if !self.slot_is_ready(slot_id) {
-            return (Vec::new(), outbox_ops);
+            return (Vec::new(), outbox_ops, effects);
         }
 
-        (self.slot_scoped_keys(slot_id), outbox_ops)
+        (self.slot_scoped_keys(slot_id), outbox_ops, effects)
     }
 
-    /// Apply retained relay-list discovery retry and ingestion-wait deadlines.
+    /// Apply discovery retries, ingestion waits, and failed-thread-plan retries.
     pub(super) fn apply_relay_list_discovery_retry_due(
         &mut self,
         now: Instant,
@@ -464,12 +676,9 @@ impl AuthorOutboxPlanRuntime {
             .slots
             .iter()
             .filter_map(|(slot_id, slot)| {
-                matches!(
-                    slot.state,
-                    AuthorOutboxPlanState::DiscoveringRelays { .. }
-                        | AuthorOutboxPlanState::WaitingForRelayListIngestion(_)
-                )
-                .then_some(*slot_id)
+                slot.next_deadline()
+                    .is_some_and(|deadline| deadline <= now)
+                    .then_some(*slot_id)
             })
             .collect::<Vec<_>>();
 
@@ -488,19 +697,87 @@ impl AuthorOutboxPlanRuntime {
         ids: &OutboxIdRegistry,
         completion: AuthorOutboxPlanJobCompletion,
         account_read_relays: &HashSet<NormRelayUrl>,
-    ) -> ScopedSubOutboxOps {
+        ndb: &Ndb,
+    ) -> (ScopedSubOutboxOps, ScopedSubEffects) {
         let AuthorOutboxPlanJobCompletion {
             slot_id,
             build_stage,
-            result,
+            mut result,
         } = completion;
-        let Some(slot) = self.slots.get_mut(&slot_id) else {
-            return ScopedSubOutboxOps::default();
+        let Some(slot) = self.slots.get(&slot_id) else {
+            return (ScopedSubOutboxOps::default(), ScopedSubEffects::default());
         };
         if !slot.state.matches_build_stage(build_stage) {
-            return ScopedSubOutboxOps::default();
+            return (ScopedSubOutboxOps::default(), ScopedSubEffects::default());
         }
 
+        if let Some(snapshot) = result.thread.take() {
+            let snapshot = match snapshot {
+                Ok(snapshot) => snapshot,
+                Err(err) => {
+                    tracing::warn!(?err, "failed to read thread routing context");
+                    let slot = self.slots.get_mut(&slot_id).expect("validated plan slot");
+                    let thread = slot
+                        .thread
+                        .as_mut()
+                        .expect("thread snapshot for thread inputs");
+                    // Failure does not mean that ancestors or routes disappeared.
+                    // Keep the prior subscription, queued arrivals, and fetches.
+                    thread.record_failed_attempt();
+                    slot.state = thread
+                        .available_plan
+                        .take()
+                        .map(AuthorOutboxPlanState::Ready)
+                        .unwrap_or(AuthorOutboxPlanState::WaitingForThreadRetry);
+                    return (ScopedSubOutboxOps::default(), ScopedSubEffects::default());
+                }
+            };
+            let missing_authors = std::mem::take(&mut result.missing_authors);
+            let cached = self.cached_plan_from_job_result(result);
+            let slot = self.slots.get_mut(&slot_id).expect("validated plan slot");
+            let thread = slot
+                .thread
+                .as_mut()
+                .expect("thread snapshot for thread inputs");
+            thread.retry_after = None;
+            let needs_watch = thread
+                .watch
+                .as_ref()
+                .is_none_or(|watch| !watch.covers(&snapshot.note_ids, &snapshot.authors));
+            let catch_up = if needs_watch {
+                match ThreadWatch::new(ndb, snapshot.note_ids, snapshot.authors) {
+                    Ok(watch) => {
+                        // Install before dropping the old subscription or scheduling
+                        // another job. That job also catches arrivals preceding setup.
+                        thread.watch = Some(watch);
+                        true
+                    }
+                    Err(err) => {
+                        tracing::warn!(?err, "failed to subscribe to thread routing changes");
+                        thread.record_failed_attempt();
+                        false
+                    }
+                }
+            } else {
+                false
+            };
+            // A successful read alone must not reset failed subscription setup.
+            if thread.retry_after.is_none() {
+                thread.retry_delay = THREAD_PLAN_RETRY_DELAY;
+            }
+            let mut ops = thread.request_missing_ids(snapshot.missing_ids, ids, &slot.inputs);
+            ops.extend(thread.discover_authors(ids, missing_authors, account_read_relays));
+            thread.available_plan = None;
+            slot.state = AuthorOutboxPlanState::Ready(cached);
+            let effects = if catch_up {
+                self.apply_thread_change(slot_id)
+            } else {
+                ScopedSubEffects::default()
+            };
+            return (ops, effects);
+        }
+
+        let slot = self.slots.get_mut(&slot_id).expect("validated plan slot");
         if build_stage == AuthorOutboxBuildStage::Initial
             && !result.missing_authors.is_empty()
             && !account_read_relays.is_empty()
@@ -515,7 +792,7 @@ impl AuthorOutboxPlanRuntime {
                 discovery,
                 original_missing_author_count,
             };
-            return outbox_ops;
+            return (outbox_ops, ScopedSubEffects::default());
         }
 
         if let AuthorOutboxBuildStage::AfterRelayListDiscovery {
@@ -535,7 +812,7 @@ impl AuthorOutboxPlanRuntime {
                         Instant::now(),
                     ),
                 );
-                return ScopedSubOutboxOps::default();
+                return (ScopedSubOutboxOps::default(), ScopedSubEffects::default());
             }
         }
 
@@ -543,7 +820,7 @@ impl AuthorOutboxPlanRuntime {
         if let Some(slot) = self.slots.get_mut(&slot_id) {
             slot.state = AuthorOutboxPlanState::Ready(cached);
         }
-        ScopedSubOutboxOps::default()
+        (ScopedSubOutboxOps::default(), ScopedSubEffects::default())
     }
 
     fn apply_relay_req_status_to_discovery_slot(
@@ -557,6 +834,16 @@ impl AuthorOutboxPlanRuntime {
             let Some(slot) = self.slots.get_mut(&slot_id) else {
                 return (ScopedSubOutboxOps::default(), ScopedSubEffects::default());
             };
+            if let Some(thread) = &mut slot.thread {
+                let Some(discovery) = &mut thread.discovery else {
+                    return (ScopedSubOutboxOps::default(), ScopedSubEffects::default());
+                };
+                let (advance, ops) = discovery.apply_relay_req_status(id, relay, status);
+                if advance == RelayListDiscoveryAdvance::Complete {
+                    thread.discovery = None;
+                }
+                return (ops, ScopedSubEffects::default());
+            }
             let AuthorOutboxPlanState::DiscoveringRelays {
                 discovery,
                 original_missing_author_count,
@@ -585,6 +872,32 @@ impl AuthorOutboxPlanRuntime {
         slot_id: AuthorOutboxPlanSlotId,
         now: Instant,
     ) -> (ScopedSubOutboxOps, ScopedSubEffects) {
+        let retry_thread = self.slots.get(&slot_id).is_some_and(|slot| {
+            !slot.state.is_building()
+                && slot
+                    .thread
+                    .as_ref()
+                    .and_then(|thread| thread.retry_after)
+                    .is_some_and(|deadline| now >= deadline)
+        });
+        if retry_thread {
+            return (
+                ScopedSubOutboxOps::default(),
+                self.apply_thread_change(slot_id),
+            );
+        }
+        if let Some(slot) = self.slots.get_mut(&slot_id) {
+            if let Some(thread) = &mut slot.thread {
+                let Some(discovery) = &mut thread.discovery else {
+                    return (ScopedSubOutboxOps::default(), ScopedSubEffects::default());
+                };
+                let (advance, ops) = discovery.apply_retry_due(now);
+                if advance == RelayListDiscoveryAdvance::Complete {
+                    thread.discovery = None;
+                }
+                return (ops, ScopedSubEffects::default());
+            }
+        }
         match self.slots.get(&slot_id).map(|slot| &slot.state) {
             Some(AuthorOutboxPlanState::DiscoveringRelays { .. }) => {
                 self.apply_discovery_retry_due_to_slot(slot_id, now)
@@ -710,22 +1023,53 @@ impl AuthorOutboxPlanRuntime {
 }
 
 impl AuthorOutboxPlanSlot {
+    /// Keep usable thread routes available during the next background rebuild.
+    fn ready_plan(&self) -> Option<&CachedAuthorOutboxPlan> {
+        if let AuthorOutboxPlanState::Ready(plan) = &self.state {
+            return Some(plan);
+        }
+        self.thread.as_ref()?.available_plan.as_ref()
+    }
+
     fn is_ready(&self) -> bool {
-        matches!(self.state, AuthorOutboxPlanState::Ready(_))
+        self.ready_plan().is_some()
     }
 
     fn next_deadline(&self) -> Option<Instant> {
-        match &self.state {
+        let discovery = match &self.state {
             AuthorOutboxPlanState::DiscoveringRelays { discovery, .. } => discovery.next_deadline(),
             AuthorOutboxPlanState::WaitingForRelayListIngestion(wait) => Some(wait.ready_at),
             AuthorOutboxPlanState::BuildingInitial
+            | AuthorOutboxPlanState::WaitingForThreadRetry
             | AuthorOutboxPlanState::BuildingAfterRelayListDiscovery { .. }
             | AuthorOutboxPlanState::Ready(_) => None,
-        }
+        };
+        let retry = self
+            .thread
+            .as_ref()
+            .filter(|_| !self.state.is_building())
+            .and_then(|thread| thread.retry_after);
+        let thread_discovery = self
+            .thread
+            .as_ref()
+            .and_then(|thread| thread.discovery.as_ref())
+            .and_then(RelayListDiscovery::next_deadline);
+        discovery
+            .into_iter()
+            .chain(retry)
+            .chain(thread_discovery)
+            .min()
     }
 }
 
 impl AuthorOutboxPlanState {
+    fn is_building(&self) -> bool {
+        matches!(
+            self,
+            Self::BuildingInitial | Self::BuildingAfterRelayListDiscovery { .. }
+        )
+    }
+
     fn matches_build_stage(&self, build_stage: AuthorOutboxBuildStage) -> bool {
         match (self, build_stage) {
             (AuthorOutboxPlanState::BuildingInitial, AuthorOutboxBuildStage::Initial) => true,
@@ -771,7 +1115,7 @@ fn relay_list_ingestion_wait_delay(attempt: u8) -> Duration {
 fn send_author_outbox_plan_job_input(
     inputs: &AuthorOutboxPlanInputs,
 ) -> SendAuthorOutboxPlanJobInput {
-    SendAuthorOutboxPlanJobInput {
+    let config = SendAuthorOutboxPlanConfig {
         account_read_relays: inputs.account_read_relays.clone(),
         live_filters: send_plan_filters(inputs.spec.filters()),
         full_history_filters: inputs
@@ -779,6 +1123,13 @@ fn send_author_outbox_plan_job_input(
             .full_history_config()
             .map(|full_history| send_plan_filters(full_history.filters()))
             .unwrap_or_default(),
+    };
+    match inputs.spec.thread_notes() {
+        Some(note_ids) => SendAuthorOutboxPlanJobInput::Thread {
+            config,
+            note_ids: note_ids.clone(),
+        },
+        None => SendAuthorOutboxPlanJobInput::AuthorFilters(config),
     }
 }
 
@@ -797,6 +1148,21 @@ fn build_author_outbox_plan(
     ndb: Ndb,
     input: SendAuthorOutboxPlanJobInput,
 ) -> SendAuthorOutboxPlanJobResult {
+    match input {
+        SendAuthorOutboxPlanJobInput::AuthorFilters(config) => {
+            build_author_filter_plan(ndb, config)
+        }
+        SendAuthorOutboxPlanJobInput::Thread { config, note_ids } => {
+            build_thread_plan(ndb, config, note_ids)
+        }
+    }
+}
+
+/// Build routes for the authors named by the configured live and history filters.
+fn build_author_filter_plan(
+    ndb: Ndb,
+    input: SendAuthorOutboxPlanConfig,
+) -> SendAuthorOutboxPlanJobResult {
     let authors = send_plan_filter_authors(&input.live_filters, &input.full_history_filters);
     let directory = RelayDirectorySnapshot::from_ndb_authors(&ndb, &authors);
     let missing_authors = directory.missing_authors(&authors);
@@ -809,6 +1175,7 @@ fn build_author_outbox_plan(
         ),
     );
     SendAuthorOutboxPlanJobResult {
+        thread: None,
         live_routed_relays: send_routed_relays(routes.live_routed_relays),
         full_history_routed_relays: send_routed_relays(routes.full_history_routed_relays),
         missing_authors,

--- a/crates/notedeck/src/scoped_subs/author_plan/mod.rs
+++ b/crates/notedeck/src/scoped_subs/author_plan/mod.rs
@@ -1317,7 +1317,7 @@ fn thread_plan_job_only_builds_a_snapshot_without_subscribing() {
         .with_author_outbox_augmentation()
         .for_thread(missing, [])
         .build();
-    let inputs = AuthorOutboxPlanInputs::new(&HashSet::new(), &spec);
+    let inputs = AuthorOutboxPlanInputs::new(&HashSet::new(), &HashSet::new(), &spec);
     let job = AuthorOutboxPlanJobRequest::new(
         AuthorOutboxPlanSlotId(1),
         AuthorOutboxBuildStage::Initial,
@@ -1808,6 +1808,371 @@ mod tests {
         assert_eq!(discovery.chunks[0].authors_for_test(), vec![author]);
     }
 
+    /// Metadata discovery adds injected bootstrap coverage without changing event reads.
+    #[test]
+    fn author_filter_discovery_adds_bootstrap_relays() {
+        let (_tmp, ndb) = new_ndb();
+        let account = test_pubkey(1);
+        let author = test_pubkey(2);
+        let read = NormRelayUrl::new("wss://account-read.example.com").expect("read relay");
+        let bootstrap = NormRelayUrl::new("wss://bootstrap.example.com").expect("bootstrap");
+        let reads = HashSet::from([read.clone()]);
+        let expected = HashSet::from([read.clone(), bootstrap.clone()]);
+        let mut runtime = runtime_with_ndb(&ndb);
+        runtime.bootstrap_relays = expected.clone();
+        let ids = OutboxIdRegistry::new();
+        let spec = author_outbox_config(author);
+        let initial = runtime.advance(AuthorOutboxPlanAdvanceRequest {
+            account_pubkey: account,
+            scoped: scoped_key("author-discovery-bootstrap"),
+            account_read_relays: &reads,
+            spec: &spec,
+        });
+        let mut effects = initial.effects.into_effects();
+        assert_eq!(effects.len(), 1);
+        let ScopedSubEffect::StartAuthorOutboxPlanJob(job) = effects.pop().expect("job");
+        runtime.bootstrap_relays.clear();
+        let (_, ops, _) = runtime.apply_plan_slot_ready(&ids, job.run(ndb.clone()), &reads, &ndb);
+        let expected_filter = Filter::new()
+            .authors([author.bytes()])
+            .kinds([10002])
+            .build();
+        let mut destinations = HashSet::new();
+        let ops = ops.into_ops();
+        assert_eq!(
+            ops.len(),
+            expected.len(),
+            "discovery retains its input snapshot and deduplicates overlapping relays"
+        );
+        for op in ops {
+            let ScopedSubOutboxOp::StartFetch {
+                filters,
+                relay_pkgs,
+                ..
+            } = op
+            else {
+                panic!("discovery should stage a one-shot");
+            };
+            assert_eq!(filters.len(), 1);
+            assert!(filters[0].same_canonical_attributes(&expected_filter));
+            destinations.extend(relay_pkgs.urls().iter().cloned());
+        }
+        assert_eq!(destinations, expected);
+        assert_eq!(reads, HashSet::from([read]));
+    }
+
+    /// Empty account reads must not prevent configured metadata discovery.
+    #[test]
+    fn author_filter_discovery_uses_bootstrap_without_account_reads() {
+        let (_tmp, ndb) = new_ndb();
+        let author = test_pubkey(2);
+        let reads = HashSet::new();
+        let bootstrap = NormRelayUrl::new("wss://bootstrap.example.com").expect("bootstrap");
+        let mut runtime = runtime_with_ndb(&ndb);
+        runtime.bootstrap_relays = HashSet::from([bootstrap.clone()]);
+        let spec = author_outbox_config(author);
+        let initial = runtime.advance(AuthorOutboxPlanAdvanceRequest {
+            account_pubkey: test_pubkey(1),
+            scoped: scoped_key("bootstrap-only-discovery"),
+            account_read_relays: &reads,
+            spec: &spec,
+        });
+        let mut effects = initial.effects.into_effects();
+        assert_eq!(effects.len(), 1);
+        let ScopedSubEffect::StartAuthorOutboxPlanJob(job) = effects.pop().expect("job");
+        let (_, ops, _) = runtime.apply_plan_slot_ready(
+            &OutboxIdRegistry::new(),
+            job.run(ndb.clone()),
+            &reads,
+            &ndb,
+        );
+        let mut ops = ops.into_ops();
+        assert_eq!(ops.len(), 1);
+        let ScopedSubOutboxOp::StartFetch {
+            filters,
+            relay_pkgs,
+            ..
+        } = ops.pop().unwrap()
+        else {
+            panic!("metadata discovery should stage a one-shot");
+        };
+        assert_eq!(relay_pkgs.urls(), &HashSet::from([bootstrap]));
+        assert_eq!(filters.len(), 1);
+        assert!(filters[0].same_canonical_attributes(
+            &Filter::new()
+                .authors([author.bytes()])
+                .kinds([10002])
+                .build()
+        ));
+    }
+
+    /// A missing thread parent discovers its author's list on reads plus bootstrap,
+    /// while the ordinary parent one-shot remains on selected-account reads.
+    #[test]
+    fn thread_discovery_adds_bootstrap_without_expanding_parent_reads() {
+        use nostrdb::{NoteBuilder, Transaction};
+
+        let (_tmp, ndb) = new_ndb();
+        let author = FullKeypair::generate();
+        let parent = NoteId::new([42; 32]);
+        let reply = NoteBuilder::new()
+            .kind(1)
+            .created_at(1)
+            .content("reply to a missing parent")
+            .start_tag()
+            .tag_str("e")
+            .tag_id(parent.bytes())
+            .tag_str("")
+            .tag_str("reply")
+            .tag_id(author.pubkey.bytes())
+            .sign(&author.secret_key.secret_bytes())
+            .build()
+            .expect("reply");
+        ndb.process_client_event(&reply.json().expect("reply JSON"))
+            .expect("ingest reply");
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let txn = Transaction::new(&ndb).expect("transaction");
+            if ndb.get_note_by_id(&txn, reply.id()).is_ok() {
+                break;
+            }
+            assert!(Instant::now() < deadline, "reply was not ingested");
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        let read = NormRelayUrl::new("wss://account-read.example.com").expect("read relay");
+        let bootstrap = NormRelayUrl::new("wss://bootstrap.example.com").expect("bootstrap");
+        let reads = HashSet::from([read.clone()]);
+        let expected_discovery = HashSet::from([read, bootstrap.clone()]);
+        let parent_filter = Filter::new().ids([parent.bytes()]).build();
+        let spec = SubConfig::builder(vec![parent_filter.clone()])
+            .accounts_read_important()
+            .with_author_outbox_augmentation()
+            .for_thread(parent, [NoteId::new(*reply.id())])
+            .build();
+        let mut runtime = runtime_with_ndb(&ndb);
+        runtime.bootstrap_relays = HashSet::from([bootstrap]);
+        let initial = runtime.advance(AuthorOutboxPlanAdvanceRequest {
+            account_pubkey: test_pubkey(1),
+            scoped: scoped_key("thread-discovery-bootstrap"),
+            account_read_relays: &reads,
+            spec: &spec,
+        });
+        let mut effects = initial.effects.into_effects();
+        assert_eq!(effects.len(), 1);
+        let ScopedSubEffect::StartAuthorOutboxPlanJob(job) = effects.pop().expect("job");
+        let (_, ops, _) = runtime.apply_plan_slot_ready(
+            &OutboxIdRegistry::new(),
+            job.run(ndb.clone()),
+            &reads,
+            &ndb,
+        );
+        let relay_list_filter = Filter::new()
+            .authors([author.pubkey.bytes()])
+            .kinds([10002])
+            .build();
+        let mut discovery_destinations = HashSet::new();
+        let mut parent_destinations = HashSet::new();
+        let mut discovery_count = 0;
+        for op in ops.into_ops() {
+            let ScopedSubOutboxOp::StartFetch {
+                filters,
+                relay_pkgs,
+                ..
+            } = op
+            else {
+                panic!("initial thread discovery should stage one-shots");
+            };
+            assert_eq!(filters.len(), 1);
+            if filters[0].same_canonical_attributes(&relay_list_filter) {
+                discovery_count += 1;
+                discovery_destinations.extend(relay_pkgs.urls().iter().cloned());
+            } else {
+                assert!(filters[0].same_canonical_attributes(&parent_filter));
+                parent_destinations.extend(relay_pkgs.urls().iter().cloned());
+            }
+        }
+        assert_eq!(discovery_count, expected_discovery.len());
+        assert_eq!(discovery_destinations, expected_discovery);
+        assert_eq!(parent_destinations, reads);
+    }
+
+    /// Authorless parents retain explicit bootstrap ID requests even on a planned hint route.
+    #[test]
+    fn thread_bootstrap_fetch_is_explicit_exact_deduplicated_and_cleared_on_arrival() {
+        use futures_util::FutureExt;
+        use nostrdb::{NoteBuilder, Transaction};
+
+        let (_tmp, ndb) = new_ndb();
+        let author = FullKeypair::generate();
+        let unknown_parent = NoteBuilder::new()
+            .kind(1)
+            .created_at(1)
+            .content("parent whose author is not in the reply tag")
+            .sign(&[3; 32])
+            .build()
+            .expect("parent");
+        let unknown_id = NoteId::new(*unknown_parent.id());
+        let known_id = NoteId::new([42; 32]);
+        let read = NormRelayUrl::new("wss://account-read.example.com").expect("read relay");
+        let hint = NormRelayUrl::new("wss://hint.example.com").expect("hint relay");
+        let bootstrap = NormRelayUrl::new("ws://127.0.0.1:7777").expect("local bootstrap");
+        let reads = HashSet::from([read.clone()]);
+        let reply = NoteBuilder::new()
+            .kind(1)
+            .created_at(2)
+            .content("reply with one authorless and one author-tagged ancestor")
+            .start_tag()
+            .tag_str("e")
+            .tag_id(unknown_id.bytes())
+            .tag_str(hint.as_str())
+            .tag_str("root")
+            .start_tag()
+            .tag_str("e")
+            .tag_id(known_id.bytes())
+            .tag_str("")
+            .tag_str("reply")
+            .tag_id(author.pubkey.bytes())
+            .sign(&author.secret_key.secret_bytes())
+            .build()
+            .expect("reply");
+        ndb.process_client_event(&reply.json().expect("reply JSON"))
+            .expect("ingest reply");
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let txn = Transaction::new(&ndb).expect("transaction");
+            if ndb.get_note_by_id(&txn, reply.id()).is_ok() {
+                break;
+            }
+            assert!(Instant::now() < deadline, "reply was not ingested");
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        let spec = SubConfig::builder(vec![Filter::new()
+            .kinds([1])
+            .event(unknown_id.bytes())
+            .limit(500)
+            .build()])
+        .accounts_read_important()
+        .with_author_outbox_augmentation()
+        .for_thread(unknown_id, [NoteId::new(*reply.id())])
+        .build();
+        let mut runtime = runtime_with_ndb(&ndb);
+        runtime.bootstrap_relays = HashSet::from([read, hint.clone(), bootstrap.clone()]);
+        let ids = OutboxIdRegistry::new();
+        let initial = runtime.advance(AuthorOutboxPlanAdvanceRequest {
+            account_pubkey: test_pubkey(1),
+            scoped: scoped_key("explicit-authorless-bootstrap"),
+            account_read_relays: &reads,
+            spec: &spec,
+        });
+        let mut effects = initial.effects.into_effects();
+        assert_eq!(effects.len(), 1);
+        let ScopedSubEffect::StartAuthorOutboxPlanJob(job) = effects.pop().expect("job");
+        let (_, ops, catch_up) =
+            runtime.apply_plan_slot_ready(&ids, job.run(ndb.clone()), &reads, &ndb);
+        let expected = Filter::new().ids([unknown_id.bytes()]).build();
+        let relay_list_filter = Filter::new()
+            .authors([author.pubkey.bytes()])
+            .kinds([10002])
+            .build();
+        let mut bootstrap_fetch = None;
+        for op in ops.into_ops() {
+            let ScopedSubOutboxOp::StartFetch {
+                id,
+                filters,
+                relay_pkgs,
+            } = op
+            else {
+                continue;
+            };
+            if !relay_pkgs.urls().contains(&bootstrap) {
+                continue;
+            }
+            if filters.len() == 1 && filters[0].same_canonical_attributes(&relay_list_filter) {
+                continue;
+            }
+            assert!(
+                bootstrap_fetch.replace(id).is_none(),
+                "only one bootstrap parent fetch"
+            );
+            assert_eq!(
+                filters.len(),
+                1,
+                "no reply/#e, kind, author, or limit filters"
+            );
+            assert!(filters[0].same_canonical_attributes(&expected));
+            assert_eq!(
+                relay_pkgs.urls(),
+                &HashSet::from([bootstrap.clone(), hint.clone()])
+            );
+            assert_eq!(relay_pkgs.source(), enostr::RelayUrlSource::Explicit);
+            assert_eq!(
+                relay_pkgs.demand_priority(),
+                enostr::RelayDemandPriority::Important
+            );
+            assert!(bootstrap.allowed_for_source(relay_pkgs.source()));
+            assert!(!bootstrap.allowed_for_source(enostr::RelayUrlSource::RemoteAdvertised));
+        }
+        let bootstrap_fetch = bootstrap_fetch.expect("explicit authorless parent fetch");
+        let slot = runtime.slots.values().next().expect("thread slot");
+        let routes = &slot
+            .ready_plan()
+            .expect("ready thread plan")
+            .routes
+            .live_routed_relays;
+        assert!(routes.iter().any(|route| route.relay == hint));
+        assert!(routes.iter().all(|route| route.relay != bootstrap));
+
+        let mut catch_up = catch_up.into_effects();
+        assert_eq!(catch_up.len(), 1);
+        let ScopedSubEffect::StartAuthorOutboxPlanJob(job) = catch_up.pop().expect("catch-up job");
+        let (_, ops, effects) =
+            runtime.apply_plan_slot_ready(&ids, job.run(ndb.clone()), &reads, &ndb);
+        assert!(
+            ops.is_empty(),
+            "same snapshot must not restart either missing-ID fetch"
+        );
+        assert!(effects.into_effects().is_empty());
+
+        ndb.process_client_event(&unknown_parent.json().expect("parent JSON"))
+            .expect("ingest parent");
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let changed = loop {
+            let present = {
+                let txn = Transaction::new(&ndb).expect("transaction");
+                let present = ndb.get_note_by_id(&txn, unknown_id.bytes()).is_ok();
+                present
+            };
+            if present {
+                if let Some(changed) = runtime.next_thread_change().now_or_never() {
+                    break changed;
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "parent arrival did not notify thread watch"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        };
+        let mut effects = runtime.apply_thread_change(changed).into_effects();
+        assert_eq!(effects.len(), 1);
+        let ScopedSubEffect::StartAuthorOutboxPlanJob(job) = effects.pop().expect("arrival job");
+        let (_, ops, _) = runtime.apply_plan_slot_ready(&ids, job.run(ndb.clone()), &reads, &ndb);
+        let ops = ops.into_ops();
+        assert!(ops.iter().any(|op| matches!(
+            op,
+            ScopedSubOutboxOp::ClearFetch { id } if *id == bootstrap_fetch
+        )));
+        assert!(ops.iter().all(|op| !matches!(
+            op,
+            ScopedSubOutboxOp::StartFetch { filters, relay_pkgs, .. }
+                if relay_pkgs.urls().contains(&bootstrap)
+                    && filters.iter().any(|filter| filter.same_canonical_attributes(&expected))
+        )));
+        let txn = Transaction::new(&ndb).expect("transaction");
+        assert!(ndb.get_note_by_id(&txn, unknown_id.bytes()).is_ok());
+        assert!(ndb.get_note_by_id(&txn, known_id.bytes()).is_err());
+    }
+
     #[test]
     fn relay_list_ingestion_wait_delay_has_short_start_and_longer_tail() {
         assert_eq!(
@@ -2095,7 +2460,7 @@ mod tests {
         runtime.slots.insert(
             ready_slot_id,
             AuthorOutboxPlanSlot {
-                inputs: AuthorOutboxPlanInputs::new(&account_read_relays, &spec),
+                inputs: AuthorOutboxPlanInputs::new(&account_read_relays, &HashSet::new(), &spec),
                 thread: None,
                 owners: HashSet::from([ready_owner.clone()]),
                 state: AuthorOutboxPlanState::Ready(CachedAuthorOutboxPlan {

--- a/crates/notedeck/src/scoped_subs/author_plan/mod.rs
+++ b/crates/notedeck/src/scoped_subs/author_plan/mod.rs
@@ -48,13 +48,19 @@ pub(crate) struct AuthorOutboxPlanSlotId(u64);
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct AuthorOutboxPlanInputs {
     account_read_relays: HashSet<NormRelayUrl>,
+    bootstrap_relays: HashSet<NormRelayUrl>,
     spec: SubConfig,
 }
 
 impl AuthorOutboxPlanInputs {
-    fn new(account_read_relays: &HashSet<NormRelayUrl>, spec: &SubConfig) -> Self {
+    fn new(
+        account_read_relays: &HashSet<NormRelayUrl>,
+        bootstrap_relays: &HashSet<NormRelayUrl>,
+        spec: &SubConfig,
+    ) -> Self {
         Self {
             account_read_relays: account_read_relays.clone(),
+            bootstrap_relays: bootstrap_relays.clone(),
             spec: spec.clone(),
         }
     }
@@ -165,8 +171,8 @@ struct ThreadPlanState {
     /// Next failure's delay, doubled up to the cap and reset after recovery.
     retry_delay: Duration,
     available_plan: Option<CachedAuthorOutboxPlan>,
-    missing_ids: HashSet<NoteId>,
-    baseline_fetch: Option<OutboxSubId>,
+    baseline_fetch: MissingIdFetch,
+    bootstrap_fetch: MissingIdFetch,
     /// Shared discovery implementation, kept alive across ancestry snapshots.
     discovery: Option<RelayListDiscovery>,
     requested_authors: HashSet<Pubkey>,
@@ -179,8 +185,8 @@ impl Default for ThreadPlanState {
             retry_after: None,
             retry_delay: THREAD_PLAN_RETRY_DELAY,
             available_plan: None,
-            missing_ids: HashSet::new(),
-            baseline_fetch: None,
+            baseline_fetch: MissingIdFetch::default(),
+            bootstrap_fetch: MissingIdFetch::default(),
             discovery: None,
             requested_authors: HashSet::new(),
         }
@@ -204,9 +210,9 @@ impl ThreadPlanState {
         &mut self,
         ids: &OutboxIdRegistry,
         missing: HashSet<Pubkey>,
-        reads: &HashSet<NormRelayUrl>,
+        relays: &HashSet<NormRelayUrl>,
     ) -> ScopedSubOutboxOps {
-        if reads.is_empty() {
+        if relays.is_empty() {
             return ScopedSubOutboxOps::default();
         }
         let new_authors = missing
@@ -216,7 +222,7 @@ impl ThreadPlanState {
         if new_authors.is_empty() {
             return ScopedSubOutboxOps::default();
         }
-        let (discovery, ops) = start_relay_list_discovery(ids, new_authors, reads.clone());
+        let (discovery, ops) = start_relay_list_discovery(ids, new_authors, relays.clone());
         if let Some(existing) = &mut self.discovery {
             existing.chunks.extend(discovery.chunks);
         } else {
@@ -224,39 +230,47 @@ impl ThreadPlanState {
         }
         ops
     }
+}
 
-    /// Keep selected-account coverage for missing ancestors independent of
-    /// author relay-list availability. Replace the fetch only when IDs change.
-    fn request_missing_ids(
+/// One exact-ID fetch retained across thread snapshots, with normal one-shot EOSE cleanup.
+/// Remembering the requested IDs and relays prevents resending an unchanged fetch.
+#[derive(Default)]
+struct MissingIdFetch {
+    missing_ids: HashSet<NoteId>,
+    relays: HashSet<NormRelayUrl>,
+    id: Option<OutboxSubId>,
+}
+
+impl MissingIdFetch {
+    /// Replace the one-shot only when its missing IDs or destination relays change.
+    fn update(
         &mut self,
         missing_ids: HashSet<NoteId>,
+        relays: HashSet<NormRelayUrl>,
         ids: &OutboxIdRegistry,
-        inputs: &AuthorOutboxPlanInputs,
+        policy: RelayUrlPolicy,
     ) -> ScopedSubOutboxOps {
         let mut ops = ScopedSubOutboxOps::default();
-        if self.missing_ids == missing_ids {
+        if self.missing_ids == missing_ids && self.relays == relays {
             return ops;
         }
         self.missing_ids = missing_ids;
-        if let Some(id) = self.baseline_fetch.take() {
+        self.relays = relays;
+        if let Some(id) = self.id.take() {
             ops.clear_fetch(id);
         }
-        if self.missing_ids.is_empty() || inputs.account_read_relays.is_empty() {
+        if self.missing_ids.is_empty() || self.relays.is_empty() {
             return ops;
         }
         let mut missing = self.missing_ids.iter().copied().collect::<Vec<_>>();
         missing.sort_unstable_by_key(|id| *id.bytes());
         let id = ids.next_sub_id();
-        let policy = inputs.spec.baseline_policy();
         ops.start_fetch(
             id,
             vec![Filter::new().ids(missing.iter().map(NoteId::bytes)).build()],
-            RelayUrlPkgs::new(
-                inputs.account_read_relays.clone(),
-                RelayUrlPolicy::explicit(policy.demand_priority(), policy.routing_preference()),
-            ),
+            RelayUrlPkgs::new(self.relays.clone(), policy),
         );
-        self.baseline_fetch = Some(id);
+        self.id = Some(id);
         ops
     }
 }
@@ -333,6 +347,8 @@ pub(super) struct AuthorOutboxPlanAdvanceResult<'a> {
 /// Shared author-outbox planner. Author-filter plans remain frozen; thread
 /// plans rebuild on NDB ingestion while retaining their relay-list discovery.
 pub(super) struct AuthorOutboxPlanRuntime {
+    /// Injected discovery destinations, captured in each immutable plan input.
+    pub(super) bootstrap_relays: HashSet<NormRelayUrl>,
     owner_slots: HashMap<AuthorOutboxPlanOwner, AuthorOutboxPlanSlotId>,
     slots: HashMap<AuthorOutboxPlanSlotId, AuthorOutboxPlanSlot>,
     next_slot_id: u64,
@@ -342,6 +358,7 @@ pub(super) struct AuthorOutboxPlanRuntime {
 impl Default for AuthorOutboxPlanRuntime {
     fn default() -> Self {
         Self {
+            bootstrap_relays: HashSet::new(),
             owner_slots: HashMap::new(),
             slots: HashMap::new(),
             next_slot_id: 1,
@@ -502,7 +519,7 @@ impl AuthorOutboxPlanRuntime {
             account_pubkey,
             scoped,
         };
-        let inputs = AuthorOutboxPlanInputs::new(account_read_relays, spec);
+        let inputs = AuthorOutboxPlanInputs::new(account_read_relays, &self.bootstrap_relays, spec);
         let (slot_id, outbox_ops, slot_effects) = self.ensure_owner_slot(owner, inputs);
         effects.extend(slot_effects);
         let Some(slot_id) = slot_id else {
@@ -603,8 +620,10 @@ impl AuthorOutboxPlanRuntime {
         };
         let mut ops = ScopedSubOutboxOps::default();
         if let Some(thread) = slot.thread {
-            if let Some(id) = thread.baseline_fetch {
-                ops.clear_fetch(id);
+            for fetch in [thread.baseline_fetch, thread.bootstrap_fetch] {
+                if let Some(id) = fetch.id {
+                    ops.clear_fetch(id);
+                }
             }
             if let Some(discovery) = thread.discovery {
                 ops.extend(discovery.unsubscribe_all());
@@ -711,6 +730,11 @@ impl AuthorOutboxPlanRuntime {
             return (ScopedSubOutboxOps::default(), ScopedSubEffects::default());
         }
 
+        let discovery_relays = account_read_relays
+            .union(&slot.inputs.bootstrap_relays)
+            .cloned()
+            .collect::<HashSet<_>>();
+
         if let Some(snapshot) = result.thread.take() {
             let snapshot = match snapshot {
                 Ok(snapshot) => snapshot,
@@ -732,6 +756,14 @@ impl AuthorOutboxPlanRuntime {
                     return (ScopedSubOutboxOps::default(), ScopedSubEffects::default());
                 }
             };
+            // Account reads already have an explicit exact-ID fetch. A planned
+            // author route may still be unadmitted, so it cannot replace this demand.
+            let bootstrap_relays = slot
+                .inputs
+                .bootstrap_relays
+                .difference(&slot.inputs.account_read_relays)
+                .cloned()
+                .collect();
             let missing_authors = std::mem::take(&mut result.missing_authors);
             let cached = self.cached_plan_from_job_result(result);
             let slot = self.slots.get_mut(&slot_id).expect("validated plan slot");
@@ -765,8 +797,22 @@ impl AuthorOutboxPlanRuntime {
             if thread.retry_after.is_none() {
                 thread.retry_delay = THREAD_PLAN_RETRY_DELAY;
             }
-            let mut ops = thread.request_missing_ids(snapshot.missing_ids, ids, &slot.inputs);
-            ops.extend(thread.discover_authors(ids, missing_authors, account_read_relays));
+            let policy = slot.inputs.spec.baseline_policy();
+            let policy =
+                RelayUrlPolicy::explicit(policy.demand_priority(), policy.routing_preference());
+            let mut ops = thread.baseline_fetch.update(
+                snapshot.missing_ids,
+                slot.inputs.account_read_relays.clone(),
+                ids,
+                policy,
+            );
+            ops.extend(thread.bootstrap_fetch.update(
+                snapshot.missing_ids_without_author,
+                bootstrap_relays,
+                ids,
+                policy,
+            ));
+            ops.extend(thread.discover_authors(ids, missing_authors, &discovery_relays));
             thread.available_plan = None;
             slot.state = AuthorOutboxPlanState::Ready(cached);
             let effects = if catch_up {
@@ -780,14 +826,11 @@ impl AuthorOutboxPlanRuntime {
         let slot = self.slots.get_mut(&slot_id).expect("validated plan slot");
         if build_stage == AuthorOutboxBuildStage::Initial
             && !result.missing_authors.is_empty()
-            && !account_read_relays.is_empty()
+            && !discovery_relays.is_empty()
         {
             let original_missing_author_count = result.missing_authors.len();
-            let (discovery, outbox_ops) = start_relay_list_discovery(
-                ids,
-                result.missing_authors,
-                account_read_relays.clone(),
-            );
+            let (discovery, outbox_ops) =
+                start_relay_list_discovery(ids, result.missing_authors, discovery_relays);
             slot.state = AuthorOutboxPlanState::DiscoveringRelays {
                 discovery,
                 original_missing_author_count,

--- a/crates/notedeck/src/scoped_subs/author_plan/thread.rs
+++ b/crates/notedeck/src/scoped_subs/author_plan/thread.rs
@@ -25,6 +25,8 @@ pub(super) struct ThreadPlanSnapshot {
     pub(super) authors: HashSet<Pubkey>,
     /// Exact IDs that the account-read baseline still needs to fetch.
     pub(super) missing_ids: HashSet<NoteId>,
+    /// Missing IDs without a claimed author, eligible for bootstrap exact-ID fetches.
+    pub(super) missing_ids_without_author: HashSet<NoteId>,
 }
 
 /// Runtime-owned subscription retained across planning jobs.
@@ -132,6 +134,7 @@ pub(super) fn build_thread_plan(
             note_ids: snapshot.note_ids,
             authors: snapshot.authors,
             missing_ids: snapshot.missing_ids,
+            missing_ids_without_author: snapshot.missing_ids_without_author,
         })),
     }
 }

--- a/crates/notedeck/src/scoped_subs/author_plan/thread.rs
+++ b/crates/notedeck/src/scoped_subs/author_plan/thread.rs
@@ -1,0 +1,191 @@
+use enostr::{NormRelayUrl, NoteId, Pubkey, RelayUrlSource};
+use futures_util::Stream;
+use hashbrown::{HashMap, HashSet};
+use nostrdb::{Error, Filter, Ndb, SubscriptionStream};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use super::{
+    send_routed_relays, PlannedRoutedRelay, SendAuthorOutboxPlanConfig,
+    SendAuthorOutboxPlanJobResult, SendPlanFilter, SendPlannedRoutedRelay,
+};
+use crate::author_outbox::{
+    thread::ThreadSnapshot, RelayDirectoryRead, RelayDirectorySnapshot, RelayDirectoryState,
+    RoutedRelayPriority,
+};
+
+/// Data read by one thread-planning job, used to request and watch missing ancestry.
+#[derive(Debug, Default)]
+pub(super) struct ThreadPlanSnapshot {
+    /// Exact thread IDs encountered by this job, including missing ancestors.
+    pub(super) note_ids: HashSet<NoteId>,
+    /// Authors whose relay-list changes can affect these routes.
+    pub(super) authors: HashSet<Pubkey>,
+    /// Exact IDs that the account-read baseline still needs to fetch.
+    pub(super) missing_ids: HashSet<NoteId>,
+}
+
+/// Runtime-owned subscription retained across planning jobs.
+/// The stream queues arrivals during a job and unsubscribes when dropped.
+pub(super) struct ThreadWatch {
+    note_ids: HashSet<NoteId>,
+    authors: HashSet<Pubkey>,
+    stream: SubscriptionStream,
+}
+
+impl ThreadWatch {
+    /// Subscribe before the runtime schedules the job that catches up this coverage.
+    pub(super) fn new(
+        ndb: &Ndb,
+        note_ids: HashSet<NoteId>,
+        authors: HashSet<Pubkey>,
+    ) -> Result<Self, Error> {
+        if note_ids.is_empty() {
+            return Err(Error::SubscriptionError);
+        }
+        let mut filters = vec![Filter::new()
+            .ids(note_ids.iter().map(NoteId::bytes))
+            .build()];
+        if !authors.is_empty() {
+            filters.push(
+                Filter::new()
+                    .authors(authors.iter().map(Pubkey::bytes))
+                    .kinds([10002])
+                    .build(),
+            );
+        }
+        let stream = ndb.subscribe(&filters)?.stream(ndb).notes_per_await(64);
+        Ok(Self {
+            note_ids,
+            authors,
+            stream,
+        })
+    }
+
+    /// Keep the existing subscription and its queued arrivals when coverage suffices.
+    pub(super) fn covers(&self, note_ids: &HashSet<NoteId>, authors: &HashSet<Pubkey>) -> bool {
+        note_ids.is_subset(&self.note_ids) && authors.is_subset(&self.authors)
+    }
+}
+
+impl Stream for ThreadWatch {
+    type Item = ();
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.stream)
+            .poll_next(cx)
+            .map(|batch| batch.map(|_| ()))
+    }
+}
+
+/// Build thread routes from available ancestors, relay hints, and author lists.
+///
+/// Context authors select relays without narrowing the requested event authors.
+/// Available routes are returned even when other authors still need discovery.
+#[profiling::function]
+pub(super) fn build_thread_plan(
+    ndb: Ndb,
+    input: SendAuthorOutboxPlanConfig,
+    seeds: HashSet<NoteId>,
+) -> SendAuthorOutboxPlanJobResult {
+    let snapshot = match ThreadSnapshot::load(&ndb, &seeds) {
+        Ok(snapshot) => snapshot,
+        Err(err) => {
+            return SendAuthorOutboxPlanJobResult {
+                live_routed_relays: Vec::new(),
+                full_history_routed_relays: Vec::new(),
+                missing_authors: HashSet::new(),
+                thread: Some(Err(err)),
+            };
+        }
+    };
+    let directory = RelayDirectorySnapshot::from_ndb_authors(&ndb, &snapshot.authors);
+    let missing_authors = directory.missing_authors(&snapshot.authors);
+    let mut relays = snapshot.relays;
+    for author in &snapshot.authors {
+        if let RelayDirectoryState::Known(author_relays) = directory.author_state(author) {
+            relays.extend(author_relays.iter().cloned());
+        }
+    }
+    relays.retain(|relay| {
+        !input.account_read_relays.contains(relay)
+            && relay.allowed_for_source(RelayUrlSource::RemoteAdvertised)
+    });
+    let mut relays = relays.into_iter().collect::<Vec<_>>();
+    relays.sort_unstable();
+
+    let mut missing_ids = snapshot.missing_ids.iter().copied().collect::<Vec<_>>();
+    missing_ids.sort_unstable_by_key(|id| *id.bytes());
+    let missing_filter = (!missing_ids.is_empty()).then(|| {
+        Filter::new()
+            .ids(missing_ids.iter().map(NoteId::bytes))
+            .build()
+    });
+
+    SendAuthorOutboxPlanJobResult {
+        live_routed_relays: thread_routes(&relays, &input.live_filters, missing_filter.as_ref()),
+        full_history_routed_relays: thread_routes(&relays, &input.full_history_filters, None),
+        missing_authors,
+        thread: Some(Ok(ThreadPlanSnapshot {
+            note_ids: snapshot.note_ids,
+            authors: snapshot.authors,
+            missing_ids: snapshot.missing_ids,
+        })),
+    }
+}
+
+/// Copy unchanged thread filters to each relay, retaining filter membership.
+///
+/// Routed live state uses map membership to distinguish demand from a removed
+/// route. Empty author sets suffice because these filters remain unmodified;
+/// context authors only select relays and need not be copied to every route.
+fn thread_routes(
+    relays: &[NormRelayUrl],
+    filters: &[SendPlanFilter],
+    missing_filter: Option<&Filter>,
+) -> Vec<SendPlannedRoutedRelay> {
+    if filters.is_empty() && missing_filter.is_none() {
+        return Vec::new();
+    }
+
+    let mut filters = filters.iter().collect::<Vec<_>>();
+    filters.sort_unstable_by_key(|filter| filter.filter_index);
+    let mut route_filters = filters
+        .iter()
+        .map(|filter| filter.filter.as_filter().clone())
+        .collect::<Vec<_>>();
+    let mut authors_by_filter_index = filters
+        .iter()
+        .map(|filter| (filter.filter_index, HashSet::new()))
+        .collect::<HashMap<usize, HashSet<Pubkey>>>();
+    if let Some(missing) = missing_filter {
+        let filter_index = filters.last().map_or(0, |filter| filter.filter_index + 1);
+        route_filters.push(missing.clone());
+        authors_by_filter_index.insert(filter_index, HashSet::new());
+    }
+
+    let routes = relays
+        .iter()
+        .enumerate()
+        .map(|(order, relay)| PlannedRoutedRelay {
+            relay: relay.clone(),
+            // Every route carries the same thread filters, so each contributes
+            // one thread's relay coverage regardless of its context authors.
+            relay_priority: RoutedRelayPriority {
+                connection_weight: 1,
+                order,
+            },
+            filters: route_filters.clone(),
+            authors_by_filter_index: authors_by_filter_index.clone(),
+        })
+        .collect();
+    let mut routes = send_routed_relays(routes);
+    for route in &mut routes {
+        route
+            .authors_by_filter_index
+            .sort_unstable_by_key(|(filter_index, _)| *filter_index);
+    }
+    routes
+}

--- a/crates/notedeck/src/scoped_subs/author_plan/thread.rs
+++ b/crates/notedeck/src/scoped_subs/author_plan/thread.rs
@@ -189,3 +189,1000 @@ fn thread_routes(
     }
     routes
 }
+
+#[test]
+fn thread_plan_preserves_reply_filters_and_fetches_missing_parents_by_exact_id() {
+    use super::{SendAuthorOutboxPlanConfig, SendPlanFilter};
+    use enostr::{NormRelayUrl, NoteId};
+    use hashbrown::HashSet;
+    use nostrdb::{Config, Filter, IngestMetadata, Ndb, NoteBuilder, SendFilter, Transaction};
+    use std::time::{Duration, Instant};
+
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let ndb = Ndb::new(tmp.path().to_str().expect("path"), &Config::new()).expect("ndb");
+    let root = NoteId::new([11; 32]);
+    let parent = NoteId::new([12; 32]);
+    let baseline = NormRelayUrl::new("wss://baseline.example.com").expect("relay");
+    let author_relay = NormRelayUrl::new("wss://author.example.com").expect("relay");
+    let parent_hint = NormRelayUrl::new("wss://parent.example.com/inbox").expect("relay");
+    let selected = NoteBuilder::new()
+        .kind(1)
+        .created_at(1)
+        .content("reply")
+        .start_tag()
+        .tag_str("e")
+        .tag_id(root.bytes())
+        .tag_str(baseline.as_str())
+        .tag_str("root")
+        .start_tag()
+        .tag_str("e")
+        .tag_id(parent.bytes())
+        .tag_str(parent_hint.as_str())
+        .tag_str("reply")
+        .sign(&[1; 32])
+        .build()
+        .expect("selected note");
+    let relay_list = NoteBuilder::new()
+        .kind(10002)
+        .created_at(2)
+        .content("")
+        .start_tag()
+        .tag_str("r")
+        .tag_str(author_relay.as_str())
+        .tag_str("write")
+        .start_tag()
+        .tag_str("r")
+        .tag_str("wss://read-only.example.com")
+        .tag_str("read")
+        .sign(&[1; 32])
+        .build()
+        .expect("relay list");
+    for note in [&selected, &relay_list] {
+        ndb.process_event_with(
+            &note.json().expect("json"),
+            IngestMetadata::new().client(true).relay(baseline.as_str()),
+        )
+        .expect("ingest note");
+    }
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let txn = Transaction::new(&ndb).expect("txn");
+        if [&selected, &relay_list]
+            .into_iter()
+            .all(|note| ndb.get_note_by_id(&txn, note.id()).is_ok())
+        {
+            break;
+        }
+        assert!(Instant::now() < deadline, "thread notes were not ingested");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    let replies = Filter::new()
+        .kinds([1])
+        .event(root.bytes())
+        .limit(500)
+        .build();
+    let root_filter = Filter::new().ids([root.bytes()]).limit(1).build();
+    let history = Filter::new().kinds([1]).event(root.bytes()).build();
+    let result = build_thread_plan(
+        ndb,
+        SendAuthorOutboxPlanConfig {
+            account_read_relays: HashSet::from([baseline]),
+            live_filters: [replies.clone(), root_filter.clone()]
+                .into_iter()
+                .enumerate()
+                .map(|(filter_index, filter)| SendPlanFilter {
+                    filter_index,
+                    filter: SendFilter::try_from_filter(filter).expect("send filter"),
+                })
+                .collect(),
+            full_history_filters: vec![SendPlanFilter {
+                filter_index: 0,
+                filter: SendFilter::try_from_filter(history.clone()).expect("send filter"),
+            }],
+        },
+        HashSet::from([root, NoteId::new(*selected.id())]),
+    );
+
+    assert!(result.missing_authors.is_empty());
+    assert_eq!(
+        result
+            .live_routed_relays
+            .iter()
+            .map(|route| &route.relay)
+            .collect::<Vec<_>>(),
+        vec![&author_relay, &parent_hint]
+    );
+    for route in &result.live_routed_relays {
+        assert_eq!(route.filters.len(), 3);
+        assert_eq!(
+            route.filters[0].as_filter().json().expect("json"),
+            replies.json().expect("json")
+        );
+        assert_eq!(
+            route.filters[1].as_filter().json().expect("json"),
+            root_filter.json().expect("json")
+        );
+        let missing: serde_json::Value =
+            serde_json::from_str(&route.filters[2].as_filter().json().expect("json"))
+                .expect("filter json");
+        assert_eq!(
+            missing,
+            serde_json::json!({ "ids": [root.hex(), parent.hex()] })
+        );
+        assert_eq!(route.authors_by_filter_index.len(), 3);
+    }
+    assert_eq!(result.full_history_routed_relays.len(), 2);
+    for route in &result.full_history_routed_relays {
+        assert_eq!(route.filters.len(), 1);
+        assert_eq!(
+            route.filters[0].as_filter().json().expect("json"),
+            history.json().expect("json")
+        );
+    }
+    let thread = result
+        .thread
+        .expect("thread result")
+        .expect("thread snapshot");
+    assert_eq!(thread.missing_ids, HashSet::from([root, parent]));
+    assert!(thread.note_ids.contains(&root));
+    assert!(thread.note_ids.contains(&parent));
+}
+
+#[test]
+fn thread_watch_tracks_late_notes_and_author_relay_lists_and_releases_its_subscription() {
+    use futures_util::{FutureExt, StreamExt};
+    use nostrdb::{Config, NoteBuilder};
+    use std::time::{Duration, Instant};
+
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let ndb = Ndb::new(tmp.path().to_str().expect("path"), &Config::new()).expect("ndb");
+    let parent = NoteBuilder::new()
+        .kind(1)
+        .created_at(1)
+        .content("late parent")
+        .sign(&[2; 32])
+        .build()
+        .expect("parent note");
+    let selected = NoteBuilder::new()
+        .kind(1)
+        .created_at(2)
+        .content("late selected")
+        .start_tag()
+        .tag_str("e")
+        .tag_id(parent.id())
+        .tag_str("")
+        .tag_str("reply")
+        .sign(&[1; 32])
+        .build()
+        .expect("selected note");
+    let seeds = HashSet::from([NoteId::new(*selected.id())]);
+    let wait_for_change = |watch: &mut ThreadWatch| {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while watch.next().now_or_never().is_none() {
+            assert!(Instant::now() < deadline, "thread watch missed ingestion");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    };
+
+    let snapshot = ThreadSnapshot::load(&ndb, &seeds).expect("missing selected snapshot");
+    assert_eq!(snapshot.missing_ids, seeds);
+    let mut watch = ThreadWatch::new(&ndb, snapshot.note_ids, snapshot.authors).expect("watch");
+    assert_eq!(ndb.subscription_count(), 1);
+    assert!(watch.next().now_or_never().is_none());
+    ndb.process_client_event(&selected.json().expect("json"))
+        .expect("ingest selected");
+    wait_for_change(&mut watch);
+    drop(watch);
+    assert_eq!(ndb.subscription_count(), 0);
+
+    let snapshot = ThreadSnapshot::load(&ndb, &seeds).expect("missing parent snapshot");
+    assert_eq!(
+        snapshot.missing_ids,
+        HashSet::from([NoteId::new(*parent.id())])
+    );
+    let mut watch = ThreadWatch::new(&ndb, snapshot.note_ids, snapshot.authors).expect("watch");
+    ndb.process_client_event(&parent.json().expect("json"))
+        .expect("ingest parent");
+    wait_for_change(&mut watch);
+    drop(watch);
+
+    let snapshot = ThreadSnapshot::load(&ndb, &seeds).expect("available parents snapshot");
+    assert!(snapshot.missing_ids.is_empty());
+    assert!(snapshot.authors.contains(&Pubkey::new(*parent.pubkey())));
+    let mut watch = ThreadWatch::new(&ndb, snapshot.note_ids, snapshot.authors).expect("watch");
+    let relay_list = NoteBuilder::new()
+        .kind(10002)
+        .created_at(3)
+        .content("")
+        .start_tag()
+        .tag_str("r")
+        .tag_str("wss://late-author.example.com")
+        .tag_str("write")
+        .sign(&[2; 32])
+        .build()
+        .expect("relay list");
+    ndb.process_client_event(&relay_list.json().expect("json"))
+        .expect("ingest relay list");
+    wait_for_change(&mut watch);
+    drop(watch);
+    assert_eq!(ndb.subscription_count(), 0);
+}
+
+#[test]
+fn thread_plans_catch_up_after_subscription_setup_and_retain_inflight_arrivals() {
+    use super::{AuthorOutboxPlanAdvanceRequest, AuthorOutboxPlanRuntime};
+    use crate::scoped_subs::{
+        config::{ResolvedSubScope, ScopedSubKey, SubKey},
+        ScopedSubEffect, SubConfig,
+    };
+    use enostr::OutboxIdRegistry;
+    use futures_util::FutureExt;
+    use nostrdb::{Config, Note, NoteBuilder, Transaction};
+    use std::{
+        future::Future,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        task::{Wake, Waker},
+        time::{Duration, Instant},
+    };
+
+    // Register a real waker: ingestion, not an advancing timer, must wake the bridge.
+    struct IngestionWake(AtomicBool);
+    impl Wake for IngestionWake {
+        fn wake(self: Arc<Self>) {
+            self.0.store(true, Ordering::Release);
+        }
+    }
+
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let ndb = Ndb::new(tmp.path().to_str().expect("path"), &Config::new()).expect("ndb");
+    let relay_list = |created_at, relay: &str| {
+        NoteBuilder::new()
+            .kind(10002)
+            .created_at(created_at)
+            .content("")
+            .start_tag()
+            .tag_str("r")
+            .tag_str(relay)
+            .tag_str("write")
+            .sign(&[3; 32])
+            .build()
+            .expect("relay list")
+    };
+    let first_list = relay_list(1, "wss://ancestor-one.example.com");
+    let second_list = relay_list(2, "wss://ancestor-two.example.com");
+    let third_list = relay_list(3, "wss://ancestor-three.example.com");
+    let ancestor = NoteId::new([31; 32]);
+    let parent = NoteBuilder::new()
+        .kind(1)
+        .content("parent")
+        .start_tag()
+        .tag_str("e")
+        .tag_id(ancestor.bytes())
+        .tag_str("")
+        .tag_str("root")
+        .tag_id(first_list.pubkey())
+        .sign(&[2; 32])
+        .build()
+        .expect("parent");
+    let selected = NoteBuilder::new()
+        .kind(1)
+        .content("selected reply")
+        .start_tag()
+        .tag_str("e")
+        .tag_id(parent.id())
+        .tag_str("wss://hint.example.com/inbox")
+        .tag_str("reply")
+        .sign(&[1; 32])
+        .build()
+        .expect("selected");
+    let ingest = |note: &Note<'_>| {
+        ndb.process_client_event(&note.json().expect("JSON"))
+            .expect("ingest");
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let txn = Transaction::new(&ndb).expect("txn");
+            if ndb.get_note_by_id(&txn, note.id()).is_ok() {
+                break;
+            }
+            assert!(Instant::now() < deadline, "note was not ingested");
+            std::thread::sleep(Duration::from_millis(2));
+        }
+    };
+    let next_job = |effects: super::ScopedSubEffects| {
+        let mut jobs = effects.into_effects();
+        assert_eq!(jobs.len(), 1, "exactly one follow-up job");
+        let ScopedSubEffect::StartAuthorOutboxPlanJob(job) = jobs.pop().expect("job");
+        job
+    };
+    let has_relay = |runtime: &AuthorOutboxPlanRuntime, relay: &str| {
+        runtime
+            .slots
+            .values()
+            .next()
+            .expect("slot")
+            .ready_plan()
+            .expect("ready")
+            .routes
+            .live_routed_relays
+            .iter()
+            .any(|route| route.relay.as_str() == relay)
+    };
+    ingest(&selected);
+    let selected_id = NoteId::new(*selected.id());
+    let spec = SubConfig::builder(vec![Filter::new().ids([selected.id()]).build()])
+        .accounts_read_important()
+        .with_author_outbox_augmentation()
+        .for_thread(selected_id, [])
+        .build();
+    let reads = HashSet::new();
+    let ids = OutboxIdRegistry::new();
+    let scoped = ScopedSubKey {
+        scope: ResolvedSubScope::Global,
+        key: SubKey::new("thread-setup-races"),
+    };
+    let mut runtime = AuthorOutboxPlanRuntime::default();
+    let job = next_job(
+        runtime
+            .advance(AuthorOutboxPlanAdvanceRequest {
+                account_pubkey: Pubkey::new([9; 32]),
+                scoped: scoped.clone(),
+                account_read_relays: &reads,
+                spec: &spec,
+            })
+            .effects,
+    );
+
+    // The worker's result is already complete when the parent is stored.
+    let initial = job.run(ndb.clone());
+    assert_eq!(ndb.subscription_count(), 0);
+    assert!(initial
+        .result
+        .thread
+        .as_ref()
+        .unwrap()
+        .as_ref()
+        .unwrap()
+        .missing_ids
+        .contains(&NoteId::new(*parent.id())));
+    ingest(&parent);
+    let (owners, _, effects) = runtime.apply_plan_slot_ready(&ids, initial, &reads, &ndb);
+    assert_eq!(
+        owners,
+        vec![scoped.clone()],
+        "first plan is usable during catch-up"
+    );
+    assert!(has_relay(&runtime, "wss://hint.example.com/inbox"));
+    assert_eq!(ndb.subscription_count(), 1);
+    let parent_snapshot = next_job(effects).run(ndb.clone());
+    assert!(parent_snapshot
+        .result
+        .thread
+        .as_ref()
+        .unwrap()
+        .as_ref()
+        .unwrap()
+        .authors
+        .contains(&Pubkey::new(*first_list.pubkey())));
+
+    // A newly discovered author's list arrives before that author is subscribed.
+    ingest(&first_list);
+    let (_, _, effects) = runtime.apply_plan_slot_ready(&ids, parent_snapshot, &reads, &ndb);
+    assert!(
+        !has_relay(&runtime, "wss://ancestor-one.example.com/"),
+        "completed result does not change"
+    );
+    assert_eq!(
+        ndb.subscription_count(),
+        1,
+        "expansion releases the old subscription"
+    );
+    let catch_up = next_job(effects).run(ndb.clone());
+    let (_, _, effects) = runtime.apply_plan_slot_ready(&ids, catch_up, &reads, &ndb);
+    assert!(
+        effects.into_effects().is_empty(),
+        "unchanged coverage needs no catch-up"
+    );
+    assert!(has_relay(&runtime, "wss://ancestor-one.example.com/"));
+    assert!(
+        runtime.next_deadline().is_none(),
+        "idle thread has no timer"
+    );
+    let sub_id = runtime
+        .slots
+        .values()
+        .next()
+        .unwrap()
+        .thread
+        .as_ref()
+        .unwrap()
+        .watch
+        .as_ref()
+        .unwrap()
+        .stream
+        .sub_id();
+
+    let wake = Arc::new(IngestionWake(AtomicBool::new(false)));
+    let waker = Waker::from(wake.clone());
+    let mut cx = Context::from_waker(&waker);
+    let changed = {
+        let mut notification = std::pin::pin!(runtime.next_thread_change());
+        assert!(notification.as_mut().poll(&mut cx).is_pending());
+        ingest(&second_list);
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !wake.0.load(Ordering::Acquire) {
+            assert!(
+                Instant::now() < deadline,
+                "NDB did not wake the waiting bridge"
+            );
+            std::thread::sleep(Duration::from_millis(2));
+        }
+        let Poll::Ready(changed) = notification.as_mut().poll(&mut cx) else {
+            panic!("ingestion wake must deliver the relay-list change");
+        };
+        changed
+    };
+    let job = next_job(runtime.apply_thread_change(changed));
+    let second_plan = job.run(ndb.clone());
+
+    // Another arrival after the snapshot stays queued while the job is in flight.
+    ingest(&third_list);
+    assert!(runtime.next_thread_change().now_or_never().is_none());
+    let (_, _, effects) = runtime.apply_plan_slot_ready(&ids, second_plan, &reads, &ndb);
+    assert!(effects.into_effects().is_empty());
+    assert!(has_relay(&runtime, "wss://ancestor-two.example.com/"));
+    assert!(!has_relay(&runtime, "wss://ancestor-three.example.com/"));
+    assert_eq!(
+        runtime
+            .slots
+            .values()
+            .next()
+            .unwrap()
+            .thread
+            .as_ref()
+            .unwrap()
+            .watch
+            .as_ref()
+            .unwrap()
+            .stream
+            .sub_id(),
+        sub_id,
+        "retain subscription and queued arrivals"
+    );
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let changed = loop {
+        if let Some(changed) = runtime.next_thread_change().now_or_never() {
+            break changed;
+        }
+        assert!(Instant::now() < deadline, "arrival during the job was lost");
+        std::thread::sleep(Duration::from_millis(2));
+    };
+    let job = next_job(runtime.apply_thread_change(changed));
+    let (_, _, effects) = runtime.apply_plan_slot_ready(&ids, job.run(ndb.clone()), &reads, &ndb);
+    assert!(effects.into_effects().is_empty());
+    assert!(has_relay(&runtime, "wss://ancestor-three.example.com/"));
+    assert!(!has_relay(&runtime, "wss://ancestor-two.example.com/"));
+    assert!(runtime.next_deadline().is_none());
+    runtime.remove_scoped(&scoped);
+    assert_eq!(ndb.subscription_count(), 0);
+}
+
+#[test]
+fn thread_plan_failure_retains_coverage_until_a_successful_retry() {
+    use super::super::config::{ResolvedSubScope, ScopedSubKey, SubConfig, SubKey};
+    use super::{
+        AuthorOutboxPlanAdvanceRequest, AuthorOutboxPlanJobCompletion, AuthorOutboxPlanRuntime,
+        ScopedSubEffect, THREAD_PLAN_RETRY_DELAY,
+    };
+    use enostr::OutboxIdRegistry;
+    use futures_util::FutureExt;
+    use nostrdb::{Config, NoteBuilder, Transaction};
+    use std::time::{Duration, Instant};
+
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let ndb = Ndb::new(tmp.path().to_str().expect("path"), &Config::new()).expect("ndb");
+    let parent = NoteId::new([12; 32]);
+    let selected = NoteBuilder::new()
+        .kind(1)
+        .created_at(1)
+        .content("reply")
+        .start_tag()
+        .tag_str("e")
+        .tag_id(parent.bytes())
+        .tag_str("wss://hint.example.com")
+        .tag_str("reply")
+        .sign(&[1; 32])
+        .build()
+        .expect("note");
+    let wait_for_note = |id: &[u8; 32]| {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let txn = Transaction::new(&ndb).expect("txn");
+            if ndb.get_note_by_id(&txn, id).is_ok() {
+                break;
+            }
+            assert!(Instant::now() < deadline, "note was not ingested");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    };
+    ndb.process_client_event(&selected.json().expect("json"))
+        .expect("ingest selected");
+    wait_for_note(selected.id());
+
+    let spec = SubConfig::builder(vec![
+        Filter::new().kinds([1]).event(parent.bytes()).build(),
+        Filter::new().ids([parent.bytes()]).build(),
+    ])
+    .accounts_read_important()
+    .with_author_outbox_augmentation()
+    .for_thread(parent, [NoteId::new(*selected.id())])
+    .build();
+    let reads = HashSet::from([NormRelayUrl::new("wss://account.example.com").expect("relay")]);
+    let scoped = ScopedSubKey {
+        scope: ResolvedSubScope::Global,
+        key: SubKey::new("thread-plan-failed-replacement"),
+    };
+    let account = Pubkey::new([9; 32]);
+    let ids = OutboxIdRegistry::new();
+    let mut runtime = AuthorOutboxPlanRuntime::default();
+    let mut initial_jobs = runtime
+        .advance(AuthorOutboxPlanAdvanceRequest {
+            account_pubkey: account,
+            scoped: scoped.clone(),
+            account_read_relays: &reads,
+            spec: &spec,
+        })
+        .effects
+        .into_effects();
+    let ScopedSubEffect::StartAuthorOutboxPlanJob(job) = initial_jobs.pop().expect("initial job");
+    let (_, _, effects) = runtime.apply_plan_slot_ready(&ids, job.run(ndb.clone()), &reads, &ndb);
+    let mut jobs = effects.into_effects();
+    assert_eq!(jobs.len(), 1, "first subscription schedules catch-up");
+    let ScopedSubEffect::StartAuthorOutboxPlanJob(job) = jobs.pop().expect("catch-up job");
+    let (_, _, effects) = runtime.apply_plan_slot_ready(&ids, job.run(ndb.clone()), &reads, &ndb);
+    assert!(effects.into_effects().is_empty());
+    let slot = runtime.slots.values().next().expect("slot");
+    let initial_generation = slot.ready_plan().expect("ready").generation;
+    let baseline_fetch = slot
+        .thread
+        .as_ref()
+        .expect("thread")
+        .baseline_fetch
+        .expect("baseline fetch");
+    assert_eq!(
+        slot.ready_plan()
+            .expect("ready")
+            .routes
+            .live_routed_relays
+            .len(),
+        1
+    );
+
+    let list = NoteBuilder::new()
+        .kind(10002)
+        .created_at(2)
+        .content("")
+        .start_tag()
+        .tag_str("r")
+        .tag_str("wss://author.example.com")
+        .tag_str("write")
+        .sign(&[1; 32])
+        .build()
+        .expect("relay list");
+    ndb.process_client_event(&list.json().expect("json"))
+        .expect("ingest relay list");
+    wait_for_note(list.id());
+    let changed = runtime
+        .next_thread_change()
+        .now_or_never()
+        .expect("relay-list notification");
+    let mut jobs = runtime.apply_thread_change(changed).into_effects();
+    assert_eq!(jobs.len(), 1, "relay-list ingestion starts a replacement");
+    let ScopedSubEffect::StartAuthorOutboxPlanJob(job) = jobs.pop().expect("replacement job");
+    let failed = AuthorOutboxPlanJobCompletion {
+        slot_id: job.slot_id,
+        build_stage: job.build_stage,
+        result: SendAuthorOutboxPlanJobResult {
+            live_routed_relays: Vec::new(),
+            full_history_routed_relays: Vec::new(),
+            missing_authors: HashSet::new(),
+            thread: Some(Err(nostrdb::Error::NotFound)),
+        },
+    };
+    let (_, ops, effects) = runtime.apply_plan_slot_ready(&ids, failed, &reads, &ndb);
+    assert!(
+        effects.into_effects().is_empty(),
+        "failure retries after its deadline"
+    );
+    assert!(
+        ops.is_empty(),
+        "a failed snapshot must not clear working fetches"
+    );
+    let slot = runtime.slots.values().next().expect("slot");
+    assert_eq!(
+        slot.ready_plan().expect("retained plan").generation,
+        initial_generation
+    );
+    assert_eq!(
+        slot.ready_plan()
+            .expect("retained plan")
+            .routes
+            .live_routed_relays
+            .len(),
+        1
+    );
+    let thread = slot.thread.as_ref().expect("thread");
+    assert_eq!(thread.baseline_fetch, Some(baseline_fetch));
+    assert_eq!(thread.missing_ids, HashSet::from([parent]));
+
+    let mut retry_jobs = runtime
+        .apply_relay_list_discovery_retry_due(Instant::now() + THREAD_PLAN_RETRY_DELAY)
+        .1
+        .into_effects();
+    assert_eq!(retry_jobs.len(), 1, "failed snapshot schedules another job");
+    let ScopedSubEffect::StartAuthorOutboxPlanJob(retry) = retry_jobs.pop().expect("retry job");
+    let (_, ops, effects) =
+        runtime.apply_plan_slot_ready(&ids, retry.run(ndb.clone()), &reads, &ndb);
+    assert!(
+        effects.into_effects().is_empty(),
+        "recovery retains the existing subscription"
+    );
+    assert!(
+        ops.is_empty(),
+        "unchanged missing IDs retain their baseline fetch"
+    );
+    let slot = runtime.slots.values().next().expect("slot");
+    assert!(slot.ready_plan().expect("recovered plan").generation > initial_generation);
+    assert_eq!(
+        slot.ready_plan()
+            .expect("recovered plan")
+            .routes
+            .live_routed_relays
+            .len(),
+        2
+    );
+    let thread = slot.thread.as_ref().expect("thread");
+    assert_eq!(thread.baseline_fetch, Some(baseline_fetch));
+    assert!(thread.watch.is_some());
+    assert_eq!(ndb.subscription_count(), 1);
+}
+
+#[test]
+fn thread_plan_failures_back_off_until_reads_and_subscription_recover() {
+    use super::super::config::{ResolvedSubScope, ScopedSubKey, SubConfig, SubKey};
+    use super::{
+        AuthorOutboxPlanAdvanceRequest, AuthorOutboxPlanJobRequest, AuthorOutboxPlanRuntime,
+        ScopedSubEffect, ScopedSubEffects,
+    };
+    use enostr::OutboxIdRegistry;
+    use std::time::{Duration, Instant};
+
+    fn next_job(effects: ScopedSubEffects) -> AuthorOutboxPlanJobRequest {
+        let mut effects = effects.into_effects();
+        assert_eq!(effects.len(), 1, "exactly one planning job");
+        let ScopedSubEffect::StartAuthorOutboxPlanJob(job) = effects.pop().unwrap();
+        job
+    }
+
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let ndb = Ndb::new(tmp.path().to_str().expect("path"), &nostrdb::Config::new()).expect("ndb");
+    let root = NoteId::new([42; 32]);
+    let filters = [Filter::new().ids([root.bytes()]).build()];
+    let mut blockers = Vec::new();
+    while let Ok(subscription) = ndb.subscribe(&filters) {
+        blockers.push(subscription.stream(&ndb));
+        assert!(
+            blockers.len() < 1024,
+            "subscription capacity must be finite"
+        );
+    }
+    assert!(!blockers.is_empty(), "fill NDB's subscription capacity");
+
+    let spec = SubConfig::builder(filters.into())
+        .accounts_read_important()
+        .with_author_outbox_augmentation()
+        .for_thread(root, [])
+        .build();
+    let scoped = ScopedSubKey {
+        scope: ResolvedSubScope::Global,
+        key: SubKey::new("thread-plan-exponential-backoff"),
+    };
+    let reads = HashSet::new();
+    let ids = OutboxIdRegistry::new();
+    let mut runtime = AuthorOutboxPlanRuntime::default();
+    let mut job = next_job(
+        runtime
+            .advance(AuthorOutboxPlanAdvanceRequest {
+                account_pubkey: Pubkey::new([1; 32]),
+                scoped: scoped.clone(),
+                account_read_relays: &reads,
+                spec: &spec,
+            })
+            .effects,
+    );
+    let slot_id = job.slot_id;
+
+    for attempt in 0..14 {
+        let mut completion = job.run(ndb.clone());
+        if attempt % 2 == 0 {
+            // Exercise the same completion boundary as an NDB read error.
+            completion.result.thread = Some(Err(nostrdb::Error::TransactionFailed));
+        }
+        // Odd attempts read successfully, but real subscription setup fails.
+        let expected = Duration::from_millis(100u64 << attempt).min(Duration::from_secs(60));
+        let before = Instant::now();
+        let (_, _, effects) = runtime.apply_plan_slot_ready(&ids, completion, &reads, &ndb);
+        let after = Instant::now();
+        assert!(effects.into_effects().is_empty());
+        let deadline = runtime.next_deadline().expect("retry deadline");
+        assert!(
+            (before + expected..=after + expected).contains(&deadline),
+            "attempt {attempt} should retry after {expected:?}, got {:?}",
+            deadline.saturating_duration_since(before),
+        );
+        assert!(
+            runtime
+                .apply_relay_list_discovery_retry_due(deadline - Duration::from_nanos(1))
+                .1
+                .into_effects()
+                .is_empty(),
+            "the timer cannot start a job before its deadline"
+        );
+        job = next_job(runtime.apply_relay_list_discovery_retry_due(deadline).1);
+        assert!(runtime.next_deadline().is_none(), "no retry during a job");
+    }
+
+    drop(blockers);
+    let (_, _, effects) = runtime.apply_plan_slot_ready(&ids, job.run(ndb.clone()), &reads, &ndb);
+    let catch_up = next_job(effects);
+    assert!(runtime.next_deadline().is_none());
+    assert_eq!(
+        runtime.slots[&slot_id].thread.as_ref().unwrap().retry_delay,
+        Duration::from_millis(100),
+        "successful subscription setup resets backoff before catch-up"
+    );
+    let (_, _, effects) =
+        runtime.apply_plan_slot_ready(&ids, catch_up.run(ndb.clone()), &reads, &ndb);
+    assert!(effects.into_effects().is_empty());
+    assert_eq!(ndb.subscription_count(), 1);
+
+    // Recovery resets backoff both after setup and with an already-covering watch.
+    for _ in 0..2 {
+        let mut completion = next_job(runtime.apply_thread_change(slot_id)).run(ndb.clone());
+        completion.result.thread = Some(Err(nostrdb::Error::TransactionFailed));
+        let before = Instant::now();
+        let (_, _, effects) = runtime.apply_plan_slot_ready(&ids, completion, &reads, &ndb);
+        let after = Instant::now();
+        assert!(effects.into_effects().is_empty());
+        let deadline = runtime.next_deadline().expect("retry after new failure");
+        let base = Duration::from_millis(100);
+        assert!((before + base..=after + base).contains(&deadline));
+        let retry = next_job(runtime.apply_relay_list_discovery_retry_due(deadline).1);
+        let (_, _, effects) =
+            runtime.apply_plan_slot_ready(&ids, retry.run(ndb.clone()), &reads, &ndb);
+        assert!(effects.into_effects().is_empty());
+        assert!(runtime.next_deadline().is_none());
+        assert_eq!(ndb.subscription_count(), 1, "retain existing coverage");
+    }
+
+    runtime.remove_scoped(&scoped);
+    assert!(runtime.next_deadline().is_none());
+    assert_eq!(ndb.subscription_count(), 0);
+}
+
+#[test]
+fn thread_routes_retain_filter_membership_without_copying_context_authors() {
+    use nostrdb::{Config, NoteBuilder, SendFilter, Transaction};
+    use std::time::{Duration, Instant};
+
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let ndb = Ndb::new(tmp.path().to_str().expect("path"), &Config::new()).expect("ndb");
+    let parent = NoteId::new([12; 32]);
+    let selected = NoteBuilder::new()
+        .kind(1)
+        .created_at(1)
+        .content("reply")
+        .start_tag()
+        .tag_str("e")
+        .tag_id(parent.bytes())
+        .tag_str("wss://hint.example.com")
+        .tag_str("reply")
+        .sign(&[1; 32])
+        .build()
+        .expect("note");
+    ndb.process_client_event(&selected.json().expect("json"))
+        .expect("ingest note");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let txn = Transaction::new(&ndb).expect("txn");
+        if ndb.get_note_by_id(&txn, selected.id()).is_ok() {
+            break;
+        }
+        assert!(Instant::now() < deadline, "note was not ingested");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let result = build_thread_plan(
+        ndb,
+        SendAuthorOutboxPlanConfig {
+            account_read_relays: HashSet::new(),
+            live_filters: vec![SendPlanFilter {
+                filter_index: 0,
+                filter: SendFilter::try_from_filter(
+                    Filter::new().kinds([1]).event(parent.bytes()).build(),
+                )
+                .expect("send filter"),
+            }],
+            full_history_filters: Vec::new(),
+        },
+        HashSet::from([NoteId::new(*selected.id())]),
+    );
+    assert_eq!(result.live_routed_relays.len(), 1);
+    let route = &result.live_routed_relays[0];
+    assert_eq!(
+        route.filters.len(),
+        2,
+        "reply filter plus missing parent ID"
+    );
+    assert_eq!(
+        route.authors_by_filter_index.len(),
+        2,
+        "each filter retains demand"
+    );
+    assert!(
+        route
+            .authors_by_filter_index
+            .iter()
+            .all(|(_, authors)| authors.is_empty()),
+        "routing authors do not need to be copied into unmodified thread filters"
+    );
+}
+
+/// A parent arriving after discovery EOSE must trigger relay-list discovery for
+/// a newly revealed ancestor author, even when a snapshot was already queued.
+#[test]
+fn thread_plan_discovers_new_ancestor_author_after_discovery_eose() {
+    use super::{AuthorOutboxPlanAdvanceRequest, AuthorOutboxPlanRuntime};
+    use crate::scoped_subs::{
+        config::{ResolvedSubScope, ScopedSubKey, SubKey},
+        ScopedSubEffect, ScopedSubOutboxOp, SubConfig,
+    };
+    use enostr::{FullKeypair, OutboxIdRegistry, RelayReqStatus};
+    use futures_util::FutureExt;
+    use nostrdb::{Config, Note, NoteBuilder, Transaction};
+    use std::time::{Duration, Instant};
+
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let ndb = Ndb::new(tmp.path().to_str().expect("path"), &Config::new()).expect("ndb");
+    let author = FullKeypair::generate();
+    let ancestor_author = FullKeypair::generate();
+    let ancestor = NoteId::new([31; 32]);
+    let parent = NoteBuilder::new()
+        .kind(1)
+        .content("parent revealing a new ancestor author")
+        .start_tag()
+        .tag_str("e")
+        .tag_id(ancestor.bytes())
+        .tag_str("")
+        .tag_str("root")
+        .tag_id(ancestor_author.pubkey.bytes())
+        .sign(&author.secret_key.secret_bytes())
+        .build()
+        .expect("parent note");
+    let child = NoteBuilder::new()
+        .kind(1)
+        .content("selected child")
+        .start_tag()
+        .tag_str("e")
+        .tag_id(parent.id())
+        .tag_str("wss://hint.example.com/inbox")
+        .tag_str("root")
+        .tag_id(author.pubkey.bytes())
+        .sign(&author.secret_key.secret_bytes())
+        .build()
+        .expect("selected note");
+    let ingest = |note: &Note<'_>| {
+        ndb.process_client_event(&note.json().expect("note JSON"))
+            .expect("ingest note");
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let txn = Transaction::new(&ndb).expect("txn");
+            if ndb.get_note_by_id(&txn, note.id()).is_ok() {
+                break;
+            }
+            assert!(Instant::now() < deadline, "note was not ingested");
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    };
+    let discovers_author = |filter: &Filter, author: &Pubkey| {
+        let value: serde_json::Value =
+            serde_json::from_str(&filter.json().expect("filter JSON")).expect("parsed filter");
+        value["kinds"]
+            .as_array()
+            .is_some_and(|kinds| kinds.contains(&serde_json::json!(10002)))
+            && value["authors"]
+                .as_array()
+                .is_some_and(|authors| authors.contains(&serde_json::json!(author.hex())))
+    };
+    ingest(&child);
+    let root = NoteId::new(*parent.id());
+    let spec = SubConfig::builder(vec![Filter::new().ids([root.bytes()]).build()])
+        .accounts_read_important()
+        .with_author_outbox_augmentation()
+        .for_thread(root, [NoteId::new(*child.id())])
+        .build();
+    let account_relay = NormRelayUrl::new("wss://account.example.com").expect("account relay");
+    let reads = HashSet::from([account_relay.clone()]);
+    let ids = OutboxIdRegistry::new();
+    let mut runtime = AuthorOutboxPlanRuntime::default();
+    let mut jobs = runtime
+        .advance(AuthorOutboxPlanAdvanceRequest {
+            account_pubkey: author.pubkey,
+            scoped: ScopedSubKey {
+                scope: ResolvedSubScope::Global,
+                key: SubKey::new("thread-author-discovered-after-eose"),
+            },
+            account_read_relays: &reads,
+            spec: &spec,
+        })
+        .effects
+        .into_effects();
+    assert_eq!(jobs.len(), 1, "initial thread snapshot");
+    let ScopedSubEffect::StartAuthorOutboxPlanJob(job) = jobs.pop().expect("initial job");
+    let (_, ops, effects) = runtime.apply_plan_slot_ready(&ids, job.run(ndb.clone()), &reads, &ndb);
+    jobs.extend(effects.into_effects());
+    assert_eq!(jobs.len(), 1, "first subscription schedules catch-up");
+    let ScopedSubEffect::StartAuthorOutboxPlanJob(job) = jobs.pop().expect("catch-up job");
+    let (_, catch_up_ops, effects) =
+        runtime.apply_plan_slot_ready(&ids, job.run(ndb.clone()), &reads, &ndb);
+    assert!(catch_up_ops.is_empty());
+    assert!(effects.into_effects().is_empty());
+    let discovery_id = ops
+        .into_ops()
+        .into_iter()
+        .find_map(|op| match op {
+            ScopedSubOutboxOp::StartFetch { id, filters, .. }
+                if filters
+                    .iter()
+                    .any(|filter| discovers_author(filter, &author.pubkey)) =>
+            {
+                Some(id)
+            }
+            _ => None,
+        })
+        .expect("initial missing-author relay-list discovery");
+    let (_, effects) =
+        runtime.apply_relay_req_status(discovery_id, &account_relay, Some(RelayReqStatus::Eose));
+    jobs.extend(effects.into_effects());
+
+    assert!(jobs.is_empty(), "EOSE does not rebuild a thread plan");
+    assert!(
+        runtime.next_deadline().is_none(),
+        "a healthy thread needs no timer"
+    );
+    ingest(&parent);
+    let changed = runtime
+        .next_thread_change()
+        .now_or_never()
+        .expect("parent notification");
+    jobs.extend(runtime.apply_thread_change(changed).into_effects());
+    assert_eq!(jobs.len(), 1, "snapshot observes the newly imported parent");
+    let ScopedSubEffect::StartAuthorOutboxPlanJob(job) = jobs.pop().expect("parent snapshot");
+    let (_, ops, effects) = runtime.apply_plan_slot_ready(&ids, job.run(ndb.clone()), &reads, &ndb);
+    assert_eq!(
+        effects.into_effects().len(),
+        1,
+        "expanded author coverage schedules catch-up"
+    );
+    assert!(
+        ops.into_ops().into_iter().any(|op| match op {
+            ScopedSubOutboxOp::StartFetch { filters, .. } => filters
+                .iter()
+                .any(|filter| discovers_author(filter, &ancestor_author.pubkey)),
+            _ => false,
+        }),
+        "new ancestor author must receive a kind-10002 discovery request after earlier EOSE"
+    );
+}

--- a/crates/notedeck/src/scoped_subs/author_plan/thread.rs
+++ b/crates/notedeck/src/scoped_subs/author_plan/thread.rs
@@ -194,6 +194,60 @@ fn thread_routes(
 }
 
 #[test]
+fn thread_plan_retains_missing_ids_without_authors_for_bootstrap_fetches() {
+    use nostrdb::{Config, NoteBuilder, Transaction};
+    use std::time::{Duration, Instant};
+
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let ndb = Ndb::new(tmp.path().to_str().expect("path"), &Config::new()).expect("ndb");
+    let root = NoteId::new([11; 32]);
+    let parent = NoteId::new([12; 32]);
+    let baseline = NormRelayUrl::new("wss://baseline.example.com").expect("relay");
+    let hint = NormRelayUrl::new("wss://hint.example.com/inbox").expect("relay");
+    let selected = NoteBuilder::new()
+        .kind(1)
+        .created_at(2)
+        .content("selected reply")
+        .start_tag()
+        .tag_str("e")
+        .tag_id(root.bytes())
+        .tag_str(baseline.as_str())
+        .tag_str("root")
+        .tag_id(&[2; 32])
+        .start_tag()
+        .tag_str("e")
+        .tag_id(parent.bytes())
+        .tag_str(hint.as_str())
+        .tag_str("reply")
+        .sign(&[1; 32])
+        .build()
+        .expect("selected");
+    ndb.process_client_event(&selected.json().expect("json"))
+        .expect("ingest selected");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let txn = Transaction::new(&ndb).expect("txn");
+        if ndb.get_note_by_id(&txn, selected.id()).is_ok() {
+            break;
+        }
+        assert!(Instant::now() < deadline, "note was not ingested");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let result = build_thread_plan(
+        ndb,
+        SendAuthorOutboxPlanConfig {
+            account_read_relays: HashSet::from([baseline]),
+            live_filters: Vec::new(),
+            full_history_filters: Vec::new(),
+        },
+        HashSet::from([root, NoteId::new(*selected.id())]),
+    );
+    let snapshot = result.thread.expect("thread").expect("snapshot");
+    assert_eq!(snapshot.missing_ids, HashSet::from([root, parent]));
+    assert_eq!(snapshot.missing_ids_without_author, HashSet::from([parent]));
+}
+
+#[test]
 fn thread_plan_preserves_reply_filters_and_fetches_missing_parents_by_exact_id() {
     use super::{SendAuthorOutboxPlanConfig, SendPlanFilter};
     use enostr::{NormRelayUrl, NoteId};
@@ -754,6 +808,7 @@ fn thread_plan_failure_retains_coverage_until_a_successful_retry() {
         .as_ref()
         .expect("thread")
         .baseline_fetch
+        .id
         .expect("baseline fetch");
     assert_eq!(
         slot.ready_plan()
@@ -818,8 +873,8 @@ fn thread_plan_failure_retains_coverage_until_a_successful_retry() {
         1
     );
     let thread = slot.thread.as_ref().expect("thread");
-    assert_eq!(thread.baseline_fetch, Some(baseline_fetch));
-    assert_eq!(thread.missing_ids, HashSet::from([parent]));
+    assert_eq!(thread.baseline_fetch.id, Some(baseline_fetch));
+    assert_eq!(thread.baseline_fetch.missing_ids, HashSet::from([parent]));
 
     let mut retry_jobs = runtime
         .apply_relay_list_discovery_retry_due(Instant::now() + THREAD_PLAN_RETRY_DELAY)
@@ -848,7 +903,7 @@ fn thread_plan_failure_retains_coverage_until_a_successful_retry() {
         2
     );
     let thread = slot.thread.as_ref().expect("thread");
-    assert_eq!(thread.baseline_fetch, Some(baseline_fetch));
+    assert_eq!(thread.baseline_fetch.id, Some(baseline_fetch));
     assert!(thread.watch.is_some());
     assert_eq!(ndb.subscription_count(), 1);
 }

--- a/crates/notedeck/src/scoped_subs/config.rs
+++ b/crates/notedeck/src/scoped_subs/config.rs
@@ -905,3 +905,75 @@ impl SubConfig {
         self
     }
 }
+
+/// Selected thread notes are retained demand and must invalidate an old declaration.
+#[test]
+fn thread_outbox_seeds_affect_config_equality() {
+    let root = enostr::NoteId::new([1; 32]);
+    let first = enostr::NoteId::new([2; 32]);
+    let second = enostr::NoteId::new([3; 32]);
+    let config = |selected: Vec<enostr::NoteId>| {
+        SubConfig::builder(vec![Filter::new().kinds([1]).event(root.bytes()).build()])
+            .accounts_read_important()
+            .with_author_outbox_augmentation()
+            .for_thread(root, selected)
+            .build()
+    };
+
+    assert_eq!(
+        config(vec![first, second]),
+        config(vec![second, first, first])
+    );
+    assert_ne!(config(vec![first]), config(vec![second]));
+    assert_eq!(
+        config(vec![first]).thread_notes(),
+        Some(&HashSet::from([root, first]))
+    );
+    let author_config =
+        SubConfig::builder(vec![Filter::new().authors([&[4; 32]]).kinds([1]).build()])
+            .accounts_read_important()
+            .with_author_outbox_augmentation()
+            .build();
+    assert_eq!(author_config.thread_notes(), None);
+}
+
+/// Shared thread demand unions owner selections and removes departed owners' seeds.
+#[test]
+fn thread_outbox_seeds_merge_for_compatible_owners() {
+    let root = enostr::NoteId::new([1; 32]);
+    let first = enostr::NoteId::new([2; 32]);
+    let second = enostr::NoteId::new([3; 32]);
+    let config = |root: enostr::NoteId, selected: enostr::NoteId| {
+        SubConfig::builder(vec![Filter::new().kinds([1]).event(root.bytes()).build()])
+            .full_history(FullHistoryConfig::new(vec![Filter::new()
+                .kinds([1])
+                .event(root.bytes())
+                .build()]))
+            .accounts_read_important()
+            .with_author_outbox_augmentation()
+            .for_thread(root, [selected])
+            .build()
+    };
+    let first_config = config(root, first);
+    let second_config = config(root, second);
+    let merged = SubConfig::merged_owner_configs(&[&first_config, &second_config])
+        .expect("shared thread config");
+    assert_eq!(
+        merged.thread_notes(),
+        Some(&HashSet::from([root, first, second]))
+    );
+    assert_eq!(
+        SubConfig::merged_owner_configs(&[&first_config]),
+        Some(first_config.clone())
+    );
+    assert_eq!(
+        SubConfig::merged_owner_configs(&[&second_config, &first_config]),
+        Some(merged)
+    );
+
+    let different_root = config(enostr::NoteId::new([5; 32]), second);
+    assert_eq!(
+        SubConfig::merged_owner_configs(&[&first_config, &different_root]),
+        Some(different_root)
+    );
+}

--- a/crates/notedeck/src/scoped_subs/config.rs
+++ b/crates/notedeck/src/scoped_subs/config.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 use enostr::{
-    FullHistoryConfig, NormRelayUrl, Pubkey, RelayDemandPriority, RelayRoutingPreference,
+    FullHistoryConfig, NormRelayUrl, NoteId, Pubkey, RelayDemandPriority, RelayRoutingPreference,
     RelayUrlSource,
 };
 use hashbrown::HashSet;
@@ -215,6 +215,8 @@ pub struct SubConfig {
     /// Optional background full-history reconciliation request paired to this
     /// scoped subscription.
     pub(super) full_history: Option<SubFullHistoryConfig>,
+    /// Root and selected thread notes used to discover ancestry and author relays.
+    pub(super) thread_notes: Option<HashSet<NoteId>>,
 }
 
 /// Sendable full-history filter set retained by one scoped-sub config.
@@ -252,6 +254,7 @@ impl SubFullHistoryConfig {
 impl PartialEq for SubConfig {
     fn eq(&self, other: &Self) -> bool {
         self.execution == other.execution
+            && self.thread_notes == other.thread_notes
             && same_canonical_send_filter_set(&self.filters, &other.filters)
             && full_history_configs_have_same_canonical_attributes(
                 self.full_history.as_ref(),
@@ -277,6 +280,7 @@ impl SubConfig {
             execution: SubExecution::AccountsRead { baseline },
             filters,
             full_history: None,
+            thread_notes: None,
         }
     }
 
@@ -290,6 +294,7 @@ impl SubConfig {
             execution: SubExecution::Explicit { relays, policy },
             filters,
             full_history: None,
+            thread_notes: None,
         }
     }
 
@@ -310,7 +315,13 @@ impl SubConfig {
             },
             filters,
             full_history: None,
+            thread_notes: None,
         }
+    }
+
+    /// Borrow the root and selected notes retained for thread outbox discovery.
+    pub(super) fn thread_notes(&self) -> Option<&HashSet<NoteId>> {
+        self.thread_notes.as_ref()
     }
 
     /// Runtime author-outbox relay policy, if this config has one.
@@ -372,6 +383,7 @@ impl SubConfig {
             },
             filters,
             full_history: None,
+            thread_notes: None,
         }
     }
 
@@ -392,8 +404,29 @@ impl SubConfig {
         )
     }
 
+    /// Union compatible owners' thread notes or explicit relays under one scoped key.
     pub(super) fn merged_owner_configs(configs: &[&SubConfig]) -> Option<SubConfig> {
-        let latest = configs.last()?.to_owned().clone();
+        let mut latest = configs.last()?.to_owned().clone();
+        if let Some(thread_notes) = &mut latest.thread_notes {
+            if configs.iter().any(|config| {
+                config.thread_notes.is_none()
+                    || config.execution != latest.execution
+                    || !same_canonical_send_filter_set(&config.filters, &latest.filters)
+                    || !full_history_configs_have_same_canonical_attributes(
+                        config.full_history.as_ref(),
+                        latest.full_history.as_ref(),
+                    )
+            }) {
+                return Some(latest);
+            }
+            for config in configs {
+                if let Some(owner_notes) = &config.thread_notes {
+                    thread_notes.extend(owner_notes);
+                }
+            }
+            return Some(latest);
+        }
+
         let latest_additive = configs
             .iter()
             .rev()
@@ -637,6 +670,7 @@ impl AccountsReadBuilder {
             baseline: self.baseline,
             author_outbox,
             full_history: self.full_history,
+            thread_notes: None,
         }
     }
 
@@ -720,9 +754,23 @@ pub struct AuthorOutboxBuilder {
     baseline: SubRelayPolicy,
     author_outbox: SubRelayPolicy,
     full_history: Option<SubFullHistoryConfig>,
+    thread_notes: Option<HashSet<NoteId>>,
 }
 
 impl AuthorOutboxBuilder {
+    /// Discover author relays and missing ancestors from this root and its selections.
+    ///
+    /// These notes are routing inputs. The retained live and history filters keep
+    /// their original shape and remain shared by owners of the same thread root.
+    pub fn for_thread(
+        mut self,
+        root: NoteId,
+        selected_ids: impl IntoIterator<Item = NoteId>,
+    ) -> Self {
+        self.thread_notes = Some(selected_ids.into_iter().chain([root]).collect());
+        self
+    }
+
     /// Add or replace generic full-history catchup on the resolved scoped-sub relay set.
     pub fn full_history(mut self, full_history: FullHistoryConfig) -> Self {
         self.full_history = normalize_full_history_policy(Some(full_history));
@@ -731,12 +779,14 @@ impl AuthorOutboxBuilder {
 
     /// Finish building the baseline-plus-author-outbox scoped subscription config.
     pub fn build(self) -> SubConfig {
-        SubConfig::accounts_read_with_author_outbox_parts(
+        let mut config = SubConfig::accounts_read_with_author_outbox_parts(
             self.filters,
             self.baseline,
             self.author_outbox,
         )
-        .with_full_history(self.full_history)
+        .with_full_history(self.full_history);
+        config.thread_notes = self.thread_notes;
+        config
     }
 }
 

--- a/crates/notedeck/src/scoped_subs/live/mod.rs
+++ b/crates/notedeck/src/scoped_subs/live/mod.rs
@@ -662,6 +662,7 @@ pub(super) fn baseline_sub_config(spec: &SubConfig) -> SubConfig {
         },
         filters: spec.filters.clone(),
         full_history: spec.full_history.clone(),
+        thread_notes: None,
     }
 }
 
@@ -1062,6 +1063,13 @@ fn apply_one_routed_live_plan_relay(
         return;
     };
 
+    let filters_changed = existing_leg.desired_filters.len() != plan.filters.len()
+        || existing_leg
+            .desired_filters
+            .iter()
+            .zip(&plan.filters)
+            .any(|(old, new)| !old.same_canonical_attributes(new));
+    existing_leg.pending_route_shape_refresh |= pending.route_shape_changed || filters_changed;
     existing_leg.desired_filters = plan.filters.clone();
     existing_leg.authors_by_filter_index = plan.authors_by_filter_index.clone();
     if existing_leg.relay_priority != plan.relay_priority {
@@ -1071,8 +1079,7 @@ fn apply_one_routed_live_plan_relay(
             &mut state.pending_relay_set,
             existing_leg.relay.clone(),
         );
-    } else if pending.route_shape_changed {
-        existing_leg.pending_route_shape_refresh = true;
+    } else if existing_leg.pending_route_shape_refresh {
         enqueue_pending_routed_relay(
             &mut state.pending_relays,
             &mut state.pending_relay_set,

--- a/crates/notedeck/src/scoped_subs/live/mod.rs
+++ b/crates/notedeck/src/scoped_subs/live/mod.rs
@@ -1094,6 +1094,55 @@ fn apply_one_routed_live_plan_relay(
     }
 }
 
+#[test]
+fn thread_route_refreshes_exact_ids_when_authors_and_config_shape_are_unchanged() {
+    use super::ScopedSubOutboxOp;
+
+    let ids = OutboxIdRegistry::new();
+    let relay = NormRelayUrl::new("wss://thread.example.com").unwrap();
+    let policy = RoutedLivePolicy {
+        demand_priority: RelayDemandPriority::Opportunistic,
+        routing_preference: RelayRoutingPreference::NoPreference,
+        relay_url_source: RelayUrlSource::RemoteAdvertised,
+    };
+    let mut plan = PlannedRoutedRelay {
+        relay,
+        relay_priority: RoutedRelayPriority::default(),
+        filters: vec![Filter::new().ids([&[1; 32]]).build()],
+        authors_by_filter_index: HashMap::from([(0, HashSet::new())]),
+    };
+    let ((state, result), ops) = refresh_routed_live_state(
+        &ids,
+        None,
+        policy,
+        None,
+        Some(1),
+        std::slice::from_ref(&plan),
+    );
+    assert_eq!(result, RouteWorkResult::Complete);
+    assert_eq!(ops.into_ops().len(), 1);
+    plan.filters = vec![Filter::new().ids([&[2; 32]]).build()];
+    let ((state, result), ops) = refresh_routed_live_state(
+        &ids,
+        state,
+        policy,
+        None,
+        Some(2),
+        std::slice::from_ref(&plan),
+    );
+    assert_eq!(result, RouteWorkResult::Complete);
+    let ops = ops.into_ops();
+    assert_eq!(
+        ops.len(),
+        1,
+        "same-author ancestry expansion needs a replacement REQ"
+    );
+    assert!(matches!(&ops[0], ScopedSubOutboxOp::SetLive { filters, .. }
+        if filters[0].same_canonical_attributes(&plan.filters[0])));
+    let (_, ops) = refresh_routed_live_state(&ids, state, policy, None, Some(3), &[plan]);
+    assert!(ops.is_empty(), "identical routes do not resend");
+}
+
 fn cleanup_one_removed_routed_live_relay(
     state: &mut RoutedLiveState,
     pending: &RoutedLivePendingPlan,

--- a/crates/notedeck/src/scoped_subs/runtime.rs
+++ b/crates/notedeck/src/scoped_subs/runtime.rs
@@ -2,11 +2,12 @@ use enostr::{
     NormRelayUrl, OutboxIdRegistry, OutboxSubId, OutboxSubRelayEose, Pubkey, RelayReqStatus,
 };
 use hashbrown::{HashMap, HashSet};
+use nostrdb::Ndb;
 use std::time::Instant;
 
 use super::author_plan::{
     AuthorOutboxPlanAdvance, AuthorOutboxPlanAdvanceRequest, AuthorOutboxPlanJobCompletion,
-    AuthorOutboxPlanRuntime,
+    AuthorOutboxPlanRuntime, AuthorOutboxPlanSlotId,
 };
 use super::author_runtime::ScopedAuthorOutboxRuntime;
 use super::config::{
@@ -221,6 +222,25 @@ impl ScopedSubRuntime {
         self.author_outbox_plans.next_deadline()
     }
 
+    /// Wait for thread-note or relay-list ingestion covered by a retained plan.
+    /// The plan runtime keeps subscriptions alive when this wait is cancelled.
+    pub(crate) async fn next_author_outbox_thread_change(&mut self) -> AuthorOutboxPlanSlotId {
+        self.author_outbox_plans.next_thread_change().await
+    }
+
+    /// Schedule the next immutable plan after a retained thread watch changes.
+    pub(crate) fn apply_author_outbox_thread_change(
+        &mut self,
+        slot_id: AuthorOutboxPlanSlotId,
+    ) -> ScopedSubDelta {
+        let effects = self.author_outbox_plans.apply_thread_change(slot_id);
+        ScopedSubDelta::new_with_effects(
+            ScopedSubOutput::default(),
+            ScopedSubOutboxOps::default(),
+            effects,
+        )
+    }
+
     /// Apply one committed relay request status event to retained author-outbox
     /// relay-list discovery state.
     pub(crate) fn apply_author_outbox_relay_req_status(
@@ -242,6 +262,7 @@ impl ScopedSubRuntime {
         selected_account_pubkey: Pubkey,
         account_read_relays: &HashSet<NormRelayUrl>,
         completion: AuthorOutboxPlanJobCompletion,
+        ndb: &Ndb,
     ) -> ScopedSubDelta {
         let ids = self.ids();
         self.apply_author_outbox_plan_completed_with_ids(
@@ -249,6 +270,7 @@ impl ScopedSubRuntime {
             selected_account_pubkey,
             account_read_relays,
             completion,
+            ndb,
         )
     }
 
@@ -258,17 +280,20 @@ impl ScopedSubRuntime {
         selected_account_pubkey: Pubkey,
         account_read_relays: &HashSet<NormRelayUrl>,
         completion: AuthorOutboxPlanJobCompletion,
+        ndb: &Ndb,
     ) -> ScopedSubDelta {
-        let mut outbox_ops = ScopedSubOutboxOps::default();
-        let (scoped_keys, ops) =
-            self.author_outbox_plans
-                .apply_plan_slot_ready(ids, completion, account_read_relays);
-        outbox_ops.extend(ops);
+        let (scoped_keys, outbox_ops, effects) = self.author_outbox_plans.apply_plan_slot_ready(
+            ids,
+            completion,
+            account_read_relays,
+            ndb,
+        );
+        let mut delta =
+            ScopedSubDelta::new_with_effects(ScopedSubOutput::default(), outbox_ops, effects);
         if scoped_keys.is_empty() {
-            return ScopedSubDelta::new(ScopedSubOutput::default(), outbox_ops);
+            return delta;
         }
 
-        let mut delta = ScopedSubDelta::new(ScopedSubOutput::default(), outbox_ops);
         delta.extend(self.apply_author_outbox_plans_for_scoped_keys_with_effects(
             ids,
             selected_account_pubkey,

--- a/crates/notedeck/src/scoped_subs/runtime.rs
+++ b/crates/notedeck/src/scoped_subs/runtime.rs
@@ -203,6 +203,11 @@ fn advance_author_outbox_plan(
 }
 
 impl ScopedSubRuntime {
+    /// Update discovery coverage before the bridge applies the account transition.
+    pub(crate) fn set_bootstrap_relays(&mut self, relays: &HashSet<NormRelayUrl>) {
+        self.author_outbox_plans.bootstrap_relays.clone_from(relays);
+    }
+
     /// Create a runtime that allocates outbox ids from the bridge-owned outbox
     /// service namespace.
     pub(crate) fn with_ids(ids: OutboxIdRegistry) -> Self {

--- a/crates/notedeck/src/scoped_subs/tests.rs
+++ b/crates/notedeck/src/scoped_subs/tests.rs
@@ -494,6 +494,7 @@ fn apply_scoped_effects_for_test(
                     selected_account_pubkey,
                     account_read_relays,
                     completion,
+                    ndb,
                 );
                 let next_effects = bridge.ingest_scoped_delta(delta);
                 apply_scoped_effects_for_test(
@@ -525,6 +526,7 @@ fn collect_scoped_effect_outbox_ops_for_test(
                     selected_account_pubkey,
                     account_read_relays,
                     completion,
+                    ndb,
                 );
                 let (_output, ops, next_effects) = delta.into_parts();
                 outbox_ops.extend(ops);

--- a/crates/notedeck_columns/src/nav.rs
+++ b/crates/notedeck_columns/src/nav.rs
@@ -109,7 +109,7 @@ fn process_settings_response(
                 app.timeline_cache
                     .refresh_remote_subscriptions(&mut scoped_subs, remote_policy);
                 app.threads
-                    .refresh_remote_subscriptions(ctx.ndb, &mut scoped_subs, remote_policy);
+                    .refresh_remote_subscriptions(&mut scoped_subs, remote_policy);
             }
             None
         }

--- a/crates/notedeck_columns/src/timeline/sub/thread_sub.rs
+++ b/crates/notedeck_columns/src/timeline/sub/thread_sub.rs
@@ -60,8 +60,8 @@ struct Scope {
 struct ThreadRemoteSnapshot {
     /// Every local overlay/scope demanding this root request.
     owners: Vec<(MetaId, usize)>,
-    /// Union of current observed relay coverage from every owner scope.
-    observed_relays: HashSet<NormRelayUrl>,
+    /// Union of root and selected notes declared by the current owner scopes.
+    selected_notes: hashbrown::HashSet<NoteId>,
     /// Logging/debug only; this is not part of the remote identity.
     stack_len: usize,
 }
@@ -347,7 +347,6 @@ impl ThreadSubs {
     #[cfg(test)]
     fn remote_snapshot_for_root(
         &self,
-        ndb: &Ndb,
         account_pk: Pubkey,
         root_id: &RootNoteId,
     ) -> Option<ThreadRemoteSnapshot> {
@@ -373,14 +372,15 @@ impl ThreadSubs {
             .map(|(meta_id, scope_depth, _scope)| (*meta_id, *scope_depth))
             .collect::<Vec<_>>();
         let stack_len = scopes.iter().map(|(_, _, scope)| scope.stack.len()).sum();
-        let observed_relays = scopes
+        let selected_notes = scopes
             .iter()
-            .flat_map(|(_, _, scope)| observed_thread_relays(ndb, scope))
-            .collect::<HashSet<_>>();
+            .flat_map(|(_, _, scope)| scope.stack.iter().map(|sub| sub.selected_id))
+            .chain([*root_id])
+            .collect();
 
         Some(ThreadRemoteSnapshot {
             owners,
-            observed_relays,
+            selected_notes,
             stack_len,
         })
     }
@@ -457,6 +457,47 @@ fn unsubscribe_click(
         return Some(UnsubscribeOutcome::KeepOwner(root_id));
     }
     Some(UnsubscribeOutcome::DropOwner(scope.root_id))
+}
+
+/// A partial close must refresh remote seeds after removing later selections.
+#[test]
+fn partial_click_unsubscribe_refreshes_remaining_thread_seeds() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let mut ndb = Ndb::new(
+        tmp.path().to_str().expect("temp path"),
+        &nostrdb::Config::new(),
+    )
+    .expect("ndb");
+    let root = NoteId::new([1; 32]);
+    let earlier = NoteId::new([2; 32]);
+    let later = NoteId::new([3; 32]);
+    let subscribe = |selected_id: NoteId| {
+        let filters = vec![Filter::new().ids([selected_id.bytes()]).build()];
+        Sub {
+            selected_id,
+            sub: ndb.subscribe(&filters).expect("subscribe"),
+            _filters: filters,
+        }
+    };
+    let earlier_sub = subscribe(earlier);
+    let later_sub = subscribe(later);
+    let later_subscription = later_sub.sub;
+    ndb.unsubscribe(earlier_sub.sub)
+        .expect("force earlier subscription failure");
+    let mut scopes = vec![Scope {
+        root_id: root,
+        stack: vec![earlier_sub, later_sub],
+    }];
+    let selection =
+        ThreadSelection::from_root_id(notedeck::RootNoteIdBuf::new_unsafe(*root.bytes()));
+
+    let outcome = unsubscribe_click(&mut scopes, &mut ndb, &selection);
+
+    assert_eq!(outcome, Some(UnsubscribeOutcome::KeepOwner(root)));
+    assert_eq!(scopes.len(), 1);
+    assert_eq!(scopes[0].stack.len(), 1);
+    assert_eq!(scopes[0].stack[0].selected_id, earlier);
+    assert!(ndb.unsubscribe(later_subscription).is_err());
 }
 
 fn dispose_thread_scope(ndb: &mut Ndb, scope: Scope) {
@@ -600,15 +641,13 @@ fn thread_remote_sub_declaration(
 }
 
 #[cfg(test)]
-fn observed_thread_relays(ndb: &Ndb, scope: &Scope) -> HashSet<NormRelayUrl> {
-    observed_thread_relays_for_thread_scope(ndb, &scope.root_id, scope_initial_selected_ids(scope))
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
     use crate::post::NewPost;
     use egui::Context;
+    use enostr::NormRelayUrl;
+    use hashbrown::HashSet;
+    use nostrdb::Transaction;
     use notedeck::{
         AppContext, Notedeck, RelayAction, RootNoteIdBuf, ScopedSubIdentity, ScopedSubReadiness,
     };
@@ -809,18 +848,21 @@ mod tests {
     }
 
     fn expected_thread_remote_config(
-        observed_relays: HashSet<NormRelayUrl>,
+        root: NoteId,
+        selected_ids: impl IntoIterator<Item = NoteId>,
         filters: Vec<Filter>,
         history_filters: Vec<Filter>,
         use_outbox_relays: bool,
     ) -> SubConfig {
-        let policy = remote_policy(use_outbox_relays);
         let builder = SubConfig::builder(filters)
             .full_history(FullHistoryConfig::new(history_filters))
             .accounts_read_important();
 
-        if policy.uses_observed_relay_coverage(!observed_relays.is_empty()) {
-            return builder.with_observed_relays(observed_relays).build();
+        if use_outbox_relays {
+            return builder
+                .with_author_outbox_augmentation()
+                .for_thread(root, selected_ids)
+                .build();
         }
 
         builder.build()
@@ -917,7 +959,7 @@ mod tests {
         );
 
         let snapshot = subs
-            .remote_snapshot_for_root(app_ctx.ndb, account_pk, &root_id)
+            .remote_snapshot_for_root(account_pk, &root_id)
             .expect("root snapshot");
         assert_eq!(snapshot.stack_len, 1);
         assert_readiness(
@@ -1194,11 +1236,17 @@ mod tests {
         );
 
         let snapshot = subs
-            .remote_snapshot_for_root(app_ctx.ndb, account_pk, &root_id)
+            .remote_snapshot_for_root(account_pk, &root_id)
             .expect("root snapshot");
         assert_eq!(snapshot.owners.len(), 2);
-        assert!(snapshot.observed_relays.contains(&bob_relay));
-        assert!(snapshot.observed_relays.contains(&carol_relay));
+        assert_eq!(
+            snapshot.selected_notes,
+            HashSet::from([
+                root_id,
+                NoteId::new(*bob_reply.id()),
+                NoteId::new(*carol_reply.id()),
+            ])
+        );
         drop(scoped_subs);
         drop(app_ctx);
         wait_for_scoped_live(&mut h, identity_a);
@@ -1216,11 +1264,13 @@ mod tests {
         );
 
         let snapshot = subs
-            .remote_snapshot_for_root(app_ctx.ndb, account_pk, &root_id)
+            .remote_snapshot_for_root(account_pk, &root_id)
             .expect("remaining root snapshot");
         assert_eq!(snapshot.owners.len(), 1);
-        assert!(snapshot.observed_relays.contains(&bob_relay));
-        assert!(!snapshot.observed_relays.contains(&carol_relay));
+        assert_eq!(
+            snapshot.selected_notes,
+            HashSet::from([root_id, NoteId::new(*bob_reply.id()),])
+        );
         assert_live(&scoped_subs, identity_a);
         assert_readiness(&scoped_subs, identity_b, ScopedSubReadiness::Missing);
     }
@@ -1333,7 +1383,7 @@ mod tests {
     }
 
     #[test]
-    fn observed_thread_relays_include_known_ancestor_relays() {
+    fn thread_scope_declares_selected_notes_for_backend_ancestry_discovery() {
         let mut h = ThreadHostHarness::new();
         let alice = enostr::FullKeypair::generate();
         let bob = enostr::FullKeypair::generate();
@@ -1363,23 +1413,34 @@ mod tests {
             stack: vec![tracked_sub(app_ctx.ndb, carol_reply.id())],
         };
 
-        let relays = observed_thread_relays(app_ctx.ndb, &scope);
-
-        assert!(relays.contains(&root_relay));
-        assert!(relays.contains(&parent_relay));
-        assert!(relays.contains(&selected_relay));
+        let (_, config) = thread_remote_sub_declaration(
+            &scope.root_id,
+            scope.stack.iter().map(|sub| sub.selected_id),
+            scope_remote_thread_filters(&scope.root_id),
+            scope_remote_thread_history_filters(&scope.root_id),
+            remote_policy(true),
+        );
+        assert_eq!(
+            config,
+            expected_thread_remote_config(
+                scope.root_id,
+                [NoteId::new(*carol_reply.id())],
+                scope_remote_thread_filters(&scope.root_id),
+                scope_remote_thread_history_filters(&scope.root_id),
+                true,
+            )
+        );
     }
 
     #[test]
-    fn thread_remote_sub_declaration_retains_observed_relays_with_baseline() {
+    fn thread_remote_sub_declaration_retains_selected_notes_with_baseline() {
         let root_id = NoteId::new([0x44; 32]);
-        let overlap_relay = NormRelayUrl::new("wss://overlap.example.com").expect("relay");
-        let observed_extra = NormRelayUrl::new("wss://thread.example.com").expect("relay");
+        let selected = NoteId::new([0x45; 32]);
         let live_filters = vec![Filter::new().kinds([1]).limit(10).build()];
         let history_filters = vec![Filter::new().kinds([1]).build()];
         let (key, config) = thread_remote_sub_declaration(
             &root_id,
-            HashSet::from_iter([overlap_relay.clone(), observed_extra.clone()]),
+            [root_id, selected],
             live_filters.clone(),
             history_filters.clone(),
             remote_policy(true),
@@ -1392,7 +1453,8 @@ mod tests {
         assert_eq!(
             config,
             expected_thread_remote_config(
-                HashSet::from_iter([overlap_relay, observed_extra]),
+                root_id,
+                [root_id, selected],
                 live_filters,
                 history_filters,
                 true,
@@ -1401,13 +1463,13 @@ mod tests {
     }
 
     #[test]
-    fn thread_remote_sub_declaration_falls_back_to_accounts_read_when_thread_relays_missing() {
+    fn thread_remote_sub_declaration_seeds_root_when_no_selected_notes_exist() {
         let root_id = NoteId::new([0x66; 32]);
         let live_filters = vec![Filter::new().kinds([1]).limit(10).build()];
         let history_filters = vec![Filter::new().kinds([1]).build()];
         let (_key, config) = thread_remote_sub_declaration(
             &root_id,
-            HashSet::new(),
+            [],
             live_filters.clone(),
             history_filters.clone(),
             remote_policy(true),
@@ -1415,7 +1477,7 @@ mod tests {
 
         assert_eq!(
             config,
-            expected_thread_remote_config(HashSet::new(), live_filters, history_filters, true)
+            expected_thread_remote_config(root_id, [], live_filters, history_filters, true)
         );
     }
 
@@ -1426,7 +1488,7 @@ mod tests {
         let history_filters = scope_remote_thread_history_filters(&root_id);
         let (_key, config) = thread_remote_sub_declaration(
             &root_id,
-            HashSet::new(),
+            [],
             live_filters.clone(),
             history_filters.clone(),
             remote_policy(true),
@@ -1462,19 +1524,19 @@ mod tests {
         assert!(history_values[1].get("kinds").is_none());
         assert_eq!(
             config,
-            expected_thread_remote_config(HashSet::new(), live_filters, history_filters, true)
+            expected_thread_remote_config(root_id, [], live_filters, history_filters, true)
         );
     }
 
     #[test]
-    fn thread_remote_sub_declaration_disable_outbox_relays_ignore_observed_relays() {
+    fn thread_remote_sub_declaration_disable_outbox_relays_omits_thread_discovery() {
         let root_id = NoteId::new([0x77; 32]);
-        let observed_relay = NormRelayUrl::new("wss://thread.example.com").expect("relay");
+        let selected = NoteId::new([0x78; 32]);
         let live_filters = vec![Filter::new().kinds([1]).limit(10).build()];
         let history_filters = vec![Filter::new().kinds([1]).build()];
         let (key, config) = thread_remote_sub_declaration(
             &root_id,
-            HashSet::from_iter([observed_relay]),
+            [selected],
             live_filters.clone(),
             history_filters.clone(),
             remote_policy(false),
@@ -1486,7 +1548,7 @@ mod tests {
         );
         assert_eq!(
             config,
-            expected_thread_remote_config(HashSet::new(), live_filters, history_filters, false)
+            expected_thread_remote_config(root_id, [], live_filters, history_filters, false)
         );
     }
 }

--- a/crates/notedeck_columns/src/timeline/sub/thread_sub.rs
+++ b/crates/notedeck_columns/src/timeline/sub/thread_sub.rs
@@ -1,7 +1,7 @@
 use egui_nav::ReturnType;
-use enostr::{Filter, NormRelayUrl, NoteId, Pubkey};
-use hashbrown::{HashMap, HashSet};
-use nostrdb::{Ndb, NoteReply, Subscription, Transaction};
+use enostr::{Filter, NoteId, Pubkey};
+use hashbrown::HashMap;
+use nostrdb::{Ndb, Subscription};
 use notedeck::{Accounts, FullHistoryConfig, ScopedSubApi, SubConfig, SubKey};
 
 use crate::column::ColumnId;
@@ -20,7 +20,7 @@ type MetaId = ThreadOwnerId;
 enum UnsubscribeOutcome {
     /// Local NDB sub(s) were removed, but the scope still has stack entries so the
     /// remote scoped-sub owner should remain.
-    KeepOwner,
+    KeepOwner(RootNoteId),
     /// The thread scope was fully removed and the remote scoped-sub owner should
     /// be released using the returned root note id plus the caller's stack depth.
     DropOwner(RootNoteId),
@@ -38,6 +38,8 @@ enum UnsubscribeOutcome {
 pub struct ThreadSubs {
     /// Per-account thread subscription bookkeeping.
     by_account: HashMap<Pubkey, AccountThreadSubs>,
+    /// Current setting used when a navigation pop changes the selected notes.
+    remote_policy: RemoteSubscriptionPolicy,
 }
 
 #[derive(Default)]
@@ -49,8 +51,8 @@ struct Scope {
     root_id: NoteId,
     /// Selected notes opened inside this thread scope.
     ///
-    /// The remote filter shape is root-only. The stack is local NDB subscription
-    /// state and must not enter the remote `SubKey`.
+    /// The remote filter shape is root-only. Selected IDs also seed backend
+    /// ancestry discovery, but do not enter the remote `SubKey`.
     stack: Vec<Sub>,
 }
 
@@ -85,6 +87,7 @@ impl ThreadSubs {
         new_scope: bool,
         remote_policy: RemoteSubscriptionPolicy,
     ) {
+        self.remote_policy = remote_policy;
         let meta_id = meta_id.into();
         let account_pk = scoped_subs.selected_account_pubkey();
         let (remote_update, num_locals) = {
@@ -104,12 +107,14 @@ impl ThreadSubs {
                 )
                 .map(|root_id| (meta_id, scope_depth, root_id))
             } else {
+                let scope_depth = cur_scopes.len() - 1;
                 let cur_scope = cur_scopes.last_mut().expect("checked non-empty above");
-                // Master only installed the remote owner when a thread scope opened.
-                // Same-scope pushes are local NDB stack entries; do not turn them
-                // into remote config churn or owner identity.
-                let _ = sub_current_scope(ndb, id, local_sub_filter, cur_scope);
-                None
+                let subscribed = sub_current_scope(ndb, id, local_sub_filter, cur_scope);
+                (subscribed && remote_policy.uses_outbox_relays()).then_some((
+                    meta_id,
+                    scope_depth,
+                    cur_scope.root_id,
+                ))
             };
 
             (remote_update, account_subs.scopes.len())
@@ -117,7 +122,6 @@ impl ThreadSubs {
 
         if let Some((meta_id, scope_depth, root_id)) = remote_update {
             self.set_remote_for_scope(
-                ndb,
                 scoped_subs,
                 account_pk,
                 meta_id,
@@ -143,7 +147,7 @@ impl ThreadSubs {
     ) {
         let meta_id = meta_id.into();
         let account_pk = scoped_subs.selected_account_pubkey();
-        let (owner_to_drop, remove_account_entry) = {
+        let (unsub_outcome, scope_depth, remove_account_entry) = {
             let Some(account_subs) = self.by_account.get_mut(&account_pk) else {
                 return;
             };
@@ -176,15 +180,8 @@ impl ThreadSubs {
             );
 
             (
-                match unsub_outcome {
-                    UnsubscribeOutcome::KeepOwner => None,
-                    UnsubscribeOutcome::DropOwner(root_id) => Some(thread_owner_scope_key(
-                        account_pk,
-                        meta_id,
-                        &root_id,
-                        removed_scope_depth as u64,
-                    )),
-                },
+                unsub_outcome,
+                removed_scope_depth,
                 account_subs.scopes.is_empty(),
             )
         };
@@ -193,8 +190,23 @@ impl ThreadSubs {
             self.by_account.remove(&account_pk);
         }
 
-        if let Some(owner) = owner_to_drop {
-            let _ = scoped_subs.drop_owner(owner);
+        match unsub_outcome {
+            UnsubscribeOutcome::KeepOwner(root_id) if self.remote_policy.uses_outbox_relays() => {
+                self.set_remote_for_scope(
+                    scoped_subs,
+                    account_pk,
+                    meta_id,
+                    scope_depth,
+                    &root_id,
+                    self.remote_policy,
+                );
+            }
+            UnsubscribeOutcome::DropOwner(root_id) => {
+                let owner =
+                    thread_owner_scope_key(account_pk, meta_id, &root_id, scope_depth as u64);
+                let _ = scoped_subs.drop_owner(owner);
+            }
+            UnsubscribeOutcome::KeepOwner(_) => {}
         }
     }
 
@@ -280,38 +292,32 @@ impl ThreadSubs {
         self.get_local_for_owner(accounts.selected_account_pubkey(), owner.into())
     }
 
+    /// Rebuild open owners' declarations after the outbox setting changes.
     pub(crate) fn refresh_remote_subscriptions(
         &mut self,
-        ndb: &Ndb,
         scoped_subs: &mut ScopedSubApi<'_>,
         remote_policy: RemoteSubscriptionPolicy,
     ) {
-        let mut scopes = Vec::new();
+        self.remote_policy = remote_policy;
         for (account_pk, account_subs) in &self.by_account {
             for (meta_id, scope_stack) in &account_subs.scopes {
                 for (scope_depth, scope) in scope_stack.iter().enumerate() {
-                    scopes.push((*account_pk, *meta_id, scope_depth, scope.root_id));
+                    self.set_remote_for_scope(
+                        scoped_subs,
+                        *account_pk,
+                        *meta_id,
+                        scope_depth,
+                        &scope.root_id,
+                        remote_policy,
+                    );
                 }
             }
         }
-
-        for (account_pk, meta_id, scope_depth, root_id) in scopes {
-            self.set_remote_for_scope(
-                ndb,
-                scoped_subs,
-                account_pk,
-                meta_id,
-                scope_depth,
-                &root_id,
-                remote_policy,
-            );
-        }
     }
 
-    #[allow(clippy::too_many_arguments)]
+    /// Retain root-shaped filters and delegate selected-note routing to scoped subs.
     fn set_remote_for_scope(
         &self,
-        ndb: &Ndb,
         scoped_subs: &mut ScopedSubApi<'_>,
         account_pk: Pubkey,
         meta_id: MetaId,
@@ -322,21 +328,20 @@ impl ThreadSubs {
         let Some(scope) = self.thread_scope(account_pk, meta_id, scope_depth, root_id) else {
             return;
         };
-        let observed_relays = observed_thread_relays_for_thread_scope(
-            ndb,
-            root_id,
-            scope_initial_selected_ids(scope),
+        tracing::debug!(
+            "Remote subscribe for thread root {:?} with {} selected notes",
+            root_id.hex(),
+            scope.stack.len()
         );
-        set_scope_remote(
-            scoped_subs,
-            account_pk,
-            meta_id,
-            scope_depth,
+        let (key, config) = thread_remote_sub_declaration(
             root_id,
-            observed_relays,
-            scope.stack.len(),
+            scope.stack.iter().map(|sub| sub.selected_id),
+            scope_remote_thread_filters(root_id),
+            scope_remote_thread_history_filters(root_id),
             remote_policy,
         );
+        let owner = thread_owner_scope_key(account_pk, meta_id, root_id, scope_depth as u64);
+        let _ = scoped_subs.set_sub_for_account(account_pk, owner, key, config);
     }
 
     #[cfg(test)]
@@ -424,9 +429,10 @@ fn unsubscribe_drag(
         return Some(UnsubscribeOutcome::DropOwner(removed_scope.root_id));
     }
 
-    Some(UnsubscribeOutcome::KeepOwner)
+    Some(UnsubscribeOutcome::KeepOwner(scope.root_id))
 }
 
+/// Close a scope, retaining its root for remote refresh if only part can be removed.
 fn unsubscribe_click(
     scopes: &mut Vec<Scope>,
     ndb: &mut Ndb,
@@ -444,10 +450,11 @@ fn unsubscribe_click(
         }
 
         // Partial rollback: restore the failed local sub (and any remaining ones)
-        // to thread bookkeeping and keep the remote owner alive.
+        // and refresh the remote owner's seeds after the successful removals.
+        let root_id = scope.root_id;
         scope.stack.push(sub);
         scopes.push(scope);
-        return None;
+        return Some(UnsubscribeOutcome::KeepOwner(root_id));
     }
     Some(UnsubscribeOutcome::DropOwner(scope.root_id))
 }
@@ -545,44 +552,7 @@ fn thread_remote_sub_key(root_id: &RootNoteId, sub: ThreadScopedSub) -> SubKey {
     SubKey::builder(sub).with(*root_id.bytes()).finish()
 }
 
-#[allow(clippy::too_many_arguments)]
-fn set_scope_remote(
-    scoped_subs: &mut ScopedSubApi<'_>,
-    account_pk: Pubkey,
-    meta_id: MetaId,
-    scope_depth: usize,
-    root_id: &RootNoteId,
-    observed_relays: HashSet<NormRelayUrl>,
-    stack_len: usize,
-    remote_policy: RemoteSubscriptionPolicy,
-) {
-    // The scoped-sub key is the remote request shape: root replies plus the root
-    // note by exact id. Column and thread scope are owner identity only. Including
-    // them in the key creates duplicate live outbox demand for identical root
-    // requests.
-    //
-    // Each owner declares the same `SubKey`. Scoped-subs counts demand by owner,
-    // merges compatible additive relay coverage, and removes the outbox request
-    // only after the last owner drops.
-    tracing::debug!(
-        "Remote subscribe for thread root {:?} with {} selected notes",
-        root_id.hex(),
-        stack_len
-    );
-
-    let filters = scope_remote_thread_filters(root_id);
-    let history_filters = scope_remote_thread_history_filters(root_id);
-    let (key, config) = thread_remote_sub_declaration(
-        root_id,
-        observed_relays,
-        filters,
-        history_filters,
-        remote_policy,
-    );
-    let owner = thread_owner_scope_key(account_pk, meta_id, root_id, scope_depth as u64);
-    let _ = scoped_subs.set_sub_for_account(account_pk, owner, key, config);
-}
-
+/// Keep baseline live subscriptions shared by every selection of one thread root.
 fn scope_remote_thread_filters(root_id: &RootNoteId) -> Vec<Filter> {
     vec![
         Filter::new()
@@ -602,58 +572,11 @@ fn scope_remote_thread_history_filters(root_id: &RootNoteId) -> Vec<Filter> {
     ]
 }
 
-fn observed_thread_relays_for_thread_scope(
-    ndb: &Ndb,
-    root_id: &RootNoteId,
-    selected_ids: impl IntoIterator<Item = [u8; 32]>,
-) -> HashSet<NormRelayUrl> {
-    let Ok(txn) = Transaction::new(ndb) else {
-        return HashSet::new();
-    };
-    let note_ids = known_thread_note_ids_with_txn(ndb, &txn, root_id.bytes(), selected_ids);
-    observed_thread_relays_for_note_ids(ndb, &txn, &note_ids)
-}
-
-/// Return the root id plus each selected note and known ancestor by note id.
-///
-/// These ids are only used to inspect local observed-relay metadata. The remote
-/// thread subscription still asks relays for `#e=root` replies plus `ids=[root]`,
-/// matching the pre-outbox thread query shape.
-fn known_thread_note_ids_with_txn(
-    ndb: &Ndb,
-    txn: &Transaction,
-    root_id: &[u8; 32],
-    selected_ids: impl IntoIterator<Item = [u8; 32]>,
-) -> Vec<[u8; 32]> {
-    let mut note_ids = vec![*root_id];
-    let mut seen: HashSet<[u8; 32]> = note_ids.iter().copied().collect();
-
-    for mut current_id in selected_ids {
-        while seen.insert(current_id) {
-            note_ids.push(current_id);
-
-            if current_id == *root_id {
-                break;
-            }
-
-            let Ok(note) = ndb.get_note_by_id(txn, &current_id) else {
-                break;
-            };
-            let Some(parent) = NoteReply::new(note.tags()).reply() else {
-                break;
-            };
-            current_id = *parent.id;
-        }
-    }
-
-    note_ids
-}
-
 /// Build the remote thread declaration from the dynamic account-read baseline plus
-/// observed relay coverage for the scope-opening thread note.
+/// root and selected notes whose ancestry and relays are discovered by the backend.
 fn thread_remote_sub_declaration(
     root_id: &RootNoteId,
-    observed_relays: HashSet<NormRelayUrl>,
+    selected_ids: impl IntoIterator<Item = NoteId>,
     filters: Vec<Filter>,
     history_filters: Vec<Filter>,
     remote_policy: RemoteSubscriptionPolicy,
@@ -664,49 +587,16 @@ fn thread_remote_sub_declaration(
     let builder = SubConfig::builder(filters)
         .full_history(full_history)
         .accounts_read_important();
-    let config = if remote_policy.uses_observed_relay_coverage(!observed_relays.is_empty()) {
-        builder.with_observed_relays(observed_relays).build()
+    let config = if remote_policy.uses_outbox_relays() {
+        builder
+            .with_author_outbox_augmentation()
+            .for_thread(*root_id, selected_ids)
+            .build()
     } else {
         builder.build()
     };
 
     (key, config)
-}
-
-fn observed_thread_relays_for_note_ids(
-    ndb: &Ndb,
-    txn: &Transaction,
-    note_ids: &[[u8; 32]],
-) -> HashSet<NormRelayUrl> {
-    let mut relays = HashSet::new();
-    for note_id in note_ids {
-        collect_note_relays(ndb, txn, note_id, &mut relays);
-    }
-    relays
-}
-
-fn collect_note_relays(
-    ndb: &Ndb,
-    txn: &Transaction,
-    note_id: &[u8; 32],
-    relays: &mut HashSet<NormRelayUrl>,
-) {
-    let Ok(note) = ndb.get_note_by_id(txn, note_id) else {
-        return;
-    };
-
-    relays.extend(
-        note.relays(txn)
-            .filter_map(|relay| NormRelayUrl::new(relay).ok()),
-    );
-}
-
-fn scope_initial_selected_ids(scope: &Scope) -> impl Iterator<Item = [u8; 32]> + '_ {
-    scope
-        .stack
-        .first()
-        .map(|sub| *sub.selected_id.bytes())
-        .into_iter()
 }
 
 #[cfg(test)]

--- a/crates/notedeck_columns/src/timeline/sub/timeline_remote.rs
+++ b/crates/notedeck_columns/src/timeline/sub/timeline_remote.rs
@@ -13,7 +13,7 @@ pub(in crate::timeline) enum TimelineScopedSub {
 }
 
 /// Columns policy for remote timeline and thread subscription declarations.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct RemoteSubscriptionPolicy {
     use_outbox_relays: bool,
 }
@@ -29,9 +29,9 @@ impl RemoteSubscriptionPolicy {
         self.use_outbox_relays && remote_filters_have_authors(remote_filters)
     }
 
-    /// Return whether observed relay coverage should augment selected-account read relays.
-    pub(crate) fn uses_observed_relay_coverage(self, has_observed_relays: bool) -> bool {
-        self.use_outbox_relays && has_observed_relays
+    /// Return whether thread routing should discover author and hinted relay coverage.
+    pub(crate) fn uses_outbox_relays(self) -> bool {
+        self.use_outbox_relays
     }
 }
 

--- a/crates/notedeck_columns/src/timeline/thread.rs
+++ b/crates/notedeck_columns/src/timeline/thread.rs
@@ -208,14 +208,14 @@ impl Threads {
             .dispose_route_for_account(ndb, scoped_subs, account_pk, id, thread);
     }
 
+    /// Rebuild thread declarations using the current outbox relay setting.
     pub(crate) fn refresh_remote_subscriptions(
         &mut self,
-        ndb: &Ndb,
         scoped_subs: &mut ScopedSubApi<'_>,
         remote_policy: RemoteSubscriptionPolicy,
     ) {
         self.subs
-            .refresh_remote_subscriptions(ndb, scoped_subs, remote_policy);
+            .refresh_remote_subscriptions(scoped_subs, remote_policy);
     }
 
     /// Responsible for making sure the chain and the direct replies are up to date

--- a/crates/notedeck_columns/tests/columns_e2e.rs
+++ b/crates/notedeck_columns/tests/columns_e2e.rs
@@ -48,6 +48,7 @@ struct ThreadLoadApp {
     selection: ThreadSelection,
     col: ColumnId,
     opened: bool,
+    use_outbox_relays: bool,
 }
 
 impl ThreadLoadApp {
@@ -57,6 +58,7 @@ impl ThreadLoadApp {
             selection,
             col: test_column_id(col),
             opened: false,
+            use_outbox_relays: true,
         }
     }
 }
@@ -77,7 +79,7 @@ impl App for ThreadLoadApp {
             true,
             self.col,
             0.0,
-            RemoteSubscriptionPolicy::from_outbox_relays(true),
+            RemoteSubscriptionPolicy::from_outbox_relays(self.use_outbox_relays),
         );
         self.opened = true;
     }
@@ -301,6 +303,61 @@ fn build_reply_note(
         .build()
         .expect("reply note")
 }
+
+/// Address the local relay through a DNS hostname accepted for advertised URLs.
+/// `localhost.localdomain` resolves locally on the Linux test host, so these
+/// scenarios use the production URL policy without an external relay or DNS service.
+fn advertised_relay_endpoint(relay_url: &str, path: &str) -> String {
+    let mut endpoint = url::Url::parse(relay_url).expect("local relay URL");
+    endpoint
+        .set_host(Some("localhost.localdomain"))
+        .expect("local DNS hostname");
+    endpoint.set_path(path);
+    let endpoint = endpoint.to_string();
+    let normalized = enostr::NormRelayUrl::new(&endpoint).expect("advertised relay URL");
+    assert!(normalized.allowed_for_source(enostr::RelayUrlSource::RemoteAdvertised));
+    endpoint
+}
+
+/// Build a reply whose NIP-10 references carry relay hints and claimed authors.
+fn build_routed_reply_note(
+    account: &FullKeypair,
+    content: &str,
+    references: &[(&str, &nostrdb::Note<'_>, &str, &enostr::Pubkey)],
+) -> nostrdb::Note<'static> {
+    let mut builder = NoteBuilder::new()
+        .kind(1)
+        .content(content)
+        .created_at(1_700_500_000);
+    for (marker, note, relay, claimed_author) in references {
+        builder = builder
+            .start_tag()
+            .tag_str("e")
+            .tag_str(&hex::encode(note.id()))
+            .tag_str(relay)
+            .tag_str(marker)
+            .tag_str(&claimed_author.hex());
+    }
+    builder
+        .sign(&account.secret_key.secret_bytes())
+        .build()
+        .expect("reply with NIP-10 routing metadata")
+}
+
+/// Advertise the relay where an author writes notes.
+fn build_write_relay_list(author: &FullKeypair, relay_url: &str) -> nostrdb::Note<'static> {
+    NoteBuilder::new()
+        .kind(10002)
+        .content("")
+        .start_tag()
+        .tag_str("r")
+        .tag_str(relay_url)
+        .tag_str("write")
+        .sign(&author.secret_key.secret_bytes())
+        .build()
+        .expect("author write relay list")
+}
+
 fn rendered_note_count(device: &DeviceHarness, substring: &str) -> usize {
     device.query_all_by_label_contains(substring).count()
 }
@@ -948,6 +1005,331 @@ async fn thread_loads_full_reply_set_e2e() {
         "thread import should open negentropy"
     );
 }
+
+/// Opening a locally stored child must fetch its hinted ancestors, including
+/// another missing ancestor revealed only after the first parent is imported.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn thread_open_fetches_hinted_parents_and_newly_discovered_ancestor_e2e() {
+    let (_account_db, account_url, _account_relay) = setup_relay().await;
+    let (parent_db, parent_url, _parent_relay) = setup_relay().await;
+    let (ancestor_db, ancestor_url, _ancestor_relay) = setup_relay().await;
+    let parent_hint = advertised_relay_endpoint(&parent_url, "/inbox");
+    let ancestor_hint = advertised_relay_endpoint(&ancestor_url, "/notes");
+    let alice = FullKeypair::generate();
+    let author = FullKeypair::generate();
+    let claimed_author = FullKeypair::generate();
+    let root = build_text_note(&author, "hinted thread root", 1_700_499_000);
+    let ancestor = build_reply_note(&author, &root, "hinted ancestor", 1_700_499_100);
+    let parent = build_routed_reply_note(
+        &author,
+        "hinted parent",
+        &[
+            ("root", &root, &parent_hint, &author.pubkey),
+            ("reply", &ancestor, &ancestor_hint, &author.pubkey),
+        ],
+    );
+    let child = build_routed_reply_note(
+        &alice,
+        "selected child",
+        &[
+            ("root", &root, &parent_hint, &claimed_author.pubkey),
+            ("reply", &parent, &parent_hint, &claimed_author.pubkey),
+        ],
+    );
+    for note in [&root, &parent] {
+        save_note(&parent_db, note).await;
+    }
+    save_note(&ancestor_db, &ancestor).await;
+    let tmpdir = TempDir::new().expect("tmpdir");
+    seed_notes_in_tmpdir(&tmpdir, &[child.json().expect("child JSON")], 1);
+    let selection = ThreadSelection {
+        root_id: RootNoteIdBuf::new_unsafe(*root.id()),
+        selected_note: Some(enostr::NoteId::new(*child.id())),
+    };
+    let mut device = build_columns_device(
+        &account_url,
+        &alice,
+        tmpdir,
+        thread_app_factory(selection, 7),
+    );
+    let ancestors = LocalQuery::new(
+        vec![Filter::new()
+            .ids([root.id(), parent.id(), ancestor.id()])
+            .build()],
+        3,
+        "query hinted ancestors",
+    );
+    ancestors.wait_for_count(
+        &mut device,
+        3,
+        Duration::from_secs(15),
+        "root, parent and newly discovered ancestor from relay hints",
+    );
+}
+
+/// A relay list imported after thread demand must route the missing note by id;
+/// its claimed author must not exclude a note signed by a different author.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn thread_open_fetches_parent_after_claimed_author_relay_list_arrives_e2e() {
+    let (_account_db, account_url, account_relay) = setup_relay().await;
+    let (author_db, author_url, _author_relay) = setup_relay().await;
+    let author_relay_url = advertised_relay_endpoint(&author_url, "/");
+    let alice = FullKeypair::generate();
+    let author = FullKeypair::generate();
+    let claimed_author = FullKeypair::generate();
+    let parent = build_text_note(&author, "parent on claimed author relay", 1_700_499_000);
+    let child = build_routed_reply_note(
+        &alice,
+        "selected child before relay discovery",
+        &[("root", &parent, "", &claimed_author.pubkey)],
+    );
+    save_note(&author_db, &parent).await;
+    let profile = NoteBuilder::new()
+        .kind(0)
+        .content(r#"{"name":"already known profile"}"#)
+        .sign(&claimed_author.secret_key.secret_bytes())
+        .build()
+        .expect("known claimed-author profile");
+    let tmpdir = TempDir::new().expect("tmpdir");
+    seed_notes_in_tmpdir(&tmpdir, &[child.json().expect("child JSON")], 1);
+    seed_notes_in_tmpdir(&tmpdir, &[profile.json().expect("profile JSON")], 0);
+    let selection = ThreadSelection {
+        root_id: RootNoteIdBuf::new_unsafe(*parent.id()),
+        selected_note: Some(enostr::NoteId::new(*child.id())),
+    };
+    let mut device = build_columns_device(
+        &account_url,
+        &alice,
+        tmpdir,
+        thread_app_factory(selection, 7),
+    );
+    wait_for_device_condition(
+        &mut device,
+        Duration::from_secs(5),
+        "initial relay requests before relay-list discovery",
+        |_| {
+            if account_relay.count_captured_prefix("[\"REQ\",") > 0 {
+                Ok(())
+            } else {
+                Err("no initial REQ received".to_owned())
+            }
+        },
+    );
+    let parent_query = LocalQuery::new(
+        vec![Filter::new().ids([parent.id()]).build()],
+        1,
+        "query parent on claimed author relay",
+    );
+    parent_query.assert_count_stable(&mut device, 0, 8, "parent before relay discovery");
+    let relay_list = NoteBuilder::new()
+        .kind(10002)
+        .content("")
+        .start_tag()
+        .tag_str("r")
+        .tag_str(&author_relay_url)
+        .tag_str("write")
+        .sign(&claimed_author.secret_key.secret_bytes())
+        .build()
+        .expect("claimed author relay list");
+    {
+        let app_ctx = &mut device.state_mut().notedeck.app_context();
+        app_ctx
+            .ndb
+            .process_client_event(&relay_list.json().expect("relay-list JSON"))
+            .expect("import relay list after thread demand");
+    }
+    parent_query.wait_for_count(
+        &mut device,
+        1,
+        Duration::from_secs(15),
+        "parent after claimed author relay-list discovery",
+    );
+}
+
+/// Disabling outbox relays keeps thread traffic on selected-account read relays,
+/// even when a selected child supplies a parent hint and a known author relay list.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn thread_open_with_outbox_disabled_uses_only_selected_read_relays_e2e() {
+    let (account_db, account_url, _account_relay) = setup_relay().await;
+    let (author_db, author_url, author_relay) = setup_relay().await;
+    let author_hint = advertised_relay_endpoint(&author_url, "/inbox");
+    let alice = FullKeypair::generate();
+    let author = FullKeypair::generate();
+    let root = build_text_note(&author, "root from selected read relay", 1_700_499_000);
+    let parent = build_reply_note(&author, &root, "parent on outbox relay", 1_700_499_100);
+    let sibling = build_reply_note(
+        &author,
+        &root,
+        "reply from selected read relay",
+        1_700_499_200,
+    );
+    let child = build_routed_reply_note(
+        &alice,
+        "selected child with outbox disabled",
+        &[
+            ("root", &root, &author_hint, &author.pubkey),
+            ("reply", &parent, &author_hint, &author.pubkey),
+        ],
+    );
+    for note in [&root, &sibling] {
+        save_note(&account_db, note).await;
+    }
+    save_note(&author_db, &parent).await;
+    let relay_list = build_write_relay_list(&author, &author_hint);
+    let tmpdir = TempDir::new().expect("tmpdir");
+    seed_notes_in_tmpdir(&tmpdir, &[child.json().expect("child JSON")], 1);
+    seed_notes_in_tmpdir(
+        &tmpdir,
+        &[relay_list.json().expect("relay-list JSON")],
+        10002,
+    );
+    let selection = ThreadSelection {
+        root_id: RootNoteIdBuf::new_unsafe(*root.id()),
+        selected_note: Some(enostr::NoteId::new(*child.id())),
+    };
+    let mut device = build_columns_device(
+        &account_url,
+        &alice,
+        tmpdir,
+        Box::new(move |notedeck, _ctx| {
+            notedeck
+                .app_context()
+                .settings
+                .set_columns_use_outbox_relays(false);
+            let mut app = ThreadLoadApp::new(selection, 7);
+            app.use_outbox_relays = false;
+            notedeck.set_app(app);
+        }),
+    );
+    LocalQuery::new(
+        vec![Filter::new().ids([root.id(), sibling.id()]).build()],
+        2,
+        "query selected-account thread notes",
+    )
+    .wait_for_count(
+        &mut device,
+        2,
+        Duration::from_secs(15),
+        "thread root and reply from selected-account read relay",
+    );
+    LocalQuery::new(
+        vec![Filter::new().ids([parent.id()]).build()],
+        1,
+        "query parent available only from outbox",
+    )
+    .assert_count_stable(
+        &mut device,
+        0,
+        12,
+        "parent remains missing with outbox disabled",
+    );
+    assert_eq!(author_relay.count_captured_prefix("[\"REQ\","), 0);
+    assert_eq!(author_relay.count_captured_prefix("[\"NEG-OPEN\","), 0);
+}
+
+/// Importing an author-routed parent reveals another author whose later relay
+/// list must route the next missing ancestor without reopening the thread.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn thread_open_fetches_new_ancestor_from_new_authors_later_relay_list_e2e() {
+    let (_account_db, account_url, _account_relay) = setup_relay().await;
+    let (parent_db, parent_url, _parent_relay) = setup_relay().await;
+    let (ancestor_db, ancestor_url, _ancestor_relay) = setup_relay().await;
+    let parent_relay_url = advertised_relay_endpoint(&parent_url, "/");
+    let ancestor_relay_url = advertised_relay_endpoint(&ancestor_url, "/");
+    let alice = FullKeypair::generate();
+    let parent_author = FullKeypair::generate();
+    let ancestor_author = FullKeypair::generate();
+    let root = build_text_note(&parent_author, "author-routed root", 1_700_499_000);
+    let ancestor = build_reply_note(
+        &ancestor_author,
+        &root,
+        "ancestor from newly discovered author",
+        1_700_499_100,
+    );
+    let parent = build_routed_reply_note(
+        &parent_author,
+        "parent exposing new author",
+        &[
+            ("root", &root, "", &parent_author.pubkey),
+            ("reply", &ancestor, "", &ancestor_author.pubkey),
+        ],
+    );
+    let child = build_routed_reply_note(
+        &alice,
+        "selected child before ancestor author is known",
+        &[
+            ("root", &root, "", &parent_author.pubkey),
+            ("reply", &parent, "", &parent_author.pubkey),
+        ],
+    );
+    for note in [&root, &parent] {
+        save_note(&parent_db, note).await;
+    }
+    save_note(&ancestor_db, &ancestor).await;
+    let parent_relay_list = build_write_relay_list(&parent_author, &parent_relay_url);
+    let tmpdir = TempDir::new().expect("tmpdir");
+    seed_notes_in_tmpdir(&tmpdir, &[child.json().expect("child JSON")], 1);
+    seed_notes_in_tmpdir(
+        &tmpdir,
+        &[parent_relay_list.json().expect("parent relay-list JSON")],
+        10002,
+    );
+    let selection = ThreadSelection {
+        root_id: RootNoteIdBuf::new_unsafe(*root.id()),
+        selected_note: Some(enostr::NoteId::new(*child.id())),
+    };
+    let mut device = build_columns_device(
+        &account_url,
+        &alice,
+        tmpdir,
+        thread_app_factory(selection, 7),
+    );
+    LocalQuery::new(
+        vec![Filter::new().ids([root.id(), parent.id()]).build()],
+        2,
+        "query first author-routed ancestors",
+    )
+    .wait_for_count(
+        &mut device,
+        2,
+        Duration::from_secs(15),
+        "root and parent from first author's write relay",
+    );
+    let ancestor_query = LocalQuery::new(
+        vec![Filter::new().ids([ancestor.id()]).build()],
+        1,
+        "query ancestor from newly discovered author",
+    );
+    ancestor_query.assert_count_stable(
+        &mut device,
+        0,
+        8,
+        "ancestor before its author's relay list arrives",
+    );
+    let ancestor_relay_list = build_write_relay_list(&ancestor_author, &ancestor_relay_url);
+    {
+        let app_ctx = &mut device.state_mut().notedeck.app_context();
+        app_ctx
+            .ndb
+            .process_client_event(
+                &ancestor_relay_list
+                    .json()
+                    .expect("ancestor relay-list JSON"),
+            )
+            .expect("import newly discovered author's relay list");
+    }
+    ancestor_query.wait_for_count(
+        &mut device,
+        1,
+        Duration::from_secs(15),
+        "ancestor from newly discovered author's write relay",
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[serial]
 async fn account_switch_restores_thread_subscription_e2e() {


### PR DESCRIPTION
Threads now use the existing asynchronous outbox planner to discover parent authors’ write relays and fetch missing ancestors by exact event ID. Newly received ancestors trigger follow-up planning.

Also preserves relay hints, supports relay paths such as /inbox, and uses bootstrap relays when author relay lists or author information are missing. Adds User-Agent headers for relays that require them.

Why NostrDB changed:

GUI testing found a parent event that arrived but failed ingestion. An event contained a "plaza://place/\u003cnaddr1\u003e" link opens a customized relay-based feed following the Hallway's format.

NostrDB rejected \u003c and \u003e instead of decoding them to < and >, preventing the parent event from being stored and displayed.

Its angle brackets arrived as \u003c and \u003e, valid JSON escapes that NostrDB rejected. The dependency update fixes decoding in NostrDB itself; surrogate-pair support remains out of scope.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved thread subscription support, including automatic discovery and retrieval of missing parent notes.
  - Thread data can now be routed through authors’ advertised write relays and configured bootstrap relays.
  - Thread subscriptions update as newly discovered ancestors and relay information become available.

- **Improvements**
  - Relay endpoints with valid non-root paths are now supported, while unsafe or excessively long URLs remain rejected.
  - Outgoing network requests now identify the application consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->